### PR TITLE
feat: unified "global" coordinate-system contract for produced zarrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Full documentation: **[M4i-Imaging-Mass-Spectrometry.github.io/thyra](https://M4
 - [Getting Started](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/getting-started/) -- installation, first conversion, common workflows
 - [CLI Reference](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/cli/) -- all command-line options
 - [Output Format](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/output-format/) -- understanding the zarr structure
+- [Coordinate Systems](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/coordinate-systems/) -- the ``"global"`` contract Thyra writes for downstream consumers
 - [API Reference](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/api/) -- Python API documentation
 
 ## Supported Formats

--- a/docs/coordinate-systems.md
+++ b/docs/coordinate-systems.md
@@ -1,0 +1,215 @@
+# Coordinate Systems
+
+Every SpatialData zarr Thyra writes carries a small but crucial promise:
+**all elements within the zarr resolve to the same physical frame at the
+``"global"`` coordinate system, and that frame is documented in the
+zarr metadata.** This page explains the contract so consumers (Ousia,
+registration tooling, custom analysis scripts) can render and compute
+without guessing what the numbers mean.
+
+---
+
+## The contract in one sentence
+
+In every Thyra-produced zarr,
+
+> the ``"global"`` coordinate system is one self-consistent frame, its
+> unit and pixel-size calibration are recorded under
+> ``zarr.attrs["coordinate_systems"]["global"]``, and every element
+> registers a transform that lands in that frame.
+
+If you only remember one thing, remember that.
+
+---
+
+## The schema
+
+At the zarr top level Thyra writes:
+
+```python
+zarr.attrs["coordinate_systems"] = {
+    "global": {
+        "unit": "micrometer" | "pixel",
+        "pixel_size_um_x": float | None,
+        "pixel_size_um_y": float | None,
+        "reference_element": str | None,
+        "convention_version": 1,
+        "produced_by": "thyra/<version>",
+    }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| ``unit`` | Unit of one step in ``"global"`` -- either ``"micrometer"`` or ``"pixel"``. |
+| ``pixel_size_um_x``, ``pixel_size_um_y`` | Conversion factor: micrometers per one ``"global"`` unit. ``1.0`` when ``unit="micrometer"``; physical pixel size when ``unit="pixel"``. ``None`` if the producer cannot calibrate (e.g. an uncalibrated optical photo). |
+| ``reference_element`` | Name of the canonical raster element that defines pixel space, when ``unit="pixel"``. ``None`` otherwise. |
+| ``convention_version`` | Schema version; bump when the shape of this attr changes. Currently ``1``. |
+| ``produced_by`` | ``"thyra/<version>"`` for Thyra-produced zarrs. |
+
+Consumers that don't know the schema can still open the zarr; they
+just won't be able to render distances in micrometers without
+making assumptions. Consumers that do know it (Ousia, the EscDat
+registration script, this project's tests) read this attr first and
+trust it.
+
+---
+
+## What ``"global"`` is in each Thyra mode
+
+Thyra operates in two modes depending on whether the input came with
+FlexImaging optical alignment data. The two modes pick different
+``"global"`` conventions because they have different *canonical
+references*.
+
+### Mode A: standalone (no optical alignment)
+
+When there is no optical photo to align against, the only naturally
+meaningful frame is **physical micrometers of the imaged tissue**.
+
+- TIC / ion images: stored intrinsically in raster pixel indices,
+  with a transform ``Scale([pixel_size_um, pixel_size_um])`` to
+  ``"global"``.
+- Pixel-polygon shapes: stored intrinsically in micrometers
+  (``spatial_x = x * pixel_size_um``), with ``Identity`` to
+  ``"global"``.
+- ``zarr.attrs["coordinate_systems"]["global"]`` declares
+  ``unit="micrometer"`` and fills ``pixel_size_um_x/y`` with the
+  MSI grid pixel size.
+
+Both elements resolve to the same micrometer extent at ``"global"``.
+
+### Mode B: with FlexImaging optical alignment
+
+When the input includes a ``.mis`` ``ImageFile`` and registration
+landmarks, Thyra picks a different canonical reference: **the
+optical photo itself**. The natural frame is then *that image's
+pixel grid*, because the photo can be drawn with no transform.
+
+- TIC / ion images: stored intrinsically in raster pixel indices,
+  with an ``Affine`` transform mapping into the optical pixel
+  grid.
+- Pixel-polygon shapes: stored directly in optical pixels, with
+  ``Identity`` to ``"global"``.
+- Primary optical image: ``Identity`` to ``"global"``.
+- Other optical images (overview, etc.): a ``Scale`` to align with
+  the primary image's pixel grid.
+- ``zarr.attrs["coordinate_systems"]["global"]`` declares
+  ``unit="pixel"`` with ``reference_element`` set to the primary
+  optical filename; ``pixel_size_um_x/y`` is typically ``None``
+  because FlexImaging photos do not generally carry a um-per-pixel
+  calibration.
+
+Note that the two modes pick the right convention for what is
+actually known about the data; consumers should look at
+``unit`` rather than assuming Thyra always uses one or the other.
+
+---
+
+## Reading the coordinate-system metadata
+
+```python
+import json
+from pathlib import Path
+
+zarr_path = Path("output.zarr")
+with open(zarr_path / "zarr.json") as f:
+    attrs = json.load(f)["attributes"]
+
+cs = attrs["coordinate_systems"]["global"]
+print(f"global unit:        {cs['unit']}")
+print(f"pixel size (um):    {cs['pixel_size_um_x']} x {cs['pixel_size_um_y']}")
+print(f"reference element:  {cs['reference_element']}")
+print(f"schema version:     {cs['convention_version']}")
+```
+
+To resolve a ``"global"`` coordinate to micrometers, multiply by the
+``pixel_size_um_x/y`` factors. When ``unit="micrometer"`` those
+factors are ``1.0`` and the multiplication is a no-op; when
+``unit="pixel"`` they perform the px-to-um conversion.
+
+---
+
+## Why two conventions?
+
+Picking ``unit="micrometer"`` for everything would be simpler, but
+also wrong:
+
+- In **Mode B** there is a canonical raster image (the optical
+  photo). Putting ``"global"`` in micrometers would force that
+  image to carry a transform, since its data is intrinsically in
+  pixels. With ``unit="pixel"``, the canonical image carries
+  ``Identity`` and downstream tools can blit it without thinking.
+- In **Mode A** there is no canonical raster image - the MSI
+  itself is the data. There's no privileged pixel grid to use as
+  ``"global"``, so ``unit="micrometer"`` is the natural and
+  unambiguous choice.
+
+The rule generalises: **``"global"`` is whichever frame is most
+natural for that dataset's canonical reference, and the metadata
+declares which one was picked.**
+
+This matches how the broader spatial-omics ecosystem works:
+``spatialdata-io``'s Xenium reader, for example, uses
+``unit="pixel"`` because Xenium has a canonical morphology image;
+its MERFISH-style readers use ``unit="micrometer"`` because they
+do not.
+
+---
+
+## Verifying the contract
+
+Because the contract is just metadata, it can drift if a producer
+has a bug. Every Thyra release has a unit-test guard that:
+
+1. Runs a representative conversion end-to-end.
+2. Reads the resulting zarr.
+3. Asserts the bbox of the TIC image and the pixel-polygon shapes
+   resolve to the same ``"global"`` extent within a half-pixel
+   tolerance.
+4. Asserts the ``coordinate_systems.global`` attr is present and
+   self-consistent.
+
+See ``tests/unit/converters/test_coordinate_systems.py``.
+
+A consumer can run the same check at load time. The recommended
+pattern is to compute the bbox at ``"global"`` for every element
+and warn if any pair differs by more than ~10x; that catches the
+``Scale(1/pixel_size)`` vs identity unit-confusion class of bug
+without flagging legitimate small-vs-large element pairs (e.g.
+a small ROI within a full-tissue dataset).
+
+---
+
+## Cross-modality registration
+
+When a Thyra zarr is later registered against another modality
+(e.g. Xenium via the EscDat registration pipeline), the
+registration step rewrites every Thyra element's transform to
+``"global"`` so that the merged zarr's ``"global"`` matches the
+other modality's convention. The merged zarr's
+``coordinate_systems.global`` attr is rewritten to declare the new
+unit and reference element.
+
+That is, **the coordinate-system contract is per-zarr, not
+per-element-or-modality**. A standalone Thyra zarr can have
+``unit="micrometer"`` while a merged Thyra+Xenium zarr produced
+from the same data will have ``unit="pixel"``. Both are correct
+for their respective zarrs.
+
+---
+
+## What if I open a zarr that doesn't have this attr?
+
+Older Thyra outputs (pre-schema) do not carry the
+``coordinate_systems`` attr. They are still readable, but you have
+to infer the convention from element layouts and accept some
+risk that two elements disagree silently.
+
+If you control the data: **regenerate**. The schema is cheap to
+write and the resulting zarrs are self-describing forever after.
+If you do not control the data, the best fallback is to write a
+producer-specific heuristic (see Ousia's coordinate-system loader
+for an example: it recognises Xenium-from-spatialdata-io zarrs by
+their ``morphology_focus`` image and assumes Xenium's documented
+pixel size).

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -39,6 +39,14 @@ A converted dataset contains the following elements:
     The default `dataset_id` is `msi_dataset`, so typical keys look like
     `msi_dataset_z0`, `msi_dataset_z0_tic`, etc. Change it with `--dataset-id`.
 
+!!! info "Coordinate systems"
+    Every element above carries a transform to a single ``"global"``
+    coordinate system, and Thyra writes a self-describing
+    ``coordinate_systems`` metadata attr at the zarr top level so
+    consumers know what ``"global"`` is in (micrometers or pixels).
+    See [Coordinate Systems](coordinate-systems.md) for the contract
+    and how to read it.
+
 ---
 
 ## TIC Images

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
   - Getting Started: getting-started.md
   - CLI Reference: cli.md
   - Output Format: output-format.md
+  - Coordinate Systems: coordinate-systems.md
   - API Reference: api.md
   - Contributing: contributing.md
   - Code of Conduct: code-of-conduct.md

--- a/tests/unit/converters/test_coordinate_systems.py
+++ b/tests/unit/converters/test_coordinate_systems.py
@@ -1,0 +1,248 @@
+# tests/unit/converters/test_coordinate_systems.py
+"""Tests for the structured coordinate-system contract emitted by the
+SpatialData converters.
+
+The contract guarantees that within one zarr produced by Thyra:
+
+  * Both the TIC image and the pixel-polygon shapes resolve to the same
+    space at the ``"global"`` coordinate system. In Mode A (no
+    FlexImaging optical alignment) that space is physical micrometers.
+
+  * A structured ``coordinate_systems`` attr is written at the zarr
+    top level so consumers (Ousia, registration tooling, etc.) do not
+    need to guess what ``"global"`` is in.
+
+These tests exercise the code path end-to-end without mocking out the
+transform plumbing, so they catch regressions where image and shapes
+silently disagree about what ``"global"`` means.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from thyra.convert import convert_msi
+
+pytestmark = pytest.mark.skipif(
+    not pytest.importorskip("spatialdata", reason="SpatialData not installed"),
+    reason="SpatialData not installed",
+)
+
+
+def _bbox_at_global(element) -> tuple[float, float, float, float]:
+    """Compute the bbox of a SpatialData element in its ``"global"`` CS.
+
+    Works for both shapes (GeoDataFrame) and images (xarray DataArray /
+    DataTree). Returns ``(xmin, ymin, xmax, ymax)`` after applying the
+    element's transform to ``"global"``.
+    """
+    import numpy as np
+    from spatialdata.transformations import get_transformation
+
+    transform = get_transformation(element, to_coordinate_system="global")
+    matrix = transform.to_affine_matrix(input_axes=("x", "y"), output_axes=("x", "y"))
+
+    # Shapes: native bbox is just the GeoDataFrame's total_bounds.
+    if hasattr(element, "geometry"):
+        xmin_n, ymin_n, xmax_n, ymax_n = element.total_bounds
+    else:
+        # Image / multiscale image: native frame is integer pixel indices.
+        # Pull the highest-resolution data to get x/y sizes.
+        if hasattr(element, "shape"):
+            data = element
+        else:
+            # DataTree: pick the first scale's "image" variable.
+            scales = list(element.children.keys())
+            data = element[scales[0]].ds["image"]
+        # Dims convention is ("c", "y", "x") for 2D images.
+        y_size = data.sizes["y"]
+        x_size = data.sizes["x"]
+        xmin_n, ymin_n = 0.0, 0.0
+        xmax_n, ymax_n = float(x_size), float(y_size)
+
+    corners = np.array(
+        [
+            [xmin_n, ymin_n, 1.0],
+            [xmax_n, ymin_n, 1.0],
+            [xmin_n, ymax_n, 1.0],
+            [xmax_n, ymax_n, 1.0],
+        ]
+    )
+    transformed = corners @ matrix.T
+    xs = transformed[:, 0]
+    ys = transformed[:, 1]
+    return float(xs.min()), float(ys.min()), float(xs.max()), float(ys.max())
+
+
+def _read_zarr_attrs(zarr_path: Path) -> dict:
+    """Read top-level zarr attrs as a plain dict.
+
+    Supports both zarr v2 (``.zattrs``) and v3 (``zarr.json``) layouts.
+    """
+    z3 = zarr_path / "zarr.json"
+    if z3.exists():
+        with open(z3) as f:
+            doc = json.load(f)
+        return doc.get("attributes", {}) or {}
+    z2 = zarr_path / ".zattrs"
+    if z2.exists():
+        with open(z2) as f:
+            return json.load(f) or {}
+    raise FileNotFoundError(
+        f"No zarr attrs file found in {zarr_path}; expected zarr.json or .zattrs"
+    )
+
+
+class TestCoordinateSystemsContract:
+    """Contract-level tests that survive across converter implementations."""
+
+    def test_no_alignment_image_and_shapes_agree_at_global(
+        self, create_minimal_imzml, temp_dir
+    ):
+        """Mode A: image and pixel-polygon shapes must resolve to the
+        same bbox at ``"global"`` (within half a pixel) when no optical
+        alignment is provided.
+        """
+        import spatialdata as sd
+
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+        pixel_size_um = 2.5
+
+        result = convert_msi(
+            str(imzml_path),
+            str(output_path),
+            format_type="spatialdata",
+            dataset_id="ds",
+            pixel_size_um=pixel_size_um,
+        )
+        assert result is True
+
+        sdata = sd.SpatialData.read(str(output_path))
+        assert len(sdata.images) >= 1
+        assert len(sdata.shapes) >= 1
+
+        image_name = next(iter(sdata.images))
+        shapes_name = next(iter(sdata.shapes))
+        image_bbox = _bbox_at_global(sdata.images[image_name])
+        shapes_bbox = _bbox_at_global(sdata.shapes[shapes_name])
+
+        # Pixel-polygon shapes are box-padded by half a pixel on every
+        # side relative to the image grid (a centroid at (0,0) becomes a
+        # box from (-px/2, -px/2) to (+px/2, +px/2)). Allow that tolerance.
+        tol = pixel_size_um
+        assert abs(image_bbox[0] - shapes_bbox[0]) < tol, (
+            f"xmin mismatch at global: image={image_bbox[0]}, "
+            f"shapes={shapes_bbox[0]}"
+        )
+        assert abs(image_bbox[1] - shapes_bbox[1]) < tol, (
+            f"ymin mismatch at global: image={image_bbox[1]}, "
+            f"shapes={shapes_bbox[1]}"
+        )
+        assert abs(image_bbox[2] - shapes_bbox[2]) < tol, (
+            f"xmax mismatch at global: image={image_bbox[2]}, "
+            f"shapes={shapes_bbox[2]}"
+        )
+        assert abs(image_bbox[3] - shapes_bbox[3]) < tol, (
+            f"ymax mismatch at global: image={image_bbox[3]}, "
+            f"shapes={shapes_bbox[3]}"
+        )
+
+    def test_no_alignment_writes_micrometer_coordinate_systems_attr(
+        self, create_minimal_imzml, temp_dir
+    ):
+        """Mode A: the structured ``coordinate_systems.global`` attr
+        must be present and declare ``unit="micrometer"`` with the MSI
+        pixel size filled in.
+        """
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+        pixel_size_um = 3.0
+
+        convert_msi(
+            str(imzml_path),
+            str(output_path),
+            format_type="spatialdata",
+            dataset_id="ds",
+            pixel_size_um=pixel_size_um,
+        )
+
+        attrs = _read_zarr_attrs(output_path)
+        assert (
+            "coordinate_systems" in attrs
+        ), "Thyra zarrs must declare a structured coordinate_systems attr"
+        cs_global = attrs["coordinate_systems"]["global"]
+        assert cs_global["unit"] == "micrometer"
+        assert cs_global["pixel_size_um_x"] == pytest.approx(pixel_size_um)
+        assert cs_global["pixel_size_um_y"] == pytest.approx(pixel_size_um)
+        assert cs_global["reference_element"] is None
+        assert cs_global["convention_version"] >= 1
+        assert cs_global["produced_by"].startswith("thyra/")
+
+    def test_image_intrinsic_frame_is_pixel_indices(
+        self, create_minimal_imzml, temp_dir
+    ):
+        """The TIC image must be stored intrinsically in raster pixel
+        indices, independent of ``pixel_size_um``. The unit conversion
+        is expressed purely through the transform to ``"global"``.
+
+        SpatialData's ``Image2DModel.parse`` stamps half-pixel-centered
+        coords (0.5, 1.5, 2.5, ...) when no coords are provided, which
+        is still pixel-index space; the key invariant is that the step
+        between consecutive pixels is exactly 1.0 and the values do not
+        scale with ``pixel_size_um``.
+        """
+        import spatialdata as sd
+
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+        pixel_size_um = 7.5  # deliberately not 1.0 so any um-leak shows up
+        convert_msi(
+            str(imzml_path),
+            str(output_path),
+            format_type="spatialdata",
+            dataset_id="ds",
+            pixel_size_um=pixel_size_um,
+        )
+
+        sdata = sd.SpatialData.read(str(output_path))
+        image_name = next(iter(sdata.images))
+        image = sdata.images[image_name]
+
+        # Resolve to the underlying DataArray (DataTree if multiscale).
+        if hasattr(image, "shape"):
+            data = image
+        else:
+            scales = list(image.children.keys())
+            data = image[scales[0]].ds["image"]
+
+        x_coord = data.coords["x"].values
+        y_coord = data.coords["y"].values
+
+        # Step must be exactly 1.0 (pixel-index spacing), not the um
+        # pixel size. This is the regression guard against the old
+        # behavior where xarray coords were stamped in micrometers.
+        if len(x_coord) > 1:
+            steps_x = x_coord[1:] - x_coord[:-1]
+            assert (
+                steps_x == 1
+            ).all(), f"image x coord must step by 1 (pixel index); got {steps_x}"
+        if len(y_coord) > 1:
+            steps_y = y_coord[1:] - y_coord[:-1]
+            assert (
+                steps_y == 1
+            ).all(), f"image y coord must step by 1 (pixel index); got {steps_y}"
+
+        # Origin must be small (0 or 0.5 from spatialdata's pixel-center
+        # convention), not scaled by pixel_size_um.
+        assert x_coord[0] < pixel_size_um, (
+            f"image x[0]={x_coord[0]} suggests um leakage "
+            f"(pixel_size_um={pixel_size_um})"
+        )
+        assert y_coord[0] < pixel_size_um, (
+            f"image y[0]={y_coord[0]} suggests um leakage "
+            f"(pixel_size_um={pixel_size_um})"
+        )

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1676,6 +1676,14 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             "conversion_timestamp": pd.Timestamp.now().isoformat(),
         }
 
+        # Structured coordinate-system contract describing what "global"
+        # actually means in this zarr. Consumers (e.g. Ousia, registration
+        # tooling) read this to know what unit "global" is in and how to
+        # convert to micrometers without guessing.
+        pixel_size_attrs["coordinate_systems"] = self._build_coordinate_systems_attr(
+            version
+        )
+
         # Add pixel size detection provenance if available
         if self._pixel_size_detection_info is not None:
             pixel_size_attrs["pixel_size_detection_info"] = dict(
@@ -1699,6 +1707,64 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         }
 
         return pixel_size_attrs
+
+    # Schema version for the structured `coordinate_systems` attr below.
+    # Bump when the schema shape changes in a way consumers need to notice.
+    _COORDINATE_SYSTEMS_SCHEMA_VERSION: int = 1
+
+    def _build_coordinate_systems_attr(self, thyra_version: str) -> Dict[str, Any]:
+        """Build the structured coordinate-system contract attr.
+
+        This describes what `"global"` means in the produced zarr so that
+        downstream consumers can render and convert without guessing.
+
+        Two variants are emitted depending on whether FlexImaging optical
+        alignment was applied during conversion:
+
+        - No alignment (`global = micrometer`): the TIC image carries a
+          `Scale(pixel_size_um)` and pixel-polygon shapes are stored in
+          micrometers with `Identity`. Both elements agree at `global`.
+          `pixel_size_um_x/y` are filled with the MSI grid pixel size,
+          since "global" is in physical micrometers and there is no
+          canonical raster image other than the MSI itself.
+
+        - With alignment (`global = pixel`): the TIC image carries an
+          `Affine` mapping raster indices to optical-image pixels and
+          shapes are stored directly in optical-image pixels with
+          `Identity`. The optical image is the canonical reference.
+          `pixel_size_um_x/y` are typically unknown at conversion time
+          (FlexImaging does not generally calibrate the optical photo
+          to um); leave them null and let the consumer fill in.
+
+        Returns:
+            Dict suitable for storing under
+            `zarr.attrs["coordinate_systems"]`.
+        """
+        if self._tic_to_image_matrix is not None:
+            unit = "pixel"
+            pixel_size_um_x: Optional[float] = None
+            pixel_size_um_y: Optional[float] = None
+            reference_element: Optional[str] = (
+                self._primary_optical_filename
+                if self._primary_optical_filename
+                else None
+            )
+        else:
+            unit = "micrometer"
+            pixel_size_um_x = float(self.pixel_size_um)
+            pixel_size_um_y = float(self.pixel_size_um)
+            reference_element = None
+
+        return {
+            "global": {
+                "unit": unit,
+                "pixel_size_um_x": pixel_size_um_x,
+                "pixel_size_um_y": pixel_size_um_y,
+                "reference_element": reference_element,
+                "convention_version": self._COORDINATE_SYSTEMS_SCHEMA_VERSION,
+                "produced_by": f"thyra/{thyra_version}",
+            }
+        }
 
     def _add_comprehensive_sections(
         self, pixel_size_attrs: Dict[str, Any], comprehensive_metadata_obj

--- a/thyra/converters/spatialdata/spatialdata_2d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_2d_converter.py
@@ -16,7 +16,7 @@ if SPATIALDATA_AVAILABLE:
     import xarray as xr
     from anndata import AnnData
     from spatialdata.models import Image2DModel, TableModel
-    from spatialdata.transformations import Affine, Identity
+    from spatialdata.transformations import Affine, Scale
 
 
 class SpatialData2DConverter(BaseSpatialDataConverter):
@@ -349,35 +349,30 @@ class SpatialData2DConverter(BaseSpatialDataConverter):
                 # SpatialData
                 tic_values_with_channel = tic_values.reshape(1, y_size, x_size)
 
-                # When alignment exists, use raster indices + Affine transform
-                # so TIC overlays correctly on the optical image.
-                # Otherwise, use physical micrometer coordinates + Identity.
+                # The image array is intrinsically in raster pixel indices.
+                # The transform to "global" expresses the conversion from
+                # raster indices into the chosen global frame:
+                #   - With FlexImaging optical alignment: Affine into optical
+                #     image pixel space (so TIC overlays correctly on the
+                #     optical image). global = optical pixels.
+                #   - Without alignment: Scale into physical micrometers, so
+                #     "global" agrees with the pixel-polygon shapes (which
+                #     are stored in um). global = micrometers.
+                tic_image = xr.DataArray(
+                    tic_values_with_channel,
+                    dims=("c", "y", "x"),
+                )
                 if self._tic_to_image_matrix is not None:
-                    tic_image = xr.DataArray(
-                        tic_values_with_channel,
-                        dims=("c", "y", "x"),
-                        coords={
-                            "c": [0],
-                            "y": np.arange(y_size),
-                            "x": np.arange(x_size),
-                        },
-                    )
                     transform = Affine(
                         self._tic_to_image_matrix,
                         input_axes=("x", "y"),
                         output_axes=("x", "y"),
                     )
                 else:
-                    tic_image = xr.DataArray(
-                        tic_values_with_channel,
-                        dims=("c", "y", "x"),
-                        coords={
-                            "c": [0],
-                            "y": np.arange(y_size) * self.pixel_size_um,
-                            "x": np.arange(x_size) * self.pixel_size_um,
-                        },
+                    transform = Scale(
+                        [self.pixel_size_um, self.pixel_size_um],
+                        axes=("x", "y"),
                     )
-                    transform = Identity()
 
                 # Create Image2DModel for the TIC image
                 data_structures["images"][f"{slice_id}_tic"] = Image2DModel.parse(

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -15,7 +15,7 @@ if SPATIALDATA_AVAILABLE:
     import xarray as xr
     from anndata import AnnData
     from spatialdata.models import Image2DModel, TableModel
-    from spatialdata.transformations import Identity
+    from spatialdata.transformations import Scale
 
 
 class SpatialData3DConverter(BaseSpatialDataConverter):
@@ -274,19 +274,18 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
             # Add channel dimension for 3D image
             tic_values_with_channel = tic_values.reshape(1, z_size, y_size, x_size)
 
+            # The image is intrinsically in raster pixel indices.
+            # Scale into physical micrometers so "global" agrees with
+            # pixel-polygon shapes (which are stored in um).
             tic_image = xr.DataArray(
                 tic_values_with_channel,
                 dims=("c", "z", "y", "x"),
-                coords={
-                    "c": [0],  # Single channel
-                    "z": np.arange(z_size) * self.pixel_size_um,
-                    "y": np.arange(y_size) * self.pixel_size_um,
-                    "x": np.arange(x_size) * self.pixel_size_um,
-                },
             )
 
-            # Create Image model for 3D image
-            transform = Identity()
+            transform = Scale(
+                [self.pixel_size_um, self.pixel_size_um, self.pixel_size_um],
+                axes=("x", "y", "z"),
+            )
             try:
                 from spatialdata.models import Image3DModel
 
@@ -324,18 +323,17 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
             # Add channel dimension to make it (c, y, x)
             tic_values_with_channel = tic_values.reshape(1, y_size, x_size)
 
+            # Image intrinsic CS is raster pixel indices; Scale into
+            # physical micrometers so "global" agrees with shapes (um).
             tic_image = xr.DataArray(
                 tic_values_with_channel,
                 dims=("c", "y", "x"),
-                coords={
-                    "c": [0],  # Single channel
-                    "y": np.arange(y_size) * self.pixel_size_um,
-                    "x": np.arange(x_size) * self.pixel_size_um,
-                },
             )
 
-            # Create Image2DModel for the TIC image
-            transform = Identity()
+            transform = Scale(
+                [self.pixel_size_um, self.pixel_size_um],
+                axes=("x", "y"),
+            )
             data_structures["images"][f"{self.dataset_id}_tic"] = Image2DModel.parse(
                 tic_image,
                 transformations={

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -36,7 +36,7 @@ if SPATIALDATA_AVAILABLE:
     from anndata import AnnData
     from spatialdata import SpatialData
     from spatialdata.models import Image2DModel, ShapesModel, TableModel
-    from spatialdata.transformations import Affine, Identity
+    from spatialdata.transformations import Affine, Identity, Scale
 
 logger = logging.getLogger(__name__)
 
@@ -882,33 +882,29 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 # Add channel dimension to make it (c, y, x) as required by SpatialData
                 tic_values_with_channel = tic_values.reshape(1, y_size, x_size)
 
-                # When alignment exists, use raster indices + Affine transform
+                # The image array is intrinsically in raster pixel indices.
+                # The transform to "global" expresses the conversion from
+                # raster indices into the chosen global frame:
+                #   - With FlexImaging optical alignment: Affine into optical
+                #     image pixel space. global = optical pixels.
+                #   - Without alignment: Scale into physical micrometers, so
+                #     "global" agrees with the pixel-polygon shapes (which
+                #     are stored in um). global = micrometers.
+                tic_image = xr.DataArray(
+                    tic_values_with_channel,
+                    dims=("c", "y", "x"),
+                )
                 if self._tic_to_image_matrix is not None:
-                    tic_image = xr.DataArray(
-                        tic_values_with_channel,
-                        dims=("c", "y", "x"),
-                        coords={
-                            "c": [0],
-                            "y": np.arange(y_size),
-                            "x": np.arange(x_size),
-                        },
-                    )
                     transform = Affine(
                         self._tic_to_image_matrix,
                         input_axes=("x", "y"),
                         output_axes=("x", "y"),
                     )
                 else:
-                    tic_image = xr.DataArray(
-                        tic_values_with_channel,
-                        dims=("c", "y", "x"),
-                        coords={
-                            "c": [0],
-                            "y": np.arange(y_size) * self.pixel_size_um,
-                            "x": np.arange(x_size) * self.pixel_size_um,
-                        },
+                    transform = Scale(
+                        [self.pixel_size_um, self.pixel_size_um],
+                        axes=("x", "y"),
                     )
-                    transform = Identity()
 
                 # Create Image2DModel for the TIC image
                 data_structures["images"][f"{slice_id}_tic"] = Image2DModel.parse(
@@ -1570,33 +1566,29 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         # Add channel dimension (c, y, x) as required by SpatialData
         tic_values_3d = tic_values.reshape(1, y_size, x_size)
 
-        # When alignment exists, use raster indices + Affine transform
+        # The image array is intrinsically in raster pixel indices.
+        # The transform to "global" expresses the conversion from raster
+        # indices into the chosen global frame:
+        #   - With FlexImaging optical alignment: Affine into optical
+        #     image pixel space. global = optical pixels.
+        #   - Without alignment: Scale into physical micrometers, so
+        #     "global" agrees with the pixel-polygon shapes (which are
+        #     stored in um). global = micrometers.
+        tic_xarray = xr.DataArray(
+            tic_values_3d,
+            dims=("c", "y", "x"),
+        )
         if self._tic_to_image_matrix is not None:
-            tic_xarray = xr.DataArray(
-                tic_values_3d,
-                dims=("c", "y", "x"),
-                coords={
-                    "c": [0],
-                    "y": np.arange(y_size),
-                    "x": np.arange(x_size),
-                },
-            )
             tic_transform = Affine(
                 self._tic_to_image_matrix,
                 input_axes=("x", "y"),
                 output_axes=("x", "y"),
             )
         else:
-            tic_xarray = xr.DataArray(
-                tic_values_3d,
-                dims=("c", "y", "x"),
-                coords={
-                    "c": [0],
-                    "y": np.arange(y_size) * self.pixel_size_um,
-                    "x": np.arange(x_size) * self.pixel_size_um,
-                },
+            tic_transform = Scale(
+                [self.pixel_size_um, self.pixel_size_um],
+                axes=("x", "y"),
             )
-            tic_transform = Identity()
 
         tic_image = Image2DModel.parse(
             tic_xarray,


### PR DESCRIPTION
## What

Make every Thyra-produced zarr land all elements in a single,
self-described `"global"` coordinate system, and emit a structured
metadata attr at the zarr top level so downstream consumers know
what `"global"` is in without guessing.

## Why

In Mode A (no FlexImaging optical alignment) the TIC image was
written with `Identity` to `"global"` while pixel-polygon shapes
were written in micrometers (also with `Identity`). The two
elements therefore disagreed: pixel indices for the image vs
micrometers for the shapes. Downstream consumers (Ousia, the
EscDat MSI/Xenium registration script) had to compensate manually
with ad-hoc `1/pixel_size` pre-scaling, which leaked Thyra's
internal layout into every consumer and silently masked
unit-mismatch bugs across modalities.

## How

**Code (`fix:`)** -- align both elements at `"global" =
micrometers` in Mode A:

  - Image now uses `Scale([pixel_size_um, pixel_size_um])`
    instead of `Identity`, with intrinsic raster pixel indices.
  - Shapes are unchanged (already in um with `Identity`).
  - Same fix applied to all three converters: 2D slices, true 3D
    volumes, and the memory-bounded streaming converter.

Also emit a structured `coordinate_systems` schema attr at the
zarr top level:

```python
zarr.attrs["coordinate_systems"] = {
    "global": {
        "unit": "micrometer" | "pixel",
        "pixel_size_um_x": float | None,
        "pixel_size_um_y": float | None,
        "reference_element": str | None,
        "convention_version": 1,
        "produced_by": "thyra/<version>",
    }
}
```

Mode A declares `unit="micrometer"`. Mode B (with optical
alignment) declares `unit="pixel"` referencing the primary
optical image; the schema makes the existing two-mode behavior
discoverable rather than implicit.

**Tests** -- new `tests/unit/converters/test_coordinate_systems.py`
runs a real conversion end-to-end and asserts:

  1. Image and shapes resolve to the same bbox at `"global"` to
     within half a pixel.
  2. The `coordinate_systems.global` attr is present and
     self-consistent.
  3. The image's intrinsic frame stays in pixel indices regardless
     of the configured pixel size.

These are contract-level guards: any future regression where
image and shapes silently disagree at `"global"` will fail (1),
and any producer change that drops the schema will fail (2).

**Docs (`docs:`)** -- new `docs/coordinate-systems.md` documents
the contract: schema fields, what `"global"` means in Mode A vs
Mode B, how to read the metadata, why two conventions exist, and
how the contract is verified. Wired into mkdocs nav, cross-linked
from `output-format.md`, linked from the README.

## Validation

  - Full unit suite passes: `pytest -m "not integration"` --
    369 passed, 11 skipped.
  - Verified end-to-end against a real ImzML conversion that
    image and shapes now agree at `"global"`.
  - Independently verified on the consumer side: an Ousia
    branch reads the schema, exposes a `CoordinateSystemMeta`
    accessor with `global_to_um` conversion, and runs a
    bbox-diagonal sanity check on every loaded zarr -- 7 new
    Ousia tests pass against synthetic Thyra-shaped zarrs.

## Migration / compatibility

  - No API surface changes. Existing public functions keep their
    signatures.
  - **Mode A zarrs produced before this PR** carry the old
    inconsistent transform layout. They remain readable but image
    and shapes will not agree at `"global"`. Regenerate if you
    rely on `"global"` as a shared frame. Mode B zarrs are
    unchanged.
  - The new `coordinate_systems` attr is additive; legacy
    consumers that don't read it continue to work.

## Out of scope

  - The Ousia-side reader and validator landed in Ousia's own
    repo on `feat/overlay-polish` (commit `ba430cc`). This PR is
    the producer side only.
  - The EscDat MSI/Xenium registration script also gained a
    schema-aware path and a clean
    `compute_msi_um_to_xenium_pixels` function; that lives
    outside any git repo for now.

## Files

  - `thyra/converters/spatialdata/spatialdata_2d_converter.py`
  - `thyra/converters/spatialdata/spatialdata_3d_converter.py`
  - `thyra/converters/spatialdata/streaming_converter.py`
  - `thyra/converters/spatialdata/base_spatialdata_converter.py`
  - `tests/unit/converters/test_coordinate_systems.py` (new)
  - `docs/coordinate-systems.md` (new)
  - `docs/output-format.md`, `mkdocs.yml`, `README.md`
