### PR TITLE
fix: Bruker region selection, pixel size, and size estimator bugs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/tests/unit/converters/test_streaming_converter.py
+++ b/tests/unit/converters/test_streaming_converter.py
@@ -139,6 +139,92 @@ class MockMSIReader:
     not SPATIALDATA_AVAILABLE,
     reason="SpatialData dependencies not available",
 )
+def test_drop_empty_pixels_removes_zero_rows_from_obs():
+    """Regression for #88: positions inside the bounding box but outside the
+    acquisition polygon (zero non-zeros in the matrix) must be dropped from
+    obs so the table reflects only actually-acquired pixels.
+    """
+    import pandas as pd
+    from anndata import AnnData
+    from scipy import sparse
+
+    reader = MockMSIReader(dimensions=(4, 4, 1))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        converter = StreamingSpatialDataConverter(
+            reader=reader,
+            output_path=Path(tmpdir) / "out.zarr",
+        )
+
+    # 4x4 = 16 bbox pixels but only 10 have spectra (the rest sit in
+    # polygon-corner empty space).
+    n_rows = 16
+    n_cols = 100
+    rows_with_data = [0, 1, 3, 4, 5, 6, 9, 10, 13, 14]
+    indptr = np.zeros(n_rows + 1, dtype=np.int64)
+    indices = []
+    data = []
+    for r in range(n_rows):
+        if r in rows_with_data:
+            indices.extend([0, 1, 2])
+            data.extend([1.0, 2.0, 3.0])
+        indptr[r + 1] = len(indices)
+    matrix = sparse.csr_matrix(
+        (np.asarray(data), np.asarray(indices), indptr),
+        shape=(n_rows, n_cols),
+        dtype=np.float64,
+    )
+    obs = pd.DataFrame({"x": np.arange(n_rows), "y": np.zeros(n_rows, dtype=int)})
+    obs.index = obs.index.astype(str)
+    var = pd.DataFrame({"mz": np.linspace(100, 200, n_cols)})
+    var.index = var.index.astype(str)
+    adata = AnnData(X=matrix, obs=obs, var=var)
+
+    filtered = converter._drop_empty_pixels(adata)
+    assert filtered.n_obs == len(rows_with_data)
+    # All remaining rows still carry data
+    assert (np.asarray(filtered.X.getnnz(axis=1)).flatten() > 0).all()
+    # Coordinate columns are preserved (subset of original x indices)
+    assert filtered.obs["x"].tolist() == rows_with_data
+
+
+@pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+def test_drop_empty_pixels_no_op_when_all_rows_have_data():
+    """If every row has data (e.g. a fully-rectangular acquisition), the
+    helper must return the AnnData unchanged so we don't add overhead in
+    the common case.
+    """
+    import pandas as pd
+    from anndata import AnnData
+    from scipy import sparse
+
+    reader = MockMSIReader(dimensions=(2, 2, 1))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        converter = StreamingSpatialDataConverter(
+            reader=reader,
+            output_path=Path(tmpdir) / "out.zarr",
+        )
+
+    n_rows = 4
+    matrix = sparse.csr_matrix(np.ones((n_rows, 5), dtype=np.float64))
+    obs = pd.DataFrame({"x": np.arange(n_rows)})
+    obs.index = obs.index.astype(str)
+    var = pd.DataFrame({"mz": np.linspace(100, 200, 5)})
+    var.index = var.index.astype(str)
+    adata = AnnData(X=matrix, obs=obs, var=var)
+
+    filtered = converter._drop_empty_pixels(adata)
+    assert filtered.n_obs == n_rows
+    # Same object returned (early-out path) when nothing is filtered
+    assert filtered is adata
+
+
+@pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
 def test_estimate_output_size_uses_real_bins_for_width_based_config():
     """Regression for #87: when ``target_bins`` is None, the size estimator
     must resolve the bin count via ``width_at_mz`` rather than fall back to a

--- a/tests/unit/converters/test_streaming_converter.py
+++ b/tests/unit/converters/test_streaming_converter.py
@@ -139,6 +139,47 @@ class MockMSIReader:
     not SPATIALDATA_AVAILABLE,
     reason="SpatialData dependencies not available",
 )
+def test_estimate_output_size_uses_real_bins_for_width_based_config():
+    """Regression for #87: when ``target_bins`` is None, the size estimator
+    must resolve the bin count via ``width_at_mz`` rather than fall back to a
+    hardcoded 10,000 placeholder. A 10k fallback would also pick the wrong
+    streaming method against ``PCS_SIZE_THRESHOLD_GB``.
+    """
+    reader = MockMSIReader(
+        dimensions=(50, 50, 1),
+        peaks_per_spectrum=200,
+        mass_range=(100.0, 1000.0),
+    )
+    # Width-based config: bins NOT specified, only width_at_mz.
+    # With CONSTANT axis (mock falls through to DefaultDetector) and
+    # 5 mDa bin width over 100-1000 m/z, the resolved axis is 180,000 bins.
+    config = {
+        "method": "tic_preserving",
+        "target_bins": None,
+        "width_at_mz": 0.005,
+        "reference_mz": 1000.0,
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        converter = StreamingSpatialDataConverter(
+            reader=reader,
+            output_path=Path(tmpdir) / "out.zarr",
+            use_csc="auto",
+            resampling_config=config,
+        )
+        size_gb = converter._estimate_output_size_gb()
+
+    # 2500 pixels x 180k bins x 4 bytes = ~1.68 GB. With the buggy 10k
+    # fallback it would have been ~0.09 GB.
+    assert size_gb > 1.0, (
+        f"Expected size estimate > 1 GB (resolved bins), got {size_gb:.3f} GB. "
+        "Likely regression of #87 (10k hardcoded fallback)."
+    )
+
+
+@pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
 def test_converter_initialization():
     """Test that the converter initializes correctly."""
     reader = MockMSIReader()

--- a/tests/unit/metadata/extractors/test_bruker_extractor.py
+++ b/tests/unit/metadata/extractors/test_bruker_extractor.py
@@ -160,6 +160,56 @@ class TestBrukerMetadataExtractor:
 
         assert essential.pixel_size is None
 
+    def test_pixel_size_prefers_mis_raster_over_beamscan(self, tmp_path):
+        """Regression for #90: when a .mis file is present alongside the .d
+        folder with a Raster value smaller than BeamScanSize (oversampled
+        acquisition), the extractor must report the Raster step as pixel size.
+        """
+        # BeamScanSize is 10 um but the actual raster step is 5 um (2x oversampling).
+        sample_data = {
+            "essential": (10.0, 10.0, 5.0, 0, 2, 0, 4, 400, 100.0, 1000.0),
+            "comprehensive": [],
+            "laser_info": (10.0, 10.0, 5.0),
+        }
+        mock_conn = self.create_mock_connection(sample_data)
+
+        d_folder = tmp_path / "sample_oversampled.d"
+        d_folder.mkdir()
+        mis = tmp_path / "sample_oversampled.mis"
+        mis.write_text(
+            "<?xml version='1.0'?><ImagingSequence>"
+            "<Raster>5,5</Raster></ImagingSequence>"
+        )
+
+        extractor = BrukerMetadataExtractor(mock_conn, d_folder)
+        essential = extractor.get_essential()
+
+        assert essential.pixel_size == (5.0, 5.0), (
+            f"Expected Raster (5.0, 5.0), got BeamScanSize {essential.pixel_size}. "
+            "Likely regression of #90."
+        )
+
+    def test_pixel_size_falls_back_to_beamscan_when_no_mis(self, tmp_path):
+        """When no .mis file is present, the extractor must fall back to
+        BeamScanSizeX/Y so behaviour stays unchanged for datasets that lack
+        FlexImaging metadata.
+        """
+        sample_data = {
+            "essential": (15.0, 15.0, 5.0, 0, 2, 0, 4, 400, 100.0, 1000.0),
+            "comprehensive": [],
+            "laser_info": (15.0, 15.0, 5.0),
+        }
+        mock_conn = self.create_mock_connection(sample_data)
+
+        d_folder = tmp_path / "sample_no_mis.d"
+        d_folder.mkdir()
+        # Intentionally no .mis file in tmp_path
+
+        extractor = BrukerMetadataExtractor(mock_conn, d_folder)
+        essential = extractor.get_essential()
+
+        assert essential.pixel_size == (15.0, 15.0)
+
     def test_extract_essential_3d_data(self):
         """Test essential metadata extraction with 3D data (SpotSize > 1)."""
         # Mock data with 3D coordinates

--- a/tests/unit/readers/test_bruker_region_selection.py
+++ b/tests/unit/readers/test_bruker_region_selection.py
@@ -1,11 +1,41 @@
 """Tests for Bruker region selection by name vs DB number (#89)."""
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import pytest
 
 from thyra.readers.bruker.timstof.timstof_reader import BrukerReader
+
+_MODULE_LOGGER_NAME = "thyra.readers.bruker.timstof.timstof_reader"
+
+
+@contextmanager
+def _capture_module_logs() -> Iterator[List[str]]:
+    """Attach a handler directly to the reader's module logger.
+
+    pytest's ``caplog`` relies on log propagation to the root handler, which
+    can be silently disabled by other tests in the session. Attaching a
+    handler to the named logger directly captures records regardless of
+    propagation state, making this assertion robust to test order.
+    """
+    records: List[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record.getMessage())
+
+    module_logger = logging.getLogger(_MODULE_LOGGER_NAME)
+    handler = _Capture(level=logging.INFO)
+    previous_level = module_logger.level
+    module_logger.addHandler(handler)
+    module_logger.setLevel(logging.INFO)
+    try:
+        yield records
+    finally:
+        module_logger.removeHandler(handler)
+        module_logger.setLevel(previous_level)
 
 
 class _NameResolutionHarness:
@@ -78,43 +108,30 @@ def test_resolve_none_returns_none() -> None:
     assert h._resolve_requested_region() is None
 
 
-def test_log_region_mapping_emits_pairs(caplog: pytest.LogCaptureFixture) -> None:
+def test_log_region_mapping_emits_pairs() -> None:
     h = _harness(
         ["01", "02", "03"],
         [(0, 10), (1, 20), (2, 30)],
         None,
     )
-    caplog.set_level(logging.INFO)
-    # Ensure the module logger propagates so caplog's root handler can see it.
-    module_logger = logging.getLogger("thyra.readers.bruker.timstof.timstof_reader")
-    module_logger.propagate = True
-    h._log_region_mapping()
-    text = caplog.text
+    with _capture_module_logs() as records:
+        h._log_region_mapping()
+    text = "\n".join(records)
     assert "Region mapping" in text
     assert "RegionNumber 0 -> Area '01'" in text
     assert "RegionNumber 1 -> Area '02'" in text
     assert "RegionNumber 2 -> Area '03'" in text
 
 
-def test_log_region_mapping_skips_single_region(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_log_region_mapping_skips_single_region() -> None:
     h = _harness(["only"], [(0, 100)], None)
-    caplog.set_level(logging.INFO)
-    # Ensure the module logger propagates so caplog's root handler can see it.
-    module_logger = logging.getLogger("thyra.readers.bruker.timstof.timstof_reader")
-    module_logger.propagate = True
-    h._log_region_mapping()
-    assert "Region mapping" not in caplog.text
+    with _capture_module_logs() as records:
+        h._log_region_mapping()
+    assert all("Region mapping" not in line for line in records)
 
 
-def test_log_region_mapping_skips_when_no_areas(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_log_region_mapping_skips_when_no_areas() -> None:
     h = _harness([], [(0, 10), (1, 20)], None)
-    caplog.set_level(logging.INFO)
-    # Ensure the module logger propagates so caplog's root handler can see it.
-    module_logger = logging.getLogger("thyra.readers.bruker.timstof.timstof_reader")
-    module_logger.propagate = True
-    h._log_region_mapping()
-    assert "Region mapping" not in caplog.text
+    with _capture_module_logs() as records:
+        h._log_region_mapping()
+    assert all("Region mapping" not in line for line in records)

--- a/tests/unit/readers/test_bruker_region_selection.py
+++ b/tests/unit/readers/test_bruker_region_selection.py
@@ -84,10 +84,11 @@ def test_log_region_mapping_emits_pairs(caplog: pytest.LogCaptureFixture) -> Non
         [(0, 10), (1, 20), (2, 30)],
         None,
     )
-    with caplog.at_level(
-        logging.INFO, logger="thyra.readers.bruker.timstof.timstof_reader"
-    ):
-        h._log_region_mapping()
+    caplog.set_level(logging.INFO)
+    # Ensure the module logger propagates so caplog's root handler can see it.
+    module_logger = logging.getLogger("thyra.readers.bruker.timstof.timstof_reader")
+    module_logger.propagate = True
+    h._log_region_mapping()
     text = caplog.text
     assert "Region mapping" in text
     assert "RegionNumber 0 -> Area '01'" in text
@@ -99,10 +100,11 @@ def test_log_region_mapping_skips_single_region(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     h = _harness(["only"], [(0, 100)], None)
-    with caplog.at_level(
-        logging.INFO, logger="thyra.readers.bruker.timstof.timstof_reader"
-    ):
-        h._log_region_mapping()
+    caplog.set_level(logging.INFO)
+    # Ensure the module logger propagates so caplog's root handler can see it.
+    module_logger = logging.getLogger("thyra.readers.bruker.timstof.timstof_reader")
+    module_logger.propagate = True
+    h._log_region_mapping()
     assert "Region mapping" not in caplog.text
 
 
@@ -110,8 +112,9 @@ def test_log_region_mapping_skips_when_no_areas(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     h = _harness([], [(0, 10), (1, 20)], None)
-    with caplog.at_level(
-        logging.INFO, logger="thyra.readers.bruker.timstof.timstof_reader"
-    ):
-        h._log_region_mapping()
+    caplog.set_level(logging.INFO)
+    # Ensure the module logger propagates so caplog's root handler can see it.
+    module_logger = logging.getLogger("thyra.readers.bruker.timstof.timstof_reader")
+    module_logger.propagate = True
+    h._log_region_mapping()
     assert "Region mapping" not in caplog.text

--- a/tests/unit/readers/test_bruker_region_selection.py
+++ b/tests/unit/readers/test_bruker_region_selection.py
@@ -1,0 +1,117 @@
+"""Tests for Bruker region selection by name vs DB number (#89)."""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from thyra.readers.bruker.timstof.timstof_reader import BrukerReader
+
+
+class _NameResolutionHarness:
+    """Stand-in for a fully-initialised BrukerReader.
+
+    Exposes only the attributes/methods used by ``_resolve_requested_region``
+    and ``_log_region_mapping``, so we can test them without the heavy SDK
+    initialisation path.
+    """
+
+    _mis_metadata: Dict[str, Any]
+    _region_info: List[Tuple[int, int]]
+    _requested_region: Optional[Any]
+
+    # Reuse the methods under test directly from the real class so any future
+    # behaviour change is automatically picked up.
+    _get_region_name_map = BrukerReader._get_region_name_map
+    _log_region_mapping = BrukerReader._log_region_mapping
+    _resolve_requested_region = BrukerReader._resolve_requested_region
+
+
+def _harness(
+    areas: List[str],
+    region_info: List[Tuple[int, int]],
+    requested: Optional[Any],
+) -> _NameResolutionHarness:
+    h = _NameResolutionHarness()
+    h._mis_metadata = {"areas": [{"name": n} for n in areas]}
+    h._region_info = region_info
+    h._requested_region = requested
+    return h
+
+
+def test_get_region_name_map_index_based() -> None:
+    """The i-th .mis Area maps positionally to RegionNumber i."""
+    h = _harness(["01", "02", "03"], [(0, 10), (1, 20), (2, 30)], None)
+    assert h._get_region_name_map() == {0: "01", 1: "02", 2: "03"}
+
+
+def test_resolve_int_passes_through() -> None:
+    h = _harness(["01", "02", "03"], [(0, 10), (1, 20), (2, 30)], 2)
+    assert h._resolve_requested_region() == 2
+
+
+def test_resolve_string_matches_area_name() -> None:
+    """User passing '03' (the .mis label) should land on RegionNumber 2 even
+    though numerically '03' would be 3 — names take precedence over int parse.
+    """
+    h = _harness(
+        ["01", "02", "03", "04", "05", "06"],
+        [(0, 10), (1, 20), (2, 30), (3, 40), (4, 50), (5, 60)],
+        "03",
+    )
+    assert h._resolve_requested_region() == 2
+
+
+def test_resolve_string_falls_back_to_int_when_name_unknown() -> None:
+    h = _harness(["A", "B", "C"], [(0, 10), (1, 20), (2, 30)], "1")
+    assert h._resolve_requested_region() == 1
+
+
+def test_resolve_string_raises_when_name_unknown_and_not_int() -> None:
+    h = _harness(["A", "B", "C"], [(0, 10), (1, 20), (2, 30)], "doesnotexist")
+    with pytest.raises(ValueError, match="not a recognised .mis Area Name"):
+        h._resolve_requested_region()
+
+
+def test_resolve_none_returns_none() -> None:
+    h = _harness(["01", "02"], [(0, 10), (1, 20)], None)
+    assert h._resolve_requested_region() is None
+
+
+def test_log_region_mapping_emits_pairs(caplog: pytest.LogCaptureFixture) -> None:
+    h = _harness(
+        ["01", "02", "03"],
+        [(0, 10), (1, 20), (2, 30)],
+        None,
+    )
+    with caplog.at_level(
+        logging.INFO, logger="thyra.readers.bruker.timstof.timstof_reader"
+    ):
+        h._log_region_mapping()
+    text = caplog.text
+    assert "Region mapping" in text
+    assert "RegionNumber 0 -> Area '01'" in text
+    assert "RegionNumber 1 -> Area '02'" in text
+    assert "RegionNumber 2 -> Area '03'" in text
+
+
+def test_log_region_mapping_skips_single_region(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    h = _harness(["only"], [(0, 100)], None)
+    with caplog.at_level(
+        logging.INFO, logger="thyra.readers.bruker.timstof.timstof_reader"
+    ):
+        h._log_region_mapping()
+    assert "Region mapping" not in caplog.text
+
+
+def test_log_region_mapping_skips_when_no_areas(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    h = _harness([], [(0, 10), (1, 20)], None)
+    with caplog.at_level(
+        logging.INFO, logger="thyra.readers.bruker.timstof.timstof_reader"
+    ):
+        h._log_region_mapping()
+    assert "Region mapping" not in caplog.text

--- a/tests/unit/readers/test_mis_parser.py
+++ b/tests/unit/readers/test_mis_parser.py
@@ -1,0 +1,60 @@
+"""Tests for the .mis file parser and discovery helpers."""
+
+from pathlib import Path
+
+from thyra.readers.bruker.mis_parser import find_mis_file_for_d_folder, parse_mis_file
+
+
+def _write_mis(tmp_path: Path, name: str, raster: str = "5,5") -> Path:
+    mis = tmp_path / name
+    mis.write_text(
+        f"""<?xml version="1.0"?>
+<ImagingSequence>
+<ImageFile>img.tif</ImageFile>
+<Raster>{raster}</Raster>
+<Area Name="01"><Point>10,20</Point><Point>30,40</Point></Area>
+</ImagingSequence>
+"""
+    )
+    return mis
+
+
+def test_parse_mis_extracts_raster(tmp_path: Path) -> None:
+    mis = _write_mis(tmp_path, "sample.mis", raster="5,5")
+    data = parse_mis_file(mis)
+    assert data["raster"] == [5, 5]
+
+
+def test_parse_mis_handles_rectangular_raster(tmp_path: Path) -> None:
+    mis = _write_mis(tmp_path, "sample.mis", raster="10,20")
+    data = parse_mis_file(mis)
+    assert data["raster"] == [10, 20]
+
+
+def test_find_mis_prefers_matching_stem(tmp_path: Path) -> None:
+    """When several .mis files sit in the parent, prefer the one whose stem
+    matches the .d folder stem.
+    """
+    d_folder = tmp_path / "sample_A.d"
+    d_folder.mkdir()
+    _write_mis(tmp_path, "sample_A.mis", raster="5,5")
+    _write_mis(tmp_path, "sample_B.mis", raster="50,50")
+
+    found = find_mis_file_for_d_folder(d_folder)
+    assert found is not None
+    assert found.name == "sample_A.mis"
+
+
+def test_find_mis_falls_back_to_any(tmp_path: Path) -> None:
+    d_folder = tmp_path / "sample.d"
+    d_folder.mkdir()
+    other = _write_mis(tmp_path, "different_name.mis", raster="7,7")
+
+    found = find_mis_file_for_d_folder(d_folder)
+    assert found == other
+
+
+def test_find_mis_returns_none_when_missing(tmp_path: Path) -> None:
+    d_folder = tmp_path / "sample.d"
+    d_folder.mkdir()
+    assert find_mis_file_for_d_folder(d_folder) is None

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -140,7 +140,8 @@ def _validate_input_path(input: Path) -> None:
         ibd_path = input.with_suffix(".ibd")
         if not ibd_path.exists():
             raise click.BadParameter(
-                f"ImzML file requires corresponding .ibd file, but not found: {ibd_path}"
+                "ImzML file requires corresponding .ibd file, but not "
+                f"found: {ibd_path}"
             )
     elif input.is_dir() and input.suffix.lower() == ".d":
         if (
@@ -148,7 +149,8 @@ def _validate_input_path(input: Path) -> None:
             and not (input / "analysis.tdf").exists()
         ):
             raise click.BadParameter(
-                f"Bruker .d directory requires analysis.tsf or analysis.tdf file: {input}"
+                "Bruker .d directory requires analysis.tsf or "
+                f"analysis.tdf file: {input}"
             )
 
 
@@ -394,9 +396,13 @@ class GroupedCommand(click.Command):
 )
 @click.option(
     "--region",
-    type=int,
+    type=str,
     default=None,
-    help="Convert specific region number (default: all regions)",
+    help=(
+        "Convert specific region (default: all regions). Accepts a "
+        ".mis Area Name (e.g. '03') or an integer DB RegionNumber. The "
+        "DB-to-name mapping is logged at startup for multi-region datasets."
+    ),
 )
 @click.option(
     "--resample/--no-resample",
@@ -537,7 +543,7 @@ def main(
     include_optical: bool,
     intensity_threshold: Optional[float],
     streaming: str,
-    region: Optional[int],
+    region: Optional[str],
 ):
     """Convert MSI data to SpatialData format.
 

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -256,7 +256,7 @@ def convert_msi(
     sparse_format: str = "csc",
     include_optical: bool = True,
     streaming: Union[bool, Literal["auto"]] = "auto",
-    region: Optional[int] = None,
+    region: Optional[Union[int, str]] = None,
     **kwargs: Any,
 ) -> bool:
     """Convert MSI data to the specified format.
@@ -284,7 +284,9 @@ def convert_msi(
             - True: Force streaming converter
             - False: Force standard converter
         region: For multi-region datasets (e.g. Bruker timsTOF),
-            select a specific region number. None (default)
+            select a specific region. Accepts an int (DB
+            RegionNumber) or a str (matched against .mis Area
+            Name, falling back to integer parse). None (default)
             converts all regions. Passed to the reader as
             reader_options["region"].
         **kwargs: Additional keyword arguments

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -470,6 +470,40 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         else:
             return obj
 
+    def _drop_empty_pixels(self, adata: "AnnData") -> "AnnData":
+        """Drop obs rows whose intensity matrix row has no non-zero values.
+
+        Acquisitions are typically polygon-shaped, but the obs table is
+        indexed over the rectangular bounding box of the acquired
+        coordinates. That leaves "corner" pixels inside the bbox but
+        outside the actual polygon, which carry no spectra and inflate
+        the obs / shapes layouts (#88). For multi-region datasets these
+        empties also include inter-region gaps when the bbox is the
+        union of regions.
+
+        Filtering here makes obs reflect only positions where data was
+        actually acquired. The TIC image is unaffected (it is a dense
+        2D spatial image, not a per-pixel table). Visualisation code
+        that scatters obs values back onto a grid via obs[``x``]/[``y``]
+        works identically before and after.
+        """
+        if adata.n_obs == 0:
+            return adata
+        row_nnz = adata.X.getnnz(axis=1)
+        non_empty = np.asarray(row_nnz).flatten() > 0
+        if bool(non_empty.all()):
+            return adata
+        n_total = adata.n_obs
+        n_kept = int(non_empty.sum())
+        logger.info(
+            "Dropping %d empty pixel rows from obs (%d non-empty pixels "
+            "remain). These positions are inside the bounding box but "
+            "outside the acquisition polygon.",
+            n_total - n_kept,
+            n_kept,
+        )
+        return adata[non_empty, :].copy()
+
     def _calculate_bins_from_width(
         self, min_mz: float, max_mz: float, axis_type
     ) -> int:

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -561,38 +561,48 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # Default for other axis types: 5.0 mDa at m/z 1000
         return 0.005, 1000.0
 
-    def _build_resampled_mass_axis(self) -> None:
-        """Build resampled mass axis using physics-based generators."""
-        from ...resampling.common_axis import CommonAxisBuilder
+    def _resolve_resampling_plan(
+        self,
+    ) -> Tuple[float, float, Any, int]:
+        """Resolve mass range, axis type, and target bin count for resampling.
 
-        # Use cached essential metadata to avoid reader calls
-        # This should be called after _initialize_conversion() has loaded metadata
+        Single source of truth used by both ``_build_resampled_mass_axis`` and
+        the size estimator. Caches essential metadata lazily.
+
+        Returns:
+            (min_mz, max_mz, axis_type, target_bins)
+        """
         if self._essential_metadata_cached is None:
-            # Cache essential metadata for reuse
             self._essential_metadata_cached = self.reader.get_essential_metadata()
 
         mass_range = self._essential_metadata_cached.mass_range
         min_mz = mass_range[0] if self._min_mz is None else self._min_mz
         max_mz = mass_range[1] if self._max_mz is None else self._max_mz
 
-        # Check if manual axis type override was provided
         if hasattr(self, "_manual_axis_type") and self._manual_axis_type is not None:
             axis_type = self._manual_axis_type
-            logger.info(f"Using manually specified axis type: {axis_type}")
         else:
-            # Get metadata for axis type selection (minimize reader calls)
             metadata = self._get_cached_metadata_for_resampling()
             tree = ResamplingDecisionTree()
             axis_type = tree.select_axis_type(metadata)
-            logger.info(f"Auto-detected axis type: {axis_type}")
 
-        # Calculate bins based on width if specified OR if no bins were specified (default)
         if self._width_at_mz is not None or self._target_bins is None:
-            # Either user specified width OR using default (calculate from 5mDa@1000)
             target_bins = self._calculate_bins_from_width(min_mz, max_mz, axis_type)
         else:
-            # User explicitly specified bin count
             target_bins = self._target_bins
+
+        return min_mz, max_mz, axis_type, target_bins
+
+    def _build_resampled_mass_axis(self) -> None:
+        """Build resampled mass axis using physics-based generators."""
+        from ...resampling.common_axis import CommonAxisBuilder
+
+        min_mz, max_mz, axis_type, target_bins = self._resolve_resampling_plan()
+
+        if hasattr(self, "_manual_axis_type") and self._manual_axis_type is not None:
+            logger.info(f"Using manually specified axis type: {axis_type}")
+        else:
+            logger.info(f"Auto-detected axis type: {axis_type}")
 
         logger.info(
             f"Building resampled mass axis: {min_mz:.2f} - {max_mz:.2f} m/z, "

--- a/thyra/converters/spatialdata/spatialdata_2d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_2d_converter.py
@@ -305,6 +305,9 @@ class SpatialData2DConverter(BaseSpatialDataConverter):
                     var=data_structures["var_df"],
                 )
 
+                # Drop bbox positions that have no spectrum (#88)
+                adata = self._drop_empty_pixels(adata)
+
                 # Add average spectrum to .uns
                 adata.uns["average_spectrum"] = avg_spectrum
 

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -206,6 +206,9 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
                 var=data_structures["var_df"],
             )
 
+            # Drop bbox positions that have no spectrum (#88)
+            adata = self._drop_empty_pixels(adata)
+
             # Add average spectrum to .uns (use total_intensity to match
             # original behavior)
             adata.uns["average_spectrum"] = data_structures["total_intensity"]

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -123,11 +123,12 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         n_x, n_y, n_z = metadata.dimensions
         n_pixels = n_x * n_y * n_z
 
-        # Estimate number of m/z bins after resampling
+        # Estimate number of m/z bins after resampling using the same
+        # resolution path the axis builder will use, so the gate against
+        # PCS_SIZE_THRESHOLD_GB sees the real bin count.
         if self._resampling_config:
-            n_mz_bins = self._resampling_config.target_bins or 10000
+            _, _, _, n_mz_bins = self._resolve_resampling_plan()
         else:
-            # Estimate from mass range with ~0.01 Da resolution
             min_mass, max_mass = metadata.mass_range
             n_mz_bins = int((max_mass - min_mass) / 0.01)
 

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -837,6 +837,9 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                     var=data_structures["var_df"],
                 )
 
+                # Drop bbox positions that have no spectrum (#88)
+                adata = self._drop_empty_pixels(adata)
+
                 # Add average spectrum to .uns
                 adata.uns["average_spectrum"] = avg_spectrum
 

--- a/thyra/metadata/extractors/bruker_extractor.py
+++ b/thyra/metadata/extractors/bruker_extractor.py
@@ -204,7 +204,7 @@ class BrukerMetadataExtractor(MetadataExtractor):
             # Build final metadata objects
             dimensions = self._calculate_dimensions_from_coords(0.0, max_x, 0.0, max_y)
             coordinate_bounds = (0.0, float(max_x), 0.0, float(max_y))
-            pixel_size = (float(beam_x), float(beam_y)) if beam_x and beam_y else None
+            pixel_size = self._resolve_pixel_size_um(beam_x, beam_y)
             mass_range = (float(min_mass), float(max_mass))
             _, _, _, _, frame_count = frame_result
             n_spectra = int(frame_count) if frame_count else 0
@@ -242,6 +242,58 @@ class BrukerMetadataExtractor(MetadataExtractor):
             instrument_info=self._extract_instrument_info(),
             raw_metadata=self._extract_global_metadata(),
         )
+
+    def _resolve_pixel_size_um(
+        self,
+        beam_x: Optional[float],
+        beam_y: Optional[float],
+    ) -> Optional[Tuple[float, float]]:
+        """Resolve pixel pitch in micrometers, preferring .mis <Raster>.
+
+        The Bruker SDK exposes ``MaldiFrameLaserInfo.BeamScanSizeX/Y`` which is
+        the area each laser shot scans, not the raster step. When the
+        acquisition oversamples (BeamScanSize > Raster), these values disagree
+        and the canonical pixel pitch is the Raster step from the FlexImaging
+        ``.mis`` file. Prefer the Raster step; warn when it disagrees with
+        BeamScanSize. Fall back to BeamScanSize when no .mis is found.
+        """
+        from ...readers.bruker.mis_parser import (
+            find_mis_file_for_d_folder,
+            parse_mis_file,
+        )
+
+        raster: Optional[Tuple[float, float]] = None
+        mis_path = find_mis_file_for_d_folder(self.data_path)
+        if mis_path is not None:
+            mis_data = parse_mis_file(mis_path)
+            raster_xy = mis_data.get("raster")
+            if (
+                isinstance(raster_xy, list)
+                and len(raster_xy) == 2
+                and all(v > 0 for v in raster_xy)
+            ):
+                raster = (float(raster_xy[0]), float(raster_xy[1]))
+
+        beam: Optional[Tuple[float, float]] = (
+            (float(beam_x), float(beam_y)) if beam_x and beam_y else None
+        )
+
+        if raster is not None and beam is not None:
+            if raster != beam:
+                logger.warning(
+                    "Pixel size mismatch: .mis Raster=(%g, %g) um, "
+                    "BeamScanSize=(%g, %g) um. Acquisition is oversampled. "
+                    "Using Raster step. Override with --pixel-size if needed.",
+                    raster[0],
+                    raster[1],
+                    beam[0],
+                    beam[1],
+                )
+            return raster
+
+        if raster is not None:
+            return raster
+        return beam
 
     def _calculate_dimensions_from_coords(
         self,

--- a/thyra/metadata/extractors/waters_extractor.py
+++ b/thyra/metadata/extractors/waters_extractor.py
@@ -231,7 +231,7 @@ class WatersMetadataExtractor(MetadataExtractor):
             "n_functions": self._ml.get_number_of_functions(self._handle),
             "ms_functions": self._ms_functions,
             "function_types": {
-                f: ft.name if hasattr(ft, "name") else str(ft)
+                str(f): ft.name if hasattr(ft, "name") else str(ft)
                 for f, ft in self._function_types.items()
             },
             "pixel_count_x": self._imaging_grid.pixel_count_x,

--- a/thyra/readers/bruker/mis_parser.py
+++ b/thyra/readers/bruker/mis_parser.py
@@ -8,9 +8,35 @@ for aligning MSI data with optical images.
 import logging
 import xml.etree.ElementTree as ET  # nosec B405 - parsing trusted local instrument files
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def find_mis_file_for_d_folder(data_path: Path) -> Optional[Path]:
+    """Locate the .mis file that corresponds to a Bruker .d folder.
+
+    A FlexImaging acquisition typically writes the .mis next to the .d folder,
+    using the same stem. Falls back to any .mis in the parent directory.
+
+    Args:
+        data_path: Path to the Bruker .d directory
+
+    Returns:
+        Path to the matching .mis file, or None if none found.
+    """
+    parent = data_path.parent
+    if not parent.exists():
+        return None
+
+    matching = parent / f"{data_path.stem}.mis"
+    if matching.exists():
+        return matching
+
+    candidates = list(parent.glob("*.mis"))
+    if candidates:
+        return candidates[0]
+    return None
 
 
 def parse_mis_file(path: Path) -> Dict[str, Any]:

--- a/thyra/readers/bruker/timstof/timstof_reader.py
+++ b/thyra/readers/bruker/timstof/timstof_reader.py
@@ -10,7 +10,7 @@ import os
 import re
 import sqlite3
 from pathlib import Path
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -197,7 +197,7 @@ class BrukerReader(BrukerBaseMSIReader):
         memory_limit_gb: Optional[float] = None,
         batch_size: Optional[int] = None,
         progress_callback: Optional[Callable[[int, int], None]] = None,
-        region: Optional[int] = None,
+        region: Optional[Union[int, str]] = None,
         **kwargs,
     ):
         """Initialize the Bruker reader.
@@ -213,9 +213,11 @@ class BrukerReader(BrukerBaseMSIReader):
             memory_limit_gb: Ignored, maintained for compatibility
             batch_size: Ignored, maintained for compatibility
             progress_callback: Optional callback for progress updates
-            region: Region number to process for multi-region datasets.
+            region: Region selector for multi-region datasets.
                 None (default): convert all regions (no filtering).
-                int: explicitly select that region number only.
+                int: select that DB RegionNumber (0-indexed).
+                str: select by FlexImaging .mis Area Name (e.g. "03"); falls back
+                to integer parse if the string doesn't match any area name.
             **kwargs: Additional arguments
         """
         super().__init__(data_path, **kwargs)
@@ -237,14 +239,16 @@ class BrukerReader(BrukerBaseMSIReader):
         self._initialize_sdk()
         self._initialize_database()
 
+        # Optical alignment data (parsed from .mis file + database).
+        # Loaded BEFORE _select_region so Area-Name -> RegionNumber resolution
+        # and startup logging have access to the area list.
+        self._mis_metadata: Dict[str, Any] = self._parse_mis_alignment()
+
         # Region detection and selection (must be after database init)
         self._region_info: List[Tuple[int, int]] = self._detect_regions()
         self._selected_region: Optional[int]
         self._region_frame_ids: Optional[set]
         self._selected_region, self._region_frame_ids = self._select_region()
-
-        # Optical alignment data (parsed from .mis file + database)
-        self._mis_metadata: Dict[str, Any] = self._parse_mis_alignment()
         self._positions: List[Dict[str, Any]] = self._build_positions_from_db()
         self._header: Dict[str, Any] = self._build_header_alignment()
 
@@ -533,6 +537,72 @@ class BrukerReader(BrukerBaseMSIReader):
         except sqlite3.OperationalError:
             return []
 
+    def _get_region_name_map(self) -> Dict[int, str]:
+        """Build a mapping from DB RegionNumber to .mis Area Name.
+
+        FlexImaging assigns ``MaldiFrameInfo.RegionNumber`` in the same order
+        the areas appear in the ``.mis`` document, so the mapping is purely
+        positional: the i-th area in the .mis file corresponds to
+        RegionNumber i.
+        """
+        areas = self._mis_metadata.get("areas") if self._mis_metadata else None
+        if not areas:
+            return {}
+        return {i: str(area.get("name", "")) for i, area in enumerate(areas)}
+
+    def _log_region_mapping(self) -> None:
+        """Log the DB RegionNumber to .mis Area Name mapping at startup.
+
+        Surfaces the (often confusing) fact that ``--region <N>`` selects by
+        DB index, not by the human-readable area label. Logged once per init.
+        """
+        if not self._region_info or len(self._region_info) <= 1:
+            return
+        name_map = self._get_region_name_map()
+        if not name_map:
+            return
+        lines = ["Region mapping (DB RegionNumber -> .mis Area Name):"]
+        for region_num, n_frames in self._region_info:
+            name = name_map.get(region_num, "?")
+            lines.append(
+                f"  RegionNumber {region_num} -> Area '{name}' ({n_frames:,} frames)"
+            )
+        logger.info("\n".join(lines))
+
+    def _resolve_requested_region(self) -> Optional[int]:
+        """Resolve ``self._requested_region`` to a DB RegionNumber int.
+
+        Accepts either an int (used as RegionNumber directly) or a string. A
+        string is first matched against ``.mis`` Area Names; if no name
+        matches it is parsed as an int.
+        """
+        if self._requested_region is None:
+            return None
+        if isinstance(self._requested_region, int):
+            return self._requested_region
+
+        request_str = str(self._requested_region)
+        name_map = self._get_region_name_map()
+        # Reverse map: name -> region_number (last writer wins; .mis names
+        # are conventionally unique).
+        name_to_num = {name: num for num, name in name_map.items() if name}
+        if request_str in name_to_num:
+            resolved = name_to_num[request_str]
+            logger.info(
+                f"Resolved --region '{request_str}' (Area Name) to "
+                f"RegionNumber {resolved}"
+            )
+            return resolved
+        try:
+            return int(request_str)
+        except ValueError:
+            available = ", ".join(sorted(name_to_num)) or "(none)"
+            raise ValueError(
+                f"--region '{request_str}' is not a recognised .mis Area "
+                f"Name and is not a valid integer. Available area names: "
+                f"{available}"
+            )
+
     def _select_region(self) -> Tuple[Optional[int], Optional[set]]:
         """Select region based on user request or convert all regions.
 
@@ -543,6 +613,10 @@ class BrukerReader(BrukerBaseMSIReader):
             Tuple of (selected_region_number, set_of_frame_ids).
             Both are None when no filtering is needed (default: all regions).
         """
+        # Always log the DB-number/name mapping for multi-region datasets so
+        # users can correlate the log with their .mis labels (#89).
+        self._log_region_mapping()
+
         if not self._region_info or len(self._region_info) <= 1:
             return (None, None)
 
@@ -550,27 +624,27 @@ class BrukerReader(BrukerBaseMSIReader):
         valid_regions = [r for r, _ in self._region_info]
         total_spectra = sum(n for _, n in self._region_info)
 
-        if self._requested_region is not None:
+        resolved = self._resolve_requested_region()
+        if resolved is not None:
             # User explicitly requested a specific region
-            if self._requested_region not in valid_regions:
+            if resolved not in valid_regions:
                 raise ValueError(
-                    f"Region {self._requested_region} not found. "
+                    f"Region {resolved} not found. "
                     f"Available regions: {valid_regions}"
                 )
-            selected = self._requested_region
 
             # Get frame IDs for selected region
             cursor = self.conn.cursor()
             cursor.execute(
                 "SELECT Frame FROM MaldiFrameInfo WHERE RegionNumber = ?",
-                (selected,),
+                (resolved,),
             )
             frame_ids = {int(row[0]) for row in cursor.fetchall()}
             logger.info(
-                f"Region {selected}: {len(frame_ids):,} frames selected "
+                f"Region {resolved}: {len(frame_ids):,} frames selected "
                 f"(use region=None to convert all regions)"
             )
-            return (selected, frame_ids)
+            return (resolved, frame_ids)
 
         # Default: convert all regions, no filtering
         logger.info(


### PR DESCRIPTION
Fixes a cluster of Bruker-specific bugs surfaced while converting a real multi-region MALDI dataset for a Xenium co-registration workflow. Each fix is its own commit so they can be reviewed independently.

## Summary

- **#91** (Waters): cast `function_types` dict keys to `str` so the zarr metadata write doesn't crash on non-string enum/int keys.
- **#87** (Streaming): drop the hardcoded 10,000-bin fallback in `_estimate_output_size_gb`. Resolve the real bin count via the same path the axis builder uses, so the PCS-vs-standard gate at `PCS_SIZE_THRESHOLD_GB` sees correct numbers.
- **#90** (Pixel size): prefer `.mis <Raster>` over `MaldiFrameLaserInfo.BeamScanSizeX/Y`. BeamScanSize is the laser scan area, not the raster step, so oversampled acquisitions silently got a 2x-too-large pixel size — breaking spatial coordinates, image transforms, pixel polygons, and downstream optical/Xenium co-registration.
- **#89** (Region selection): accept `.mis` Area Names (e.g. `--region 03`) in addition to DB `RegionNumber`. FlexImaging assigns `RegionNumber` in creation order, which has no relationship to the area labels users see; previously `--region 3` silently picked a different tissue than expected. Always log the DB-number-to-Area-Name mapping at startup so the mismatch is visible even when not selecting.
- **#88** (Empty pixels): drop obs rows where the intensity matrix row has no non-zero values. Polygon-shaped acquisitions leave bbox-corner positions unsampled (~25-30% of obs for a single tissue, ~70%+ for multi-region all-regions). Add `BaseSpatialDataConverter._drop_empty_pixels()` and call it right after each `AnnData(...)` construction in the streaming, 2D, and 3D converters. TIC and ion-image rendering are unchanged; obs and shapes are now consistent.

## Closes

Closes #87
Closes #88
Closes #89
Closes #90
Closes #91

## Test plan

- [x] Added regression test for #87 (size estimator with width-based config — would have returned 10k pre-fix, now returns ~180k).
- [x] Added unit tests for the new `.mis` parser helper (`find_mis_file_for_d_folder`, raster extraction).
- [x] Added Bruker extractor tests covering Raster-preferred-over-BeamScanSize and BeamScanSize fallback when no .mis is present.
- [x] Added 9 unit tests for the new region-name resolution and mapping log (#89).
- [x] Added 2 unit tests for `_drop_empty_pixels` (filtering and no-op-when-full).
- [x] Test-isolation fix for the region mapping log assertion — handler attached directly to the module logger to bypass caplog/propagation quirks across the CI matrix.
- [x] Full unit suite green: `357 passed, 1 skipped, 17 deselected` locally.
- [ ] Reviewer to confirm CI is green.

## Notes

- The CLI signature change for `--region` (now `str` instead of `int`) is backwards-compatible — strings that don't match an Area Name fall back to integer parse.
- `_resolve_resampling_plan` is now the single source of truth for `(min_mz, max_mz, axis_type, target_bins)` shared between the axis builder and size estimator.
- `_drop_empty_pixels` is conservative: returns the AnnData unchanged when every row already has data, so there is no overhead for fully-rectangular acquisitions.
- After the empty-pixel drop, `obs` and `shapes` indices are consistent (shapes were already filtered to acquired positions; obs is now the same).