### PR TITLE
fix(streaming): write PCS images via spatialdata and fail loudly on error

### DIFF
--- a/tests/fixtures/mock_msi_generator.py
+++ b/tests/fixtures/mock_msi_generator.py
@@ -1,10 +1,14 @@
-"""Generate mock MSI data for testing streaming SpatialData conversion.
+"""Generate mock MSI data for testing SpatialData conversion.
 
-This script creates synthetic MSI-like data without needing real datasets,
-making it easy to test and iterate on memory-efficient conversion approaches.
+This module provides a synthetic MSI reader so the converters can be
+exercised end-to-end without real datasets.  ``MockMSIReader`` implements
+the full :class:`thyra.core.base_reader.BaseMSIReader` interface (including
+``get_region_map``/``get_region_info``/``reset``/``close`` and the metadata
+extractor contract), so it is a drop-in stand-in for a real reader.
 
-Usage:
-    poetry run python mock_msi_generator.py [--size small|medium|large|huge]
+Run as a script for a quick streaming-conversion smoke test:
+
+    poetry run python tests/fixtures/mock_msi_generator.py [--size small|medium|large|huge]
 
 Sizes:
     small  : 100x100 pixels, ~10k spectra (quick test, <1s)
@@ -15,7 +19,7 @@ Sizes:
 The mock data simulates processed MSI data with:
 - Sparse spectra (typical ~50-200 peaks per pixel)
 - Realistic m/z range (100-2000 Da)
-- Gaussian peak shapes with noise
+- Peaks placed exactly on the common mass axis so they map without loss
 """
 
 import sys
@@ -23,9 +27,14 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator, Optional, Tuple
+from typing import Generator, List, Optional, Tuple
 
 import numpy as np
+from numpy.typing import NDArray
+
+from thyra.core.base_extractor import MetadataExtractor
+from thyra.core.base_reader import BaseMSIReader
+from thyra.metadata.types import ComprehensiveMetadata, EssentialMetadata
 
 
 @dataclass
@@ -43,6 +52,7 @@ class MockMSIConfig:
     noise_level: float = 0.1
     sparsity: float = 0.0  # Fraction of empty pixels (0-1)
     seed: Optional[int] = 42
+    pixel_size_um: float = 10.0
 
 
 PRESETS = {
@@ -53,17 +63,69 @@ PRESETS = {
 }
 
 
-class MockMSIReader:
+class _MockMetadataExtractor(MetadataExtractor):
+    """Metadata extractor backed by a :class:`MockMSIConfig`."""
+
+    def __init__(self, config: MockMSIConfig, n_spectra: int):
+        super().__init__(data_source=None)
+        self._config = config
+        self._n_spectra = n_spectra
+
+    def _extract_essential_impl(self) -> EssentialMetadata:
+        cfg = self._config
+        n_pixels = cfg.n_x * cfg.n_y * cfg.n_z
+        avg_peaks = sum(cfg.peaks_per_spectrum) // 2
+        return EssentialMetadata(
+            dimensions=(cfg.n_x, cfg.n_y, cfg.n_z),
+            coordinate_bounds=(
+                0.0,
+                float(cfg.n_x - 1),
+                0.0,
+                float(cfg.n_y - 1),
+            ),
+            mass_range=(cfg.mz_min, cfg.mz_max),
+            pixel_size=(cfg.pixel_size_um, cfg.pixel_size_um),
+            n_spectra=self._n_spectra,
+            total_peaks=self._n_spectra * avg_peaks,
+            estimated_memory_gb=n_pixels * 150 * 8 / (1024**3),
+            source_path="mock_msi_data",
+            spectrum_type="processed",
+        )
+
+    def _extract_comprehensive_impl(self) -> ComprehensiveMetadata:
+        return ComprehensiveMetadata(
+            essential=self._extract_essential_impl(),
+            format_specific={"format": "mock"},
+            acquisition_params={},
+            instrument_info={"instrument": "mock"},
+            raw_metadata={"source": "mock"},
+        )
+
+
+class MockMSIReader(BaseMSIReader):
     """Mock MSI reader that generates synthetic data on-the-fly.
 
-    This reader mimics the interface of ImzMLReader but generates
-    random MSI-like data, useful for testing conversion pipelines
-    without needing real data files.
+    Implements the full :class:`BaseMSIReader` interface so it can be passed
+    directly to the converters.  Generated peaks sit exactly on the common
+    mass axis, so they survive nearest-neighbour mapping and produce a
+    non-empty table (mirroring continuous-then-binned real data).
     """
 
-    def __init__(self, config: MockMSIConfig):
-        """Initialize the mock MSI reader with the given configuration."""
+    def __init__(
+        self,
+        config: MockMSIConfig,
+        optical_image_paths: Optional[List[Path]] = None,
+    ):
+        """Initialize the mock MSI reader.
+
+        Args:
+            config: Mock data generation configuration.
+            optical_image_paths: Optional list of TIFF paths to expose via
+                ``get_optical_image_paths`` for testing optical handling.
+        """
+        super().__init__(data_path=Path("mock_msi_data"))
         self.config = config
+        self._seed = config.seed
         self._rng = np.random.default_rng(config.seed)
 
         # Build common mass axis
@@ -72,141 +134,127 @@ class MockMSIReader:
         )
 
         # Simulate some "real" peaks that appear in multiple spectra
-        # These are like biomarker peaks
+        # (like biomarker peaks).
         n_common_peaks = 20
         self._common_peak_indices = self._rng.choice(
             config.n_mz_bins, size=n_common_peaks, replace=False
         )
 
-        # Pre-generate which pixels are empty (for sparse datasets)
+        # Pre-generate which pixels are empty (for sparse datasets).
         self._n_pixels = config.n_x * config.n_y * config.n_z
-        self._empty_pixels = set()
+        self._empty_pixels: set = set()
         if config.sparsity > 0:
             n_empty = int(self._n_pixels * config.sparsity)
             self._empty_pixels = set(
-                self._rng.choice(self._n_pixels, size=n_empty, replace=False)
+                self._rng.choice(self._n_pixels, size=n_empty, replace=False).tolist()
             )
 
-        # Mock data path for compatibility
-        self.data_path = Path("mock_msi_data")
+        self._optical_image_paths: List[Path] = list(optical_image_paths or [])
 
-        # Mock has_shared_mass_axis for continuous mode detection
-        self.has_shared_mass_axis = False  # Mock data is processed mode
+    @property
+    def _n_spectra(self) -> int:
+        return self._n_pixels - len(self._empty_pixels)
 
-    def get_essential_metadata(self):
-        """Return metadata matching the EssentialMetadata interface."""
+    def _create_metadata_extractor(self) -> MetadataExtractor:
+        """Create the mock metadata extractor."""
+        return _MockMetadataExtractor(self.config, self._n_spectra)
 
-        class MockMetadata:
-            """Mock metadata object for testing."""
+    @property
+    def has_shared_mass_axis(self) -> bool:
+        """Mock data is processed mode (no shared m/z axis)."""
+        return False
 
-            dimensions: Tuple[int, int, int]
-            n_spectra: int
-            mass_range: Tuple[float, float]
-            spectrum_type: str
-            pixel_size: Tuple[float, float]
-            coordinate_bounds: dict
-            estimated_memory_gb: float
+    def get_common_mass_axis(self) -> NDArray[np.float64]:
+        """Return the common mass axis."""
+        return self._common_mass_axis
 
-        meta = MockMetadata()
-        meta.dimensions = (self.config.n_x, self.config.n_y, self.config.n_z)
-        meta.n_spectra = self._n_pixels - len(self._empty_pixels)
-        meta.mass_range = (self.config.mz_min, self.config.mz_max)
-        meta.spectrum_type = "processed"
-        meta.pixel_size = (10.0, 10.0)  # (x, y) pixel size in um
-        meta.coordinate_bounds = {
-            "x": (0, self.config.n_x - 1),
-            "y": (0, self.config.n_y - 1),
-            "z": (0, self.config.n_z - 1),
-        }
-        meta.estimated_memory_gb = (
-            self._n_pixels * 150 * 8 / (1024**3)
-        )  # rough estimate
-        return meta
+    def get_optical_image_paths(self) -> List[Path]:
+        """Return configured optical image paths (empty by default)."""
+        return list(self._optical_image_paths)
 
-    def scan_mass_range(self):
-        """Scan mass range - returns min/max m/z."""
-        return self.config.mz_min, self.config.mz_max
+    def get_peak_counts_per_pixel(self) -> Optional[NDArray[np.int32]]:
+        """Return None to exercise the two-pass counting fallback."""
+        return None
 
-    def iter_spectra(
-        self, batch_size: int = 1000
-    ) -> Iterator[Tuple[Tuple[int, int, int], np.ndarray, np.ndarray]]:
+    def reset(self) -> None:
+        """Reset reader state for re-iteration.
+
+        Spectra are a pure function of pixel coordinates (see
+        ``_generate_spectrum``), so re-iteration is already reproducible and
+        this is effectively a no-op.  It exists to satisfy readers whose
+        two-pass converters call ``reset()`` between passes.
+        """
+        self._rng = np.random.default_rng(self._seed)
+
+    def iter_spectra(self, batch_size: Optional[int] = None) -> Generator[
+        Tuple[Tuple[int, int, int], NDArray[np.float64], NDArray[np.float64]],
+        None,
+        None,
+    ]:
         """Iterate through synthetic spectra.
 
         Yields:
-            Tuple of (coords, mz_values, intensities) for each pixel
+            Tuple of ``((x, y, z), mz_values, intensities)`` for each
+            non-empty pixel.
         """
         cfg = self.config
-
         for z in range(cfg.n_z):
             for y in range(cfg.n_y):
                 for x in range(cfg.n_x):
                     pixel_idx = z * (cfg.n_x * cfg.n_y) + y * cfg.n_x + x
-
-                    # Skip empty pixels
                     if pixel_idx in self._empty_pixels:
                         continue
-
-                    # Generate spectrum for this pixel
-                    mz_indices, intensities = self._generate_spectrum()
+                    mz_indices, intensities = self._generate_spectrum(pixel_idx)
                     mz_values = self._common_mass_axis[mz_indices]
-
                     yield (x, y, z), mz_values, intensities
 
-    def _generate_spectrum(self) -> Tuple[np.ndarray, np.ndarray]:
-        """Generate a single synthetic spectrum."""
+    def _generate_spectrum(
+        self, pixel_idx: int
+    ) -> Tuple[NDArray[np.int32], NDArray[np.float64]]:
+        """Generate a single synthetic spectrum for a pixel.
+
+        Deterministic in ``pixel_idx``: the streaming PCS/COO paths iterate
+        the reader twice (count then write) and require the second pass to
+        reproduce the first exactly, so the spectrum must not depend on RNG
+        history or iteration order.
+        """
         cfg = self.config
+        base_seed = self._seed if self._seed is not None else 0
+        rng = np.random.default_rng([base_seed, pixel_idx])
 
-        # Random number of peaks
-        n_peaks = self._rng.integers(
-            cfg.peaks_per_spectrum[0], cfg.peaks_per_spectrum[1]
-        )
+        n_peaks = rng.integers(cfg.peaks_per_spectrum[0], cfg.peaks_per_spectrum[1])
 
-        # Include some common peaks (biomarkers)
+        # Include some common peaks (biomarkers).
         n_common = min(len(self._common_peak_indices), n_peaks // 3)
-        common_indices = self._rng.choice(
+        common_indices = rng.choice(
             self._common_peak_indices, size=n_common, replace=False
         )
 
-        # Random peaks
+        # Random peaks.
         n_random = n_peaks - n_common
-        random_indices = self._rng.choice(cfg.n_mz_bins, size=n_random, replace=False)
+        random_indices = rng.choice(cfg.n_mz_bins, size=n_random, replace=False)
 
-        # Combine and sort
         all_indices = np.unique(np.concatenate([common_indices, random_indices]))
 
-        # Generate intensities with log-normal distribution
-        intensities = self._rng.lognormal(
-            mean=np.log(1000), sigma=1.5, size=len(all_indices)
-        )
-
-        # Clip to range
+        # Log-normal intensities clipped to the configured range.
+        intensities = rng.lognormal(mean=np.log(1000), sigma=1.5, size=len(all_indices))
         intensities = np.clip(
             intensities, cfg.intensity_range[0], cfg.intensity_range[1]
         )
 
-        # Add noise
         if cfg.noise_level > 0:
-            noise = self._rng.normal(0, cfg.noise_level * intensities)
+            noise = rng.normal(0, cfg.noise_level * intensities)
             intensities = np.maximum(intensities + noise, 0)
 
         return all_indices.astype(np.int32), intensities.astype(np.float64)
 
-    def get_common_mass_axis(self) -> np.ndarray:
-        """Return the common mass axis."""
-        return self._common_mass_axis
-
-    def get_peak_counts_per_pixel(self) -> Optional[np.ndarray]:
-        """Return per-pixel peak counts for CSR indptr construction.
-
-        For mock data, we estimate based on average peaks per spectrum.
-        Returns None to trigger the fallback estimation in the converter.
-        """
-        # Return None to test the fallback path
+    def close(self) -> None:
+        """No-op close (mock holds no file handles)."""
         return None
 
 
-def test_streaming_conversion(config: MockMSIConfig, output_dir: Path):
-    """Test the streaming converter with mock data."""
+def run_streaming_demo(config: MockMSIConfig, output_dir: Path) -> Path:
+    """Run the streaming converter on mock data and report basic stats."""
     import tracemalloc
 
     from thyra.converters.spatialdata.streaming_converter import (
@@ -220,14 +268,10 @@ def test_streaming_conversion(config: MockMSIConfig, output_dir: Path):
     print(f"  Peaks per spectrum: {config.peaks_per_spectrum}")
     print(f"  Sparsity: {config.sparsity * 100:.1f}%")
 
-    # Create mock reader
     reader = MockMSIReader(config)
-
     output_path = output_dir / "mock_streaming.zarr"
 
-    # Start memory tracking
     tracemalloc.start()
-
     print("\nConverting with streaming method...")
     start_time = time.time()
 
@@ -235,29 +279,14 @@ def test_streaming_conversion(config: MockMSIConfig, output_dir: Path):
         reader=reader,
         output_path=output_path,
         dataset_id="mock",
-        pixel_size_um=10.0,
-        zero_copy=True,
+        pixel_size_um=config.pixel_size_um,
         chunk_size=5000,
+        use_csc=True,  # force the memory-bounded PCS path
     )
-
-    # Pre-set the mass axis and dimensions to skip initialization
-    # (mock reader doesn't support full initialization flow)
-    converter._common_mass_axis = reader.get_common_mass_axis()
-    converter._dimensions = (config.n_x, config.n_y, config.n_z)
-
-    # Call the direct zarr method directly
-    try:
-        converter._stream_write_direct_zarr()
-        success = True
-    except Exception as e:
-        print(f"Error: {e}")
-        import traceback
-
-        traceback.print_exc()
-        success = False
+    success = converter.convert()
 
     elapsed = time.time() - start_time
-    current, peak = tracemalloc.get_traced_memory()
+    _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
 
     print(f"\nConversion: {'SUCCESS' if success else 'FAILED'}")
@@ -265,52 +294,29 @@ def test_streaming_conversion(config: MockMSIConfig, output_dir: Path):
     print(f"Peak memory: {peak / (1024 * 1024):.1f} MB")
 
     if success:
-        # Verify output
-        print("\nVerifying output...")
-
-        import zarr
-
-        store = zarr.open_group(str(output_path), mode="r")
-
-        if "tables" in store:
-            table_name = list(store["tables"].keys())[0]
-            X = store[f"tables/{table_name}/X"]
-            shape = X.attrs.get("shape", [0, 0])
-            indptr = X["indptr"][-1]
-
-            print(f"  Shape: {shape[0]:,} x {shape[1]:,}")
-            print(f"  Total NNZ: {indptr:,}")
-
-            # Estimate expected NNZ
-            n_spectra = config.n_x * config.n_y - len(reader._empty_pixels)
-            avg_peaks = sum(config.peaks_per_spectrum) / 2
-            expected_nnz = int(n_spectra * avg_peaks)
-
-            print(f"  Expected NNZ (approx): {expected_nnz:,}")
-
-        # Test SpatialData reading
-        print("\nTesting SpatialData.read()...")
+        print("\nVerifying output with spatialdata.read_zarr ...")
         try:
-            from spatialdata import SpatialData
+            import spatialdata
 
-            sdata = SpatialData.read(str(output_path), selection=("tables",))
+            sdata = spatialdata.read_zarr(str(output_path))
             table = list(sdata.tables.values())[0]
-            print("  SpatialData read: SUCCESS")
+            print("  read_zarr: SUCCESS")
             print(f"  Table shape: {table.X.shape}")
             print(f"  Table NNZ: {table.X.nnz:,}")
-        except Exception as e:
-            print(f"  SpatialData read: FAILED - {e}")
+            print(f"  Images: {list(sdata.images.keys())}")
+            print(f"  Shapes: {list(sdata.shapes.keys())}")
+        except Exception as e:  # pragma: no cover - demo diagnostics
+            print(f"  read_zarr: FAILED - {e}")
 
     return output_path
 
 
-def main():
-    """Run the mock MSI data generator test."""
+def main() -> None:
+    """Run the mock MSI data generator smoke test."""
     print("=" * 70)
     print("  MOCK MSI DATA GENERATOR FOR STREAMING CONVERSION TEST")
     print("=" * 70)
 
-    # Get size from command line
     size = "small"
     for arg in sys.argv[1:]:
         if arg.startswith("--size="):
@@ -326,16 +332,13 @@ def main():
     config = PRESETS[size]
     print(f"\nUsing preset: {size}")
 
-    # Create temp directory
     temp_dir = Path(tempfile.mkdtemp(prefix="mock_msi_"))
     print(f"Output directory: {temp_dir}")
 
-    # Run test
-    output_path = test_streaming_conversion(config, temp_dir)
+    output_path = run_streaming_demo(config, temp_dir)
 
     print("\n" + "=" * 70)
     print(f"Output saved to: {output_path}")
-    print(f'To clean up: rmdir /s /q "{temp_dir}"')
 
 
 if __name__ == "__main__":

--- a/tests/unit/converters/test_streaming_pcs_roundtrip.py
+++ b/tests/unit/converters/test_streaming_pcs_roundtrip.py
@@ -1,0 +1,165 @@
+"""Round-trip tests for the streaming converter's PCS (CSC) path.
+
+Regression coverage for the silent-corruption bug where the PCS path
+hand-writes the table store, then added the TIC image / optical images by
+re-reading the store and calling ``write_element`` inside a try/except that
+swallowed any failure.  A failed image write left an image group with
+incomplete OME metadata (no ``ome.version``/``multiscales``) and no optical
+images, yet ``convert()`` returned ``True`` -- so a corrupt, unreadable zarr
+was reported as a success and only blew up later in ``spatialdata.read_zarr``
+with ``KeyError: 'version'``.
+
+These tests assert that:
+  * the PCS path produces a ``spatialdata.read_zarr``-readable zarr;
+  * the TIC (and optical) image groups carry ``ome.version``;
+  * a failure while writing images/optical makes ``convert()`` return
+    ``False`` (fail loudly) instead of reporting a corrupt success.
+"""
+
+import numpy as np
+import pytest
+import zarr
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+)
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+
+def _image_ome_attrs(zarr_path, image_name):
+    """Return the on-disk ``ome`` attribute dict for an image element."""
+    root = zarr.open_group(str(zarr_path), mode="r")
+    return dict(root["images"][image_name].attrs)["ome"]
+
+
+def _small_config(**overrides):
+    base = dict(n_x=6, n_y=6, n_mz_bins=500, peaks_per_spectrum=(20, 40))
+    base.update(overrides)
+    return MockMSIConfig(**base)
+
+
+def test_pcs_path_roundtrips_with_ome_version(tmp_path):
+    """PCS path output must be read_zarr-readable with a versioned TIC image."""
+    reader = MockMSIReader(_small_config())
+    out = tmp_path / "pcs.zarr"
+
+    converter = StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=out,
+        dataset_id="mock",
+        pixel_size_um=10.0,
+        use_csc=True,  # force the PCS path
+    )
+
+    assert converter.convert() is True, "PCS conversion should succeed"
+
+    # The TIC image group must carry complete OME metadata: the original bug
+    # left only ['omero'] (no version/multiscales).
+    ome = _image_ome_attrs(out, "mock_z0_tic")
+    assert "version" in ome, f"TIC image missing ome.version (got {list(ome)})"
+    assert "multiscales" in ome
+
+    # read_zarr must round-trip (this is exactly what broke downstream).
+    import spatialdata
+
+    sdata = spatialdata.read_zarr(str(out))
+    assert "mock_z0_tic" in sdata.images
+    assert "mock_z0_pixels" in sdata.shapes
+    assert len(sdata.tables) == 1
+    table = list(sdata.tables.values())[0]
+    assert table.n_obs == 36  # 6x6 fully-populated grid
+
+
+def test_pcs_path_writes_optical_image(tmp_path):
+    """Optical images requested in the PCS path must be written and readable."""
+    import tifffile
+
+    # Large enough to exercise the multi-scale pyramid + chunked write that the
+    # PCS path now shares with the COO converter.
+    optical = tmp_path / "optical.tif"
+    rng = np.random.default_rng(0)
+    tifffile.imwrite(str(optical), rng.integers(0, 255, (1024, 1024), dtype="uint8"))
+
+    reader = MockMSIReader(_small_config(), optical_image_paths=[optical])
+    out = tmp_path / "pcs_optical.zarr"
+
+    converter = StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=out,
+        dataset_id="mock",
+        pixel_size_um=10.0,
+        use_csc=True,
+        include_optical=True,
+    )
+
+    assert converter.convert() is True
+
+    import spatialdata
+
+    sdata = spatialdata.read_zarr(str(out))
+    optical_keys = [k for k in sdata.images if "optical" in k.lower()]
+    assert optical_keys, f"expected an optical image, got {list(sdata.images)}"
+
+    # Both the TIC and the optical image must carry ome.version.
+    assert "version" in _image_ome_attrs(out, "mock_z0_tic")
+    assert "version" in _image_ome_attrs(out, optical_keys[0])
+
+
+def test_coo_path_roundtrips(tmp_path):
+    """The COO (use_csc=False) path must also round-trip via read_zarr."""
+    reader = MockMSIReader(_small_config())
+    out = tmp_path / "coo.zarr"
+
+    converter = StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=out,
+        dataset_id="mock",
+        pixel_size_um=10.0,
+        use_csc=False,  # force the COO path
+    )
+
+    assert converter.convert() is True
+
+    import spatialdata
+
+    sdata = spatialdata.read_zarr(str(out))
+    assert len(sdata.tables) == 1
+    assert "version" in _image_ome_attrs(out, "mock_z0_tic")
+
+
+def test_image_write_failure_is_not_silent(tmp_path, monkeypatch):
+    """A failure writing images/optical must make convert() return False.
+
+    The original code swallowed the exception and returned True, producing a
+    silently corrupt zarr.  Whatever the cause, an image-write failure must
+    now surface as a failed conversion.
+    """
+    reader = MockMSIReader(_small_config())
+    out = tmp_path / "fail.zarr"
+
+    converter = StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=out,
+        dataset_id="mock",
+        pixel_size_um=10.0,
+        use_csc=True,
+    )
+
+    def _boom(_data_structures):
+        raise RuntimeError("simulated optical/image write failure")
+
+    # _add_optical_images is the shared image-loading seam invoked while
+    # writing the TIC + optical elements; forcing it to raise simulates any
+    # downstream image/optical write failure.
+    monkeypatch.setattr(converter, "_add_optical_images", _boom)
+
+    assert converter.convert() is False, (
+        "convert() must fail loudly when image writing fails, not report a "
+        "corrupt zarr as success"
+    )

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -36,7 +36,7 @@ if SPATIALDATA_AVAILABLE:
     from anndata import AnnData
     from spatialdata import SpatialData
     from spatialdata.models import Image2DModel, ShapesModel, TableModel
-    from spatialdata.transformations import Affine, Identity, Scale, Sequence
+    from spatialdata.transformations import Affine, Identity, Scale
 
 logger = logging.getLogger(__name__)
 
@@ -205,7 +205,8 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 coo_result = self._stream_build_coo()
                 data_structures = self._create_data_structures_from_coo(coo_result)
                 self._finalize_data(data_structures)
-                self._save_output(data_structures)
+                if not self._save_output(data_structures):
+                    raise RuntimeError("Failed to write SpatialData output (COO path)")
                 logger.info("Zero-copy COO conversion complete")
 
             return True
@@ -1638,43 +1639,62 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             },
         )
 
-        # === Write to existing store using SpatialData ===
-        # Open the store and add elements
-        try:
-            with _suppress_upstream_warnings():
-                # Also suppress table-annotating-missing-shapes warning (shapes
-                # are created and written immediately after this read).
-                warnings.filterwarnings(
-                    "ignore",
-                    message="The table is annotating.*which is not present",
-                    category=UserWarning,
-                )
-                sdata = SpatialData.read(str(self.output_path))
+        # === Write images and shapes via spatialdata's own element writer ===
+        #
+        # The CSC table is already hand-written to the Zarr store to keep
+        # memory bounded.  The TIC image, pixel shapes, and any optical
+        # images are small, so we let spatialdata write them through its
+        # normal element writer.  That guarantees the produced OME-NGFF
+        # metadata (``ome.version`` + ``multiscales``) matches whatever
+        # spatialdata version is installed, so ``spatialdata.read_zarr``
+        # round-trips on both the stock package and the Ousia fork.
+        #
+        # We deliberately do NOT call ``SpatialData.read(self.output_path)``
+        # first: re-reading the hand-written store coupled element writing
+        # to the hand-crafted store layout and -- combined with the
+        # swallow below -- previously let a half-written, unreadable image
+        # group pass as a successful conversion.  A fresh in-memory
+        # SpatialData pointed at the existing store writes only the named
+        # elements and leaves the hand-written table untouched.
+        #
+        # No try/except: any failure here propagates to convert(), which
+        # returns False.  A corrupt zarr must never be reported as success.
+        tic_name = f"{slice_id}_tic"
+        data_structures: Dict[str, Any] = {
+            "images": {tic_name: tic_image},
+            "shapes": {region_key: shapes},
+            "tables": {},
+        }
 
-                # Add TIC image
-                tic_name = f"{slice_id}_tic"
-                sdata.images[tic_name] = tic_image
+        # Load optical images through the COO converter's path so they get
+        # the same multi-scale pyramid + chunked layout and identical
+        # transforms.  Honours self._include_optical internally.
+        self._add_optical_images(data_structures)
 
-                # Add shapes
-                sdata.shapes[region_key] = shapes
+        with _suppress_upstream_warnings():
+            # This SpatialData intentionally carries no table (the table is
+            # already on disk), so suppress the "table is annotating ...
+            # which is not present" warning for the region it annotates.
+            warnings.filterwarnings(
+                "ignore",
+                message="The table is annotating.*which is not present",
+                category=UserWarning,
+            )
+            sdata = SpatialData(
+                images=data_structures["images"],
+                shapes=data_structures["shapes"],
+            )
+            sdata.path = Path(self.output_path)
+            element_names = list(data_structures["images"].keys()) + list(
+                data_structures["shapes"].keys()
+            )
+            sdata.write_element(element_names, overwrite=True)
 
-                # Write elements to disk
-                sdata.write_element(tic_name, overwrite=True)
-                sdata.write_element(region_key, overwrite=True)
-
-                logger.info(
-                    f"  Added TIC image '{tic_name}' ({x_size}x{y_size}) and "
-                    f"{n_rows:,} pixel shapes"
-                )
-
-                # Add optical images if available
-                self._add_optical_images_to_sdata(sdata, slice_id)
-
-        except Exception as e:
-            logger.warning(f"Failed to add TIC image and shapes: {e}")
-            import traceback
-
-            logger.debug(f"Traceback:\n{traceback.format_exc()}")
+        n_optical = len(data_structures["images"]) - 1
+        logger.info(
+            f"  Wrote TIC image '{tic_name}' ({x_size}x{y_size}), "
+            f"{n_rows:,} pixel shapes, and {n_optical} optical image(s)"
+        )
 
     def _create_streaming_pixel_shapes(
         self, n_rows: int, n_x: int, n_y: int
@@ -1757,126 +1777,3 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         else:
             instance_ids = [str(i) for i in range(n_rows)]
         return gpd.GeoDataFrame(geometry=geometries, index=instance_ids)
-
-    def _add_optical_images_to_sdata(self, sdata: "SpatialData", slice_id: str) -> None:
-        """Add optical images directly to SpatialData store.
-
-        The primary alignment image (from .mis <ImageFile>) gets an Identity
-        transform and is loaded first. Other images get a Scale transform
-        mapping their pixel coordinates to the primary image's space.
-
-        Args:
-            sdata: SpatialData object to add images to
-            slice_id: Slice identifier for transformations
-        """
-        if not self._include_optical:
-            return
-
-        optical_paths = self.reader.get_optical_image_paths()
-        if not optical_paths:
-            logger.debug("No optical images found")
-            return
-
-        import tifffile
-
-        logger.info(f"  Adding {len(optical_paths)} optical image(s)...")
-
-        # Load primary image first so we know its dimensions for scaling others
-        primary_paths = [p for p in optical_paths if self._is_primary_optical(p)]
-        other_paths = [p for p in optical_paths if not self._is_primary_optical(p)]
-
-        for tiff_path in primary_paths + other_paths:
-            try:
-                # Generate image name
-                image_name = self._generate_optical_image_name(tiff_path)
-
-                logger.info(f"    Loading: {tiff_path.name} as '{image_name}'")
-
-                # Read TIFF
-                with tifffile.TiffFile(tiff_path) as tif:
-                    img_data = tif.pages[0].asarray()
-
-                    # Convert to (c, y, x) format
-                    if img_data.ndim == 2:
-                        img_data = img_data[np.newaxis, :, :]
-                    elif img_data.ndim == 3:
-                        img_data = np.moveaxis(img_data, -1, 0)
-                    else:
-                        logger.warning(
-                            f"Unexpected dimensions {img_data.ndim} for {tiff_path.name}"
-                        )
-                        continue
-
-                    n_channels, y_size, x_size = img_data.shape
-
-                    # Create xarray DataArray
-                    optical_xarray = xr.DataArray(
-                        img_data,
-                        dims=("c", "y", "x"),
-                        coords={
-                            "c": list(range(n_channels)),
-                            "y": np.arange(y_size),
-                            "x": np.arange(x_size),
-                        },
-                    )
-
-                    # Determine transform.  Mirrors the logic in
-                    # base_spatialdata_converter._load_single_optical_image:
-                    #   - apply_optical_alignment=True (default):
-                    #       primary -> Identity, others -> Scale to primary.
-                    #   - apply_optical_alignment=False:
-                    #       primary -> Affine(optical_to_um), others ->
-                    #       Sequence(scale_to_primary, optical_to_um).
-                    # This way the wizard gets the FlexImaging optical
-                    # image landing in MSI-micrometer space at "global",
-                    # so the assemble step's EscDat affine maps both
-                    # MSI and optical into Xenium pixel space together.
-                    is_primary = self._is_primary_optical(tiff_path)
-                    if is_primary:
-                        self._primary_optical_dims = (x_size, y_size)
-                        if (
-                            not self._apply_optical_alignment
-                            and self._tic_to_image_matrix is not None
-                        ):
-                            transform = self._build_optical_to_um_transform()
-                            logger.info(
-                                f"    Primary image -> um via inverse "
-                                f"alignment: {x_size}x{y_size}"
-                            )
-                        else:
-                            transform = Identity()
-                            logger.info(
-                                f"    Primary alignment image: " f"{x_size}x{y_size}"
-                            )
-                    elif self._primary_optical_dims is not None:
-                        base = self._compute_optical_scale_transform(x_size, y_size)
-                        if (
-                            not self._apply_optical_alignment
-                            and self._tic_to_image_matrix is not None
-                        ):
-                            transform = Sequence(
-                                [base, self._build_optical_to_um_transform()]
-                            )
-                        else:
-                            transform = base
-                    else:
-                        transform = Identity()
-
-                    optical_image = Image2DModel.parse(
-                        optical_xarray,
-                        transformations={
-                            self.dataset_id: transform,
-                            "global": transform,
-                        },
-                    )
-
-                    # Add to SpatialData and write
-                    sdata.images[image_name] = optical_image
-                    sdata.write_element(image_name, overwrite=True)
-
-                    logger.info(
-                        f"    Added optical image ({x_size}x{y_size}, {n_channels}ch)"
-                    )
-
-            except Exception as e:
-                logger.warning(f"Failed to load optical image {tiff_path.name}: {e}")


### PR DESCRIPTION
## Problem

The streaming converter's PCS (CSC) path -- used for large MSI datasets, and the path Ousia's import wizard needs for memory-bounded conversion -- silently corrupts its output.

`_add_tic_image_and_shapes_to_store()` hand-writes the table store, then adds the TIC image, pixel shapes, and optical images by re-reading the store with `SpatialData.read(...)` and calling `write_element(...)` **inside a `try/except` that swallows any failure** (`logger.warning("Failed to add TIC image and shapes")`). When a write fails, `convert()` still returns `True`, leaving a corrupt zarr:

- an image group with incomplete OME metadata (`ome` = `['omero']` only, no `version`/`multiscales`),
- no optical images,

yet the conversion is reported as a success. Downstream, `spatialdata.read_zarr` raises `KeyError: 'version'`.

## Fix

1. **Write images/shapes through spatialdata's own element writer.** Build a fresh in-memory `SpatialData` containing only the TIC image, pixel shapes, and optical images (the large CSC table stays hand-written), point it at the existing store, and `write_element` each. This produces OME-NGFF metadata matching whatever spatialdata version is installed, so `read_zarr` round-trips. The fragile read-back of the hand-written store is gone.
2. **Reuse the COO path's `_add_optical_images`** for optical handling -- DRY, plus multi-scale pyramid + chunked-layout parity with the standard converter (`_add_optical_images_to_sdata` is deleted).
3. **Stop swallowing.** Any image/optical write failure now propagates, so `convert()` returns `False` -- a corrupt zarr can never pass as success again. The COO path's ignored `_save_output` return value is checked for the same reason.

## Tests

- Brought `tests/fixtures/MockMSIReader` up to the current `BaseMSIReader` interface (metadata extractor, region/optical/reset/close, grid-aligned deterministic spectra) so the converters can be exercised end-to-end without real data.
- Added `tests/unit/converters/test_streaming_pcs_roundtrip.py`: asserts the PCS path produces a `read_zarr`-readable zarr, that the TIC (and optical) image carries `ome.version`, that the COO path round-trips, and that an image-write failure makes `convert()` return `False` (fail loudly).

## Verification

- Full unit suite (`pytest -m "not integration"`, what CI runs): **395 passed, 11 skipped**, no regressions.
- New round-trip + fail-loudly tests pass on stock spatialdata 0.6.1 and were verified against the downstream spatialdata fork (0.7.0a1) where the original corruption manifested.
- The two pre-existing `integration`-marked COO failures (`test_coo_path_small_dataset`, `test_custom_temp_directory`) are unrelated to this change (they fail on `main` too) and are excluded from CI.