### PR TITLE
fix: polygon Area definitions produce correct bounding box

### DIFF
--- a/tests/unit/readers/test_rapiflex_reader.py
+++ b/tests/unit/readers/test_rapiflex_reader.py
@@ -396,6 +396,63 @@ class TestRapiflexFormatDetection:
 
         assert format_name == "rapiflex"
 
+    def test_extract_areas_rectangular(self, create_mock_rapiflex_data):
+        """Test area extraction with rectangular (Type=0) 2-point areas."""
+        folder, _, _, _, _, _ = create_mock_rapiflex_data
+        reader = RapiflexReader(folder)
+
+        import xml.etree.ElementTree as ET
+
+        xml_str = """<Root>
+            <Area Type="0" Name="01">
+                <Point>9768,6372</Point>
+                <Point>10672,6676</Point>
+            </Area>
+        </Root>"""
+        root = ET.fromstring(xml_str)
+        metadata = {}
+        reader._extract_areas(root, metadata)
+
+        assert len(metadata["areas"]) == 1
+        area = metadata["areas"][0]
+        assert area["name"] == "01"
+        assert area["p1"] == [9768, 6372]
+        assert area["p2"] == [10672, 6676]
+        reader.close()
+
+    def test_extract_areas_polygon(self, create_mock_rapiflex_data):
+        """Test area extraction with polygon (Type=3) N-point areas."""
+        folder, _, _, _, _, _ = create_mock_rapiflex_data
+        reader = RapiflexReader(folder)
+
+        import xml.etree.ElementTree as ET
+
+        xml_str = """<Root>
+            <Area Type="3" Name="01">
+                <Point>24470,4585</Point>
+                <Point>24420,3818</Point>
+                <Point>24862,3543</Point>
+                <Point>25353,3168</Point>
+                <Point>26228,3043</Point>
+                <Point>26753,4193</Point>
+                <Point>26462,5485</Point>
+                <Point>25362,5777</Point>
+                <Point>24737,4943</Point>
+                <Point>24487,4552</Point>
+            </Area>
+        </Root>"""
+        root = ET.fromstring(xml_str)
+        metadata = {}
+        reader._extract_areas(root, metadata)
+
+        assert len(metadata["areas"]) == 1
+        area = metadata["areas"][0]
+        assert area["name"] == "01"
+        # Bounding box should span ALL points, not just first two
+        assert area["p1"] == [24420, 3043]
+        assert area["p2"] == [26753, 5777]
+        reader.close()
+
     def test_not_rapiflex_without_dat(self, tmp_path):
         """Test that folder without .dat is not detected as Rapiflex."""
         from thyra.core.registry import detect_format

--- a/thyra/readers/bruker/rapiflex/rapiflex_reader.py
+++ b/thyra/readers/bruker/rapiflex/rapiflex_reader.py
@@ -376,7 +376,8 @@ class RapiflexReader(BrukerBaseMSIReader):
         """Extract Area definitions from .mis XML.
 
         Areas define the image pixel coordinates for each acquisition region.
-        Each Area has a Name and two Point elements defining the bounding box.
+        Areas may be rectangular (Type=0, 2 points) or polygon (Type=3, N
+        points). In both cases the bounding box of all points is stored.
 
         Args:
             root: XML root element
@@ -388,20 +389,21 @@ class RapiflexReader(BrukerBaseMSIReader):
             points = area_elem.findall("Point")
             if len(points) >= 2:
                 try:
-                    # Parse point coordinates (format: "x,y")
-                    # Use lists instead of tuples for Zarr serialization
-                    p1_text = points[0].text or ""
-                    p2_text = points[1].text or ""
-                    p1_parts = p1_text.split(",")
-                    p2_parts = p2_text.split(",")
-                    p1 = [int(p1_parts[0]), int(p1_parts[1])]
-                    p2 = [int(p2_parts[0]), int(p2_parts[1])]
+                    # Parse ALL point coordinates to get bounding box
+                    # Works for both rectangular (2 points) and polygon (N points)
+                    all_x = []
+                    all_y = []
+                    for pt in points:
+                        pt_text = pt.text or ""
+                        parts = pt_text.split(",")
+                        all_x.append(int(parts[0]))
+                        all_y.append(int(parts[1]))
 
                     areas.append(
                         {
                             "name": area_name,
-                            "p1": p1,  # [x1, y1] in image pixels
-                            "p2": p2,  # [x2, y2] in image pixels
+                            "p1": [min(all_x), min(all_y)],
+                            "p2": [max(all_x), max(all_y)],
                         }
                     )
                 except (ValueError, IndexError) as e:


### PR DESCRIPTION
## Summary
- `_extract_areas` in `RapiflexReader` only used the first 2 `<Point>` elements as bounding box corners, which is correct for rectangular areas (Type=0) but wrong for polygon areas (Type=3) where the first 2 points are adjacent vertices
- Now iterates all points to compute min/max bounding box, matching the standalone `mis_parser.py` which was already correct
- Adds tests for both rectangular and polygon area extraction

Closes #84

## Test plan
- [x] Existing rapiflex reader tests pass (16/16)
- [x] New test: rectangular area (Type=0) with 2 points produces correct bbox
- [x] New test: polygon area (Type=3) with 10 points produces correct bbox from all vertices