### PR TITLE
feat: Add optical image (TIFF) integration for Bruker MSI data

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1970,6 +1970,38 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "imagecodecs"
+version = "2025.11.11"
+description = "Image transformation, compression, and decompression codecs"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "imagecodecs-2025.11.11-cp311-abi3-macosx_10_15_x86_64.whl", hash = "sha256:f5d01cc85ca2fe354302b3650f4848e8f1d3174200277b7cb2624abed4d02ea5"},
+    {file = "imagecodecs-2025.11.11-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:45a865690275a3a8893c4c54377c678a7b361ebe13dd3a9e22c66443a96b1c2a"},
+    {file = "imagecodecs-2025.11.11-cp311-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be6e2f4b6601b57cfc9fba2382da7e02ad43c44e3b037adbf275a11f688b231f"},
+    {file = "imagecodecs-2025.11.11-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4a3894b62ca6ad0c4d75cb0a0aac2a525c4a5c4a2a60defc5d7fb716a4bb355"},
+    {file = "imagecodecs-2025.11.11-cp311-abi3-win32.whl", hash = "sha256:3735ea088321b0685e593c5d44fc1d146a84fcf6645c52ed136fa576e16c3572"},
+    {file = "imagecodecs-2025.11.11-cp311-abi3-win_amd64.whl", hash = "sha256:4252b15f5ba55bc7d7aacf621f6bb6e73fd70e66d56277a1f26563198b2cd576"},
+    {file = "imagecodecs-2025.11.11-cp311-abi3-win_arm64.whl", hash = "sha256:f4480973fcf2d826ba6806b7ac6f4d9bd72eeb557cfd3687ac885939d130ec47"},
+    {file = "imagecodecs-2025.11.11-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bb0f4714e60dd94b94ca778b872fb90b885b83381228743903035d79b7e91a88"},
+    {file = "imagecodecs-2025.11.11-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:faf4ab8f2f11694aa2d6ed7548ce1d1598a14e326a6bb3d50669ed5c7da764c6"},
+    {file = "imagecodecs-2025.11.11-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdb475f54d0abac3cfcde42ec47f606eea1d4afa52173420577317102d361ae5"},
+    {file = "imagecodecs-2025.11.11-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e3d4cb2dc507c0bab057321333927575d1d611efe368e76b752f5ad3c55856ad"},
+    {file = "imagecodecs-2025.11.11-cp314-cp314t-win32.whl", hash = "sha256:7bcc214d6f6ecd2bd7b648a6ac5589edcde946bcb738b6c763ce1c864934c58c"},
+    {file = "imagecodecs-2025.11.11-cp314-cp314t-win_amd64.whl", hash = "sha256:58dbc0095142dcef55aaac392ee5bd8fb7c3656753e3c37424c3612209c656a4"},
+    {file = "imagecodecs-2025.11.11-cp314-cp314t-win_arm64.whl", hash = "sha256:dd61871455ae6c3486051e68e0d576d54e53c45d157ce233c4a09269f132bf48"},
+    {file = "imagecodecs-2025.11.11.tar.gz", hash = "sha256:a836d329f91c890d17b9dc3f3a2bba944a198ae741592c3cb0c4b9b097d10d34"},
+]
+
+[package.dependencies]
+numpy = "*"
+
+[package.extras]
+all = ["matplotlib", "numcodecs", "tifffile"]
+test = ["bitshuffle", "blosc", "blosc2", "brotli", "czifile", "kerchunk", "lz4", "numcodecs", "pyliblzfse", "pytest", "pytest-run-parallel", "python-lzf", "python-snappy", "tifffile", "zarr", "zopflipy", "zstd"]
+
+[[package]]
 name = "imageio"
 version = "2.37.0"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
@@ -6630,4 +6662,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.13"
-content-hash = "ca12f2fb609548538c488169073a78872e1d338c72fc3d1e48a131f984a44ed9"
+content-hash = "6458f7ab94baba18b7f605849809add4e28ed02b9562a71b65771eb02416dd60"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ spatialdata = ">=0.2.0"
 tqdm = ">=4.50.0"
 zarr = ">=3.0.0"
 cryptography = "^45.0.5"
+imagecodecs = ">=2024.1.1"  # For reading compressed TIFF optical images
 
 anndata = ">=0.11.0"
 matplotlib = "^3.10.6"

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -337,6 +337,12 @@ def _build_resampling_config(
     "default, better for column-wise operations like feature selection) or "
     "csr (Compressed Sparse Row, better for row-wise operations).",
 )
+# Optical image options
+@click.option(
+    "--include-optical/--no-optical",
+    default=True,
+    help="Include optical images (TIFF) in output (default: True)",
+)
 def main(
     input: Path,
     output: Path,
@@ -358,6 +364,7 @@ def main(
     resample_reference_mz: float,
     mass_axis_type: str,
     sparse_format: str,
+    include_optical: bool,
 ):
     """Convert MSI data to SpatialData format.
 
@@ -412,6 +419,7 @@ def main(
         resampling_config=resampling_config,
         reader_options=reader_options,
         sparse_format=sparse_format,
+        include_optical=include_optical,
     )
 
     # Optimize chunks if requested and conversion succeeded

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -166,6 +166,7 @@ def _create_converter(
     pixel_size_detection_info: Dict[str, Any],
     resampling_config: Optional[Dict[str, Any]] = None,
     sparse_format: str = "csc",
+    include_optical: bool = True,
     **kwargs: Any,
 ) -> Any:
     """Create and return a converter for the specified format."""
@@ -194,6 +195,7 @@ def _create_converter(
         pixel_size_detection_info=pixel_size_detection_info,
         resampling_config=resampling_config,
         sparse_format=sparse_format,
+        include_optical=include_optical,
         **kwargs,
     )
 
@@ -220,6 +222,7 @@ def convert_msi(
     resampling_config: Optional[Dict[str, Any]] = None,
     reader_options: Optional[Dict[str, Any]] = None,
     sparse_format: str = "csc",
+    include_optical: bool = True,
     **kwargs: Any,
 ) -> bool:
     """Convert MSI data to the specified format with enhanced error handling.
@@ -237,6 +240,7 @@ def convert_msi(
         reader_options: Optional format-specific reader options. For Bruker data:
             - use_recalibrated_state: bool - Use active/recalibrated calibration (default True)
         sparse_format: Sparse matrix format for output ('csc' or 'csr', default: 'csc')
+        include_optical: Whether to include optical images in output (default: True)
         **kwargs: Additional keyword arguments
 
     Returns:
@@ -282,6 +286,7 @@ def convert_msi(
             pixel_size_detection_info,
             resampling_config,
             sparse_format,
+            include_optical=include_optical,
             **kwargs,
         )
 

--- a/thyra/converters/spatialdata/spatialdata_2d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_2d_converter.py
@@ -326,3 +326,6 @@ class SpatialData2DConverter(BaseSpatialDataConverter):
 
                 logging.debug(f"Detailed traceback:\n{traceback.format_exc()}")
                 raise
+
+        # Add optical images if available
+        self._add_optical_images(data_structures)

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -303,3 +303,6 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
                     "global": transform,
                 },
             )
+
+        # Add optical images if available
+        self._add_optical_images(data_structures)

--- a/thyra/core/base_reader.py
+++ b/thyra/core/base_reader.py
@@ -1,7 +1,7 @@
 # thyra/core/base_reader.py
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Generator, Optional, Tuple
+from typing import TYPE_CHECKING, Generator, List, Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -44,6 +44,21 @@ class BaseMSIReader(ABC):
     def get_comprehensive_metadata(self) -> ComprehensiveMetadata:
         """Get complete metadata."""
         return self.metadata_extractor.get_comprehensive()
+
+    def get_optical_image_paths(self) -> List[Path]:
+        """Get paths to optical/microscopy images associated with this data.
+
+        Returns list of TIFF file paths that contain optical images of the
+        sample. These images can be stored alongside MSI data in SpatialData
+        output for multimodal analysis.
+
+        Default implementation returns empty list. Subclasses should override
+        to return paths to optical images specific to their format.
+
+        Returns:
+            List of paths to TIFF files, empty if no optical images available.
+        """
+        return []
 
     @abstractmethod
     def get_common_mass_axis(self) -> NDArray[np.float64]:

--- a/thyra/readers/fleximaging/fleximaging_reader.py
+++ b/thyra/readers/fleximaging/fleximaging_reader.py
@@ -588,6 +588,21 @@ class FlexImagingReader(BaseMSIReader):
         finally:
             pbar.close()
 
+    def get_optical_image_paths(self) -> List[Path]:
+        """Get paths to optical/microscopy TIFF images.
+
+        FlexImaging data folders typically contain optical images:
+        - *deriv*.tif: Low-resolution optical overview
+        - *_0000.tif: High-resolution reference image (used for teaching points)
+        - *_0001.tif: Derived/processed image
+
+        Returns:
+            List of paths to TIFF files in the data folder, sorted by name.
+        """
+        tiff_paths = list(self.data_path.glob("*.tif"))
+        tiff_paths.extend(self.data_path.glob("*.tiff"))
+        return sorted(set(tiff_paths))
+
     def close(self) -> None:
         """Close the reader and release resources."""
         if self._closed:


### PR DESCRIPTION
## Summary

Add support for integrating optical/microscopy images (TIFF files) that accompany Bruker MSI data into the SpatialData output.

- Both timsTOF and FlexImaging datasets include optical images that are now stored alongside the MSI data
- Optical images are loaded using tifffile with imagecodecs for LZW compression support
- Images are stored as Image2DModel layers in SpatialData output
- New CLI option `--include-optical/--no-optical` (default: enabled)

### Changes

- Add `get_optical_image_paths()` method to BaseMSIReader (returns empty list by default)
- Implement `get_optical_image_paths()` in FlexImagingReader to find TIFFs in data folder
- Add `_add_optical_images()` and `_load_single_optical_image()` to base SpatialData converter
- Add `imagecodecs` dependency for reading LZW-compressed TIFFs
- Pass `include_optical` parameter through CLI -> convert_msi -> converter

### Output

Optical images are stored with descriptive names:
- `msi_dataset_optical_overview` (for `*deriv*.tif`)
- `msi_dataset_optical_highres` (for `*_0000.tif`)
- `msi_dataset_optical_derived` (for `*_0001.tif`)

Example output structure:
```
images/
  msi_dataset_optical_overview: shape=(3, 2833, 5417), dtype=uint8
  msi_dataset_optical_highres: shape=(3, 11464, 21744), dtype=uint8
  msi_dataset_optical_derived: shape=(3, 2866, 5436), dtype=uint8
  msi_dataset_z0_tic: shape=(1, 494, 424), dtype=float64
```

## Test plan

- [x] Unit tests pass (181 passed)
- [x] Tested with real FlexImaging rapifleX data
- [x] Verified optical images are correctly stored in SpatialData output
- [x] Verified shape and dtype of stored images

Closes #56