### PR TITLE
fix(deps): declare defusedxml as runtime dependency for Bruker reader

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1348,7 +1348,7 @@ version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
@@ -1863,6 +1863,7 @@ python-versions = ">=3.10"
 groups = ["docs"]
 files = [
     {file = "griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f"},
+    {file = "griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934"},
 ]
 
 [package.extras]
@@ -7123,4 +7124,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.14"
-content-hash = "b6ba200303573dc59611afa8ece4453869287cc5f9c4da05ef027d7ffcb98f65"
+content-hash = "5a56aabf1a612890145ff26ddab6e76f5918d563386db2f0ab919499b4a1a0ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ python = ">=3.11, <3.14"
 # is set transitively by whichever SpatialData version is installed
 # (0.7.3 wants <2026.1.2, main wants >=2026.3.0).
 dask = ">=2025.12.0"
+defusedxml = ">=0.7.1"  # Secure XML parsing for the Bruker Rapiflex reader
 geopandas = ">=0.9.0"
 lxml = ">=4.6.0"
 numpy = ">=2.0.0"

--- a/thyra/readers/bruker/rapiflex/rapiflex_reader.py
+++ b/thyra/readers/bruker/rapiflex/rapiflex_reader.py
@@ -24,7 +24,18 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional
 if TYPE_CHECKING:
     from xml.etree.ElementTree import Element  # nosec B405 - type hint only
 
-import defusedxml.ElementTree as ET
+try:
+    # Prefer defusedxml for secure parsing of instrument XML files.
+    import defusedxml.ElementTree as ET
+except ImportError:
+    # Fallback to the standard library so the reader still works when
+    # defusedxml is unavailable (mirrors imzml_extractor._get_xml_parser).
+    import xml.etree.ElementTree as ET  # nosec B405
+
+    logging.getLogger(__name__).warning(
+        "defusedxml not available, using xml.etree.ElementTree"
+    )
+
 import numpy as np
 from numpy.typing import NDArray
 from tqdm import tqdm
@@ -324,7 +335,9 @@ class RapiflexReader(BrukerBaseMSIReader):
         metadata: Dict[str, Any] = {}
 
         try:
-            tree = ET.parse(path)
+            tree = ET.parse(
+                path
+            )  # nosec B314 - defusedxml preferred; trusted local instrument file
             root = tree.getroot()
 
             self._extract_basic_elements(root, metadata)


### PR DESCRIPTION
## Problem

The Bruker Rapiflex reader does a top-level import of `defusedxml`:

```python
# thyra/readers/bruker/rapiflex/rapiflex_reader.py
import defusedxml.ElementTree as ET
```

But `defusedxml` was never declared as a runtime dependency. It only appeared in the mypy overrides and was pulled in transitively via the lock file. Any consumer that resolves Thyra from its declared metadata (e.g. an editable install in another project) never gets `defusedxml` installed and hits:

```
ModuleNotFoundError: No module named 'defusedxml'
```

when reading Bruker `.d` data through `convert_msi`. This surfaced downstream in Ousia (Tomatokeftes/Ousia#276).

## Fix

- Declare `defusedxml>=0.7.1` as a runtime dependency in `pyproject.toml` (and refresh `poetry.lock` accordingly: the package moves from the `dev` group to `main`+`dev`).
- Make the reader's import gracefully fall back to `xml.etree.ElementTree` with a warning when `defusedxml` is unavailable, mirroring the existing `imzml_extractor._get_xml_parser` pattern. The single `ET.parse` call on a trusted local instrument file is annotated `# nosec B314`.

## Verification

- `import thyra.readers.bruker.rapiflex.rapiflex_reader` resolves `ET` to `defusedxml.ElementTree`.
- `poetry lock` diff is minimal (defusedxml group change + content-hash).
- All 18 `tests/unit/readers/test_rapiflex_reader.py` tests pass.
- pre-commit (black, isort, flake8, mypy, bandit, pydocstyle) passes.
