### PR TITLE
fix(convert): make auto-streaming threshold RAM-aware

### DIFF
--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -1,0 +1,86 @@
+"""Tests for thyra.convert streaming auto-detection.
+
+The standard SpatialData converter pre-allocates the whole dataset's
+sparse matrix in memory, so ``convert_msi(streaming="auto")`` must switch
+to the streaming converter once the estimated footprint would claim too
+much RAM. These tests pin that decision and the RAM-aware budget.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from thyra import convert
+from thyra.convert import _should_use_streaming, _streaming_memory_budget_gb
+
+
+def _reader_with_pixels(n_pixels: int) -> SimpleNamespace:
+    """A stub reader exposing get_essential_metadata().dimensions."""
+    meta = SimpleNamespace(dimensions=(n_pixels, 1, 1))
+    return SimpleNamespace(get_essential_metadata=lambda: meta)
+
+
+class TestShouldUseStreaming:
+    def test_explicit_true_always_streams(self):
+        assert _should_use_streaming(True, _reader_with_pixels(1)) is True
+
+    def test_explicit_false_never_streams(self):
+        assert _should_use_streaming(False, _reader_with_pixels(10**9)) is False
+
+    def test_auto_small_dataset_stays_in_memory(self, monkeypatch):
+        monkeypatch.setattr(convert, "_streaming_memory_budget_gb", lambda: 4.0)
+        # 10k pixels -> ~0.07 GB estimated, below the 4 GB budget.
+        assert _should_use_streaming("auto", _reader_with_pixels(10_000)) is False
+
+    def test_auto_large_dataset_streams(self, monkeypatch):
+        monkeypatch.setattr(convert, "_streaming_memory_budget_gb", lambda: 4.0)
+        # 100k pixels -> ~7.5 GB estimated, above the 4 GB budget.
+        assert _should_use_streaming("auto", _reader_with_pixels(100_000)) is True
+
+    def test_auto_estimation_error_defaults_to_in_memory(self, monkeypatch):
+        monkeypatch.setattr(convert, "_streaming_memory_budget_gb", lambda: 4.0)
+
+        def boom():
+            raise RuntimeError("no metadata")
+
+        reader = SimpleNamespace(get_essential_metadata=boom)
+        # A metadata failure must not raise out of the decision helper.
+        assert _should_use_streaming("auto", reader) is False
+
+
+class TestStreamingMemoryBudget:
+    def test_env_override_caps_budget(self, monkeypatch):
+        import psutil
+
+        monkeypatch.setenv("THYRA_STREAMING_MAX_GB", "2")
+        monkeypatch.setattr(
+            psutil,
+            "virtual_memory",
+            lambda: SimpleNamespace(available=999 * 1024**3),
+        )
+        # Huge available RAM -> the 2 GB env cap wins the min().
+        assert _streaming_memory_budget_gb() == pytest.approx(2.0)
+
+    def test_ram_fraction_can_win(self, monkeypatch):
+        import psutil
+
+        monkeypatch.delenv("THYRA_STREAMING_MAX_GB", raising=False)
+        monkeypatch.setattr(
+            psutil,
+            "virtual_memory",
+            lambda: SimpleNamespace(available=4 * 1024**3),
+        )
+        # 0.5 * 4 GB = 2 GB < 4 GB cap -> the RAM fraction wins.
+        assert _streaming_memory_budget_gb() == pytest.approx(2.0)
+
+    def test_invalid_env_falls_back_to_cap(self, monkeypatch):
+        import psutil
+
+        monkeypatch.setenv("THYRA_STREAMING_MAX_GB", "not-a-number")
+        monkeypatch.setattr(
+            psutil,
+            "virtual_memory",
+            lambda: SimpleNamespace(available=999 * 1024**3),
+        )
+        # Bad override is ignored; the 4 GB default cap applies.
+        assert _streaming_memory_budget_gb() == pytest.approx(4.0)

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -1,5 +1,6 @@
 # thyra/convert.py
 import logging
+import os
 import traceback
 import warnings
 from pathlib import Path
@@ -145,6 +146,44 @@ def _determine_pixel_size(
     return final_pixel_size, PixelSizeSource.AUTO_DETECTED, pixel_size_detection_info
 
 
+# Auto-streaming budget. The standard converter pre-allocates the whole
+# dataset's sparse matrix up front, so once the estimated footprint would
+# claim a meaningful share of RAM we switch to the streaming converter
+# (which writes CSR straight to Zarr without holding the matrix in RAM).
+# Budget = min(absolute cap, fraction of *currently available* RAM): a
+# 16 GB laptop streams sooner than a 256 GB workstation, but neither lets
+# the in-memory build run away. The old fixed 10 GB threshold let multi-GB
+# mid-size datasets take the in-memory path on every machine.
+_STREAMING_ABS_CAP_GB = 4.0
+_STREAMING_RAM_FRACTION = 0.5
+
+
+def _streaming_memory_budget_gb() -> float:
+    """Footprint threshold (GB) above which auto-mode uses streaming.
+
+    ``min(_STREAMING_ABS_CAP_GB, _STREAMING_RAM_FRACTION * available_RAM)``.
+    Override the absolute cap with the ``THYRA_STREAMING_MAX_GB`` env var.
+    Falls back to the cap if psutil/RAM info is unavailable.
+    """
+    cap_gb = _STREAMING_ABS_CAP_GB
+    env = os.environ.get("THYRA_STREAMING_MAX_GB")
+    if env:
+        try:
+            cap_gb = float(env)
+        except ValueError:
+            logger.warning(
+                "Invalid THYRA_STREAMING_MAX_GB=%r; using %.1f GB", env, cap_gb
+            )
+    try:
+        import psutil
+
+        available_gb = float(psutil.virtual_memory().available) / (1024**3)
+        return min(cap_gb, _STREAMING_RAM_FRACTION * available_gb)
+    except Exception as e:  # pragma: no cover - psutil edge cases
+        logger.debug(f"Could not read RAM for streaming budget: {e}")
+        return cap_gb
+
+
 def _should_use_streaming(streaming: Union[bool, Literal["auto"]], reader: Any) -> bool:
     """Determine if streaming converter should be used."""
     if streaming is True:
@@ -152,17 +191,21 @@ def _should_use_streaming(streaming: Union[bool, Literal["auto"]], reader: Any) 
     if streaming != "auto":
         return False
 
-    # Auto-detect based on estimated dataset size (>10GB)
+    # Auto-detect: stream when the estimated in-memory footprint exceeds
+    # the RAM-aware budget (see _streaming_memory_budget_gb).
     try:
         essential_meta = reader.get_essential_metadata()
         dims = essential_meta.dimensions
         n_pixels = dims[0] * dims[1] * dims[2]
-        # Rough estimate: assume average 10k peaks per spectrum, 8 bytes each
+        # Conservative proxy for the standard converter's peak footprint:
+        # ~10k non-zeros/spectrum x 8 bytes. (Its COO arrays are ~2k
+        # peaks x 16 B/nnz plus a CSC copy, of the same order.)
         estimated_gb = (n_pixels * 10000 * 8) / (1024**3)
-        if estimated_gb > 10:
+        budget_gb = _streaming_memory_budget_gb()
+        if estimated_gb > budget_gb:
             logger.info(
-                f"Auto-detected large dataset (~{estimated_gb:.1f} GB), "
-                "using streaming converter"
+                f"Auto-detected large dataset (~{estimated_gb:.1f} GB est. "
+                f"peak > {budget_gb:.1f} GB budget), using streaming converter"
             )
             return True
     except Exception as e:


### PR DESCRIPTION
## Problem

`convert_msi(streaming="auto")` only switches to the memory-efficient streaming converter above a **fixed ~10 GB *dense* estimate** (`n_pixels * 10000 * 8`), i.e. ~134k pixels:

```python
estimated_gb = (n_pixels * 10000 * 8) / (1024**3)
if estimated_gb > 10: ...
```

Below that, it uses the standard `SpatialData2DConverter`, which pre-allocates the whole dataset's COO arrays up front (`_create_sparse_matrix_for_slice`: `n_pixels * 2000 peaks * 16 B/nnz * 1.1` ≈ 34 KB/pixel). So a mid-size dataset (several GB of in-memory matrix) takes the standard converter on **every** machine, regardless of how much RAM is actually free. Downstream (e.g. Ousia's import wizard converting many Bruker `.d` samples) this shows up as a multi-GB memory spike per sample.

## Fix

Replace the fixed 10 GB threshold with a **RAM-aware budget**:

```
budget = min(_STREAMING_ABS_CAP_GB, _STREAMING_RAM_FRACTION * available_RAM)
```

- Uses the `psutil` already declared as a dependency.
- Default cap **4 GB** (override via `THYRA_STREAMING_MAX_GB`), fraction **0.5**.
- A 16 GB laptop streams sooner than a 256 GB workstation, and neither lets the in-memory build claim most of RAM. Falls back to the absolute cap if psutil/RAM info is unavailable.
- The estimate formula is unchanged (a conservative proxy for the converter's real footprint); only the threshold became adaptive.

## Tests

New `tests/unit/test_convert.py`:
- explicit `streaming=True/False` short-circuits;
- `"auto"` small dataset stays in-memory, large dataset streams;
- estimation error defaults to in-memory (no raise);
- budget: env cap wins on big-RAM, RAM-fraction wins on small-RAM, invalid env override falls back to the cap.

8 passed. black / isort / flake8 / mypy / bandit / pydocstyle all clean (pre-commit).

## Context

Found while debugging an Ousia multi-sample import-wizard build (Bruker `.d` MSI) that spiked memory during `convert_msi`. The wizard now also passes `streaming=True` explicitly on its side; this PR makes the `"auto"` heuristic sane for all other Thyra callers too.