### PR TITLE
fix(spatialdata): coerce ArrowStringArray table dtypes to object on write

### DIFF
--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1762,6 +1762,40 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
         return f"{self.dataset_id}_optical_{suffix}"
 
+    @staticmethod
+    def _coerce_table_strings_to_object(df: pd.DataFrame) -> None:
+        """Coerce pandas string-extension dtypes in ``df`` to NumPy ``object``.
+
+        Under pandas >= 3.0 (or with ``future.infer_string`` enabled) string
+        columns and string indices are backed by ``ArrowStringArray``
+        (``pandas.StringDtype``), for which anndata's Zarr writer has no
+        registered serialization method -- writing such a table raises
+        ``IORegistryError: No method registered for writing ArrowStringArray
+        into zarr.core.group.Group``. Converting these to ``object`` dtype
+        restores writeability without changing any values, and is a no-op on
+        pandas < 3.0 where the same columns are already ``object``.
+
+        Operates on an AnnData ``obs``/``var`` table in place. Categorical
+        columns whose categories are string-backed (e.g. the ``region`` column)
+        have their categories coerced to ``object`` while preserving codes.
+
+        Args:
+            df: An AnnData ``obs`` or ``var`` table to sanitize in place.
+        """
+        if isinstance(df.index.dtype, pd.StringDtype):
+            df.index = df.index.astype(object)
+
+        for column in df.columns:
+            dtype = df[column].dtype
+            if isinstance(dtype, pd.StringDtype):
+                df[column] = df[column].astype(object)
+            elif isinstance(dtype, pd.CategoricalDtype) and isinstance(
+                dtype.categories.dtype, pd.StringDtype
+            ):
+                df[column] = df[column].cat.rename_categories(
+                    dtype.categories.astype(object)
+                )
+
     def _save_output(self, data_structures: Dict[str, Any]) -> bool:
         """Save the data to SpatialData format.
 
@@ -1775,6 +1809,18 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             raise ImportError("SpatialData dependencies not available")
 
         try:
+            # Coerce pandas string-extension dtypes (ArrowStringArray under
+            # pandas >= 3.0 / future.infer_string) back to ``object`` so
+            # anndata's Zarr writer can serialize the table indices and string
+            # columns. No-op on pandas < 3.0 (already ``object``).
+            for table in data_structures["tables"].values():
+                obs = getattr(table, "obs", None)
+                if isinstance(obs, pd.DataFrame):
+                    self._coerce_table_strings_to_object(obs)
+                var = getattr(table, "var", None)
+                if isinstance(var, pd.DataFrame):
+                    self._coerce_table_strings_to_object(var)
+
             # Create SpatialData object with images included
             sdata = SpatialData(
                 tables=data_structures["tables"],


### PR DESCRIPTION
## Problem

The streaming **COO path** (`use_csc=False`) fails to write its SpatialData output under **pandas >= 3.0** (where `future.infer_string` defaults to `True`):

```
IORegistryError: No method registered for writing
<class 'pandas.arrays.ArrowStringArray'> into <class 'zarr.core.group.Group'>
```

`convert()` then raises `RuntimeError: Failed to write SpatialData output (COO path)`.

Reproduced by `tests/unit/converters/test_streaming_pcs_roundtrip.py::test_coo_path_roundtrips` when run under a pandas-3 environment (e.g. pandas 3.0.3 + anndata 0.13.dev + spatialdata 0.7). It does **not** reproduce under Thyra's own poetry venv (pandas 2.3.2), which is why CI is green today.

## Root cause

With `future.infer_string=True`, the COO table's obs index (`instance_id`), the `instance_key` column, and the var index (`mz_*`) are inferred as the new `str` dtype backed by `ArrowStringArray` (`pandas.StringDtype`). anndata's Zarr writer has no registered serialization method for that extension array, so the write raises. The `region` column is unaffected (it is a Categorical).

## Fix

Add `BaseSpatialDataConverter._coerce_table_strings_to_object()` and call it in the base `_save_output()` for every table's `obs`/`var` before `SpatialData.write()`. It converts string-extension indices/columns (and string-backed categorical categories, preserving codes) to NumPy `object`. Values are unchanged and the coercion is a **no-op on pandas < 3.0** where these are already `object`.

Because the coercion lives at the single serialization chokepoint, it also hardens the 2D and 3D converters (which build `obs`/`var` identically) against the same failure. The **PCS path (`use_csc=True`) is unaffected** -- it hand-writes NumPy `str` arrays to Zarr and never goes through anndata's writer.

## Validation

- `test_coo_path_roundtrips` passes under the pandas-3 environment; deep round-trip check confirms the X matrix, obs index / `instance_key`, `region` categories, var index / `mz`, all `uns` metadata, the TIC image and pixel shapes survive.
- PCS round-trip tests still green; converter suite 53/53 under pandas 3.0.
- Full unit suite: 400 passed, 11 skipped under the poetry venv (pandas 2.3.2) -- no regressions.
- pre-commit all green (black / isort / flake8 / mypy / bandit / pydocstyle).