### PR TITLE
fix(deps): add upper bounds so pip install lands on a working set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,3 +35,31 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
+
+  # Installs thyra the way an end user does: a plain `pip install .` that
+  # resolves dependencies fresh from PyPI, WITHOUT poetry.lock. This is the
+  # only job that exercises the pip resolver against the version bounds in
+  # pyproject.toml, so it catches mismatched dependency sets (e.g. a stale
+  # spatialdata paired with too-new ome-zarr/dask) that the lockfile hides.
+  clean-venv-install:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.13']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install thyra from a clean venv (no lockfile)
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install pytest pytest-cov mock
+    - name: Report the resolved dependency set
+      run: pip list
+    - name: Verify save / read-back round-trip on the resolved set
+      run: pytest -m "not integration" --disable-warnings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,4 +62,9 @@ jobs:
     - name: Report the resolved dependency set
       run: pip list
     - name: Verify save / read-back round-trip on the resolved set
-      run: pytest -m "not integration" --disable-warnings
+      # thyra + its dependencies come from the non-editable pip install
+      # above; PYTHONPATH only puts the repo root on sys.path so the
+      # in-repo test helpers (the `tests` namespace package, which has no
+      # __init__.py) import. Editable installs get this for free via a
+      # .pth file, so the lockfile job never needs it.
+      run: PYTHONPATH=. pytest -m "not integration" --disable-warnings

--- a/poetry.lock
+++ b/poetry.lock
@@ -7124,4 +7124,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.14"
-content-hash = "5a56aabf1a612890145ff26ddab6e76f5918d563386db2f0ab919499b4a1a0ff"
+content-hash = "26ba5180357077a8e6bda469e2e17d6ffe4f8cd099b081fb66892b4f6f428a04"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,29 +56,34 @@ packages = [{include = "thyra"}]
 [tool.poetry.dependencies]
 python = ">=3.11, <3.14"
 
-# Lower bound stops the resolver from picking pre-2025.12 dask where
-# old ome_zarr 0.12.2's zarr_format kwarg leaked through. ome_zarr
-# >=0.14 below fixes the leak at source; the actual upper bound on dask
-# is set transitively by whichever SpatialData version is installed
-# (0.7.3 wants <2026.1.2, main wants >=2026.3.0).
-dask = ">=2025.12.0"
+# The spatialdata / ome-zarr / zarr / dask cluster is tightly coupled and
+# all four release frequently with breaking cross-version interactions.
+# Floors alone are NOT enough for `pip install thyra`: without upper
+# bounds pip resolves a mismatched set (e.g. spatialdata 0.7.0 pulled in
+# alongside ome-zarr 0.18.0 + dask 2026.7.0), which fails to save/read
+# back a SpatialData object. The upper bounds below pin this cluster to
+# the tested, lockfile-consistent set so a plain pip install lands on a
+# working combination. The clean-venv CI job in .github/workflows/tests.yml
+# exercises exactly this pip-resolved path so these bounds stay honest.
+# Bump the ceilings deliberately after re-testing against newer releases.
+dask = ">=2025.12.0, <2026.2"       # tested 2026.1.1 (spatialdata 0.7.3 needs <2026.1.2)
 defusedxml = ">=0.7.1"  # Secure XML parsing for the Bruker Rapiflex reader
 geopandas = ">=0.9.0"
 lxml = ">=4.6.0"
-numpy = ">=2.0.0"
+numpy = ">=2.0.0, <3"
 pandas = ">=2.0.0"
 pyimzML = ">=1.4.0"
 scipy = ">=1.7.0"
 Shapely = ">=2.0.0"
-spatialdata = ">=0.6.0"
+spatialdata = ">=0.7.3, <0.8"       # tested 0.7.3
 # Floor pulls the fix for the zarr_format/Group.create_array() bug that
-# bit ome_zarr 0.12.x with newer dask. Source-level fix beats the
-# previous dask version cap.
-ome-zarr = ">=0.14.0"
+# bit ome_zarr 0.12.x with newer dask; the ceiling keeps pip off the
+# 0.16+ releases that the resolver otherwise pairs with a stale spatialdata.
+ome-zarr = ">=0.14.0, <0.16"        # tested 0.15.0
 tqdm = ">=4.50.0"
-zarr = ">=3.0.0"
+zarr = ">=3.0.0, <3.2"              # tested 3.1.3
 imagecodecs = ">=2024.1.1"  # For reading compressed TIFF optical images
-anndata = ">=0.11.0"
+anndata = ">=0.11.0, <0.13"         # tested 0.12.2
 psutil = ">=5.0.0"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
## Problem

Review feedback (P2): a fresh, unconstrained `pip install` resolves a mismatched dependency set (e.g. spatialdata 0.7.0 with ome-zarr 0.18.0 + dask 2026.7.0) that fails to save and read back a SpatialData object. Floors alone do not fix this because pip users never get the lockfile.

## Fix

- Add upper bounds to the tightly-coupled `spatialdata` / `ome-zarr` / `zarr` / `dask` / `anndata` cluster (plus `numpy`), pinned to the tested, lockfile-consistent versions (spatialdata 0.7.3, ome-zarr 0.15.0, zarr 3.1.3, dask 2026.1.1, anndata 0.12.2). Verified via a `pip install .` dry-run that the resolver now lands on the working set instead of the broken one.
- Add a `clean-venv-install` CI job that installs via a plain `pip install .` (no lockfile) on Python 3.11 and 3.13, prints the resolved set, and runs the unit suite including the save/read-back round-trip. This exercises the pip-resolved path the lockfile otherwise hides and keeps the bounds honest.

Chose metadata upper bounds over a shipped constraints file because only bounds protect the literal `pip install thyra` (a constraints file requires users to pass `-c`).
