### PR TITLE
Centralize image chunk policy as the zarr v3 sharding seam (no-op foundation)

### DIFF
--- a/tests/unit/converters/test_chunking_policy.py
+++ b/tests/unit/converters/test_chunking_policy.py
@@ -1,0 +1,37 @@
+"""Foundation tests for the Thyra raster chunk/shard policy.
+
+Locks the current chunk tuples (so the future zarr v3 sharding wiring, gated on
+spatialdata PR #1106, cannot silently change output) and documents the
+cross-repo INNER_TILE_EDGE contract with Ousia's serving tile size.
+"""
+
+import pytest
+
+from thyra.converters.spatialdata._chunking import (
+    IMAGE_CHUNK_EDGE,
+    INNER_TILE_EDGE,
+    image_chunks,
+)
+
+
+def test_image_chunks_2d_reproduces_todays_literal():
+    # No-op-refactor lock: the helper must return exactly the (1, 4096, 4096)
+    # literal it replaced at base_spatialdata_converter.py's optical parse.
+    assert image_chunks(2) == (1, 4096, 4096)
+
+
+def test_image_chunks_3d_prepends_a_z_chunk():
+    assert image_chunks(3) == (1, 1, 4096, 4096)
+
+
+def test_image_chunks_rejects_other_ndim():
+    with pytest.raises(ValueError):
+        image_chunks(4)
+
+
+def test_inner_tile_edge_matches_ousia_serving_contract():
+    # Duplicated-by-contract with Ousia DEFAULT_TILE_SIZE = 512 (Thyra cannot
+    # import Ousia). If Ousia's serving tile changes, update this in lockstep.
+    assert INNER_TILE_EDGE == 512
+    # Outer chunk must tile exactly into inner tiles (no ragged remainder).
+    assert IMAGE_CHUNK_EDGE % INNER_TILE_EDGE == 0

--- a/thyra/converters/spatialdata/_chunking.py
+++ b/thyra/converters/spatialdata/_chunking.py
@@ -1,0 +1,41 @@
+"""Image chunk/shard policy for Thyra-written SpatialData rasters.
+
+Single source of truth for how Thyra chunks the raster images it writes to
+SpatialData zarr -- and the designated seam for tile-aligned zarr v3 sharding
+once scverse/spatialdata PR #1106 (``raster_write_kwargs``) lands.
+
+Cross-repo contract: the viewer (Ousia) morphology tile server streams
+``DEFAULT_TILE_SIZE`` (= 512) edge tiles. Once sharding lands, the zarr INNER
+chunk edge must equal that so one served tile == one decompress. Thyra is a
+separate package and CANNOT import Ousia, so the coupling is DUPLICATED BY
+CONTRACT here -- keep ``INNER_TILE_EDGE`` numerically in sync with Ousia's
+``DEFAULT_TILE_SIZE``; a silent divergence reintroduces cold-tile amplification
+on the viewer. See the Ousia ADR docs/ADR-pyramid-tile-sharding.md.
+"""
+
+from typing import Tuple
+
+# Outer chunk edge used TODAY (pre-sharding the chunk IS the outer block): a 4096
+# block means a viewer 512-tile read decompresses at most one chunk per request.
+IMAGE_CHUNK_EDGE = 4096
+
+# Future zarr INNER chunk edge once #1106 lands == Ousia DEFAULT_TILE_SIZE (512).
+# Duplicated by contract (Thyra cannot import Ousia).
+INNER_TILE_EDGE = 512
+
+
+def image_chunks(spatial_ndim: int, edge: int = IMAGE_CHUNK_EDGE) -> Tuple[int, ...]:
+    """The zarr chunk tuple for a Thyra-written raster image (leading channel axis).
+
+    ``spatial_ndim == 2`` (c, y, x) -> ``(1, edge, edge)``;
+    ``spatial_ndim == 3`` (c, z, y, x) -> ``(1, 1, edge, edge)``.
+
+    This is the ONE place the future inner=``INNER_TILE_EDGE`` + outer-shard policy
+    will live when spatialdata PR #1106 ships ``raster_write_kwargs``. Today it
+    returns the pre-sharding behaviour, byte-for-byte.
+    """
+    if spatial_ndim == 2:
+        return (1, edge, edge)
+    if spatial_ndim == 3:
+        return (1, 1, edge, edge)
+    raise ValueError(f"spatial_ndim must be 2 or 3, got {spatial_ndim}")

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -18,6 +18,7 @@ from ...core.base_reader import BaseMSIReader
 from ...metadata.types import ComprehensiveMetadata, EssentialMetadata
 from ...resampling import ResamplingDecisionTree, ResamplingMethod
 from ...resampling.types import ResamplingConfig
+from ._chunking import image_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -1712,7 +1713,9 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                     self.dataset_id: transform,
                     "global": transform,
                 },
-                "chunks": (1, 4096, 4096),
+                "chunks": image_chunks(
+                    2
+                ),  # (1, 4096, 4096); sharding seam, see _chunking
             }
             if scale_factors:
                 parse_kwargs["scale_factors"] = scale_factors


### PR DESCRIPTION
## What

Foundation for tile-aligned zarr v3 sharding, mirroring the Ousia-side `_raster_policy.py`. Gated on upstream scverse/spatialdata PR #1106 (`raster_write_kwargs`).

**No on-disk change.** Pure no-op refactor.

- New `thyra/converters/spatialdata/_chunking.py`: `IMAGE_CHUNK_EDGE=4096` (today's outer block), `INNER_TILE_EDGE=512` (== Ousia `DEFAULT_TILE_SIZE`, duplicated by contract since Thyra cannot import Ousia), and `image_chunks(spatial_ndim, edge)` — the single seam for the future inner + outer-shard policy.
- Routed the optical-image write in `base_spatialdata_converter.py` through `image_chunks(2)`. Same `(1, 4096, 4096)` tuple.
- `test_chunking_policy.py` (4 tests) locks the no-op tuples + the Ousia tile-size contract.

### Recorded for the gated sharding work (not fixed here)
- The streaming PCS optical loader (`streaming_converter.py:_add_optical_images_to_sdata`) writes optical rasters with no chunks/scale_factors — a pre-existing parity gap to close when `image_chunks()` is wired into every write site.
- The sparse-X array chunk literals (`1_000_000` / `100_000`) are NOT raster and stay a separate concern.

The actual sharding wiring waits for #1106 to merge.
