### PR TITLE
Fix CLI exit code, resampling axis physics, Windows write failures, and lint config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,19 @@
 [flake8]
-max-line-length = 88
+# Single source of truth for flake8. The pre-commit hook deliberately passes
+# no arguments so that `poetry run flake8`, `pre-commit run`, and CI all apply
+# exactly these settings. Keep them here, not in hook args.
+max-line-length = 100
 extend-ignore = E203, W503
+per-file-ignores =
+    # Re-exports are the whole point of a package __init__.
+    __init__.py:F401,F403
+# Matches the CI complexity gate (complexity-monitoring.yml, raised 10->15 in
+# d8f1e42).
+max-complexity = 15
+# flake8 always checks a path passed explicitly on the command line, so this
+# list only applies to discovery mode (`poetry run flake8`). pre-commit passes
+# filenames explicitly, so it carries a matching `exclude:` on the flake8 hook
+# -- keep the two in step.
 exclude =
     .git,
     __pycache__,
@@ -15,5 +28,12 @@ exclude =
     ENV,
     env.bak,
     venv.bak,
-    # Ignore auto-generated ontology files
+    # Built documentation
+    site,
+    # Auto-generated ontology files
     thyra/metadata/ontology/_*.py,
+    # Ad-hoc developer diagnostics: not part of the shipped package and not
+    # exercised by CI. black and isort still cover them, so formatting stays
+    # consistent; the stricter lint and complexity gates apply to thyra/ and
+    # tests/ only.
+    scripts,

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # MkDocs build output
 site/
+# mkdocs-jupyter's rendered-notebook cache, written by `mkdocs build`
+.cache/
 
 # Python cache and build files
 *.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,16 +39,15 @@ repos:
         args: ["--profile", "black"]
 
   # Code linting with stricter rules
+  # Settings live in .flake8 so this hook and `poetry run flake8` cannot drift
+  # apart. Do not add setting args here. The exclude below mirrors the
+  # `exclude` list in .flake8, which flake8 itself ignores for filenames
+  # passed explicitly the way pre-commit passes them.
   - repo: https://github.com/pycqa/flake8
     rev: 7.1.0
     hooks:
       - id: flake8
-        args: [
-          "--max-line-length=100",
-          "--extend-ignore=E203,W503",  # E203: black compatibility, W503: line break before binary operator (conflicts with W504)
-          "--per-file-ignores=__init__.py:F401,F403",  # Allow unused imports in __init__.py files only
-          "--max-complexity=15"  # match the CI complexity gate (complexity-monitoring.yml, raised 10->15 in d8f1e42)
-        ]
+        exclude: ^(scripts/|thyra/metadata/ontology/_)
 
   # Type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,7 +10,27 @@ thyra [OPTIONS] INPUT OUTPUT
 
 !!! tip "Grouped help"
     Run `thyra --help` to see all options organised by category (Conversion,
-    Logging, Resampling, Performance, Bruker-Specific, Other).
+    Logging, Resampling, Performance, Bruker-Specific, Other), and
+    `thyra --version` to print the installed version.
+
+---
+
+## Exit status
+
+| Code | Meaning |
+|------|---------|
+| `0` | Conversion completed and the output store was written |
+| `1` | Conversion failed |
+| `2` | Invalid command-line arguments (click usage error) |
+
+A failed conversion renames any partially written store to
+`<output>.zarr.failed`, so the output path stays free for a retry and an
+incomplete store is never left where a finished one is expected. This makes
+`thyra` safe to chain in a shell script or CI job:
+
+```bash
+thyra input.imzML output.zarr && python analyse.py output.zarr
+```
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -186,8 +186,14 @@ thyra large_dataset.d output.zarr --streaming false
 
 ### "WinError 5: Access is denied"
 
-This means the output `.zarr` directory is locked by another process (e.g., a
-Python session, napari, or a Jupyter notebook that loaded it).
+Windows has no atomic file replace, so Zarr's metadata writes have to delete the
+destination before renaming the new copy over it. If any handle is open on that
+file at that instant the rename fails outright instead of waiting.
+
+Thyra retries these renames a few times, which clears the transient contention
+Zarr's own concurrent writes create. A failure that survives the retries means
+something is holding the store open for longer than that -- typically a Python
+session, napari, or a Jupyter notebook that loaded it.
 
 **Fix:** Close any program that has the zarr open, or write to a different output
 path.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,23 +198,33 @@ session, napari, or a Jupyter notebook that loaded it.
 **Fix:** Close any program that has the zarr open, or write to a different output
 path.
 
-### Windows: "No such file or directory" ending in `.partial`
+### Windows: long output paths
 
-A conversion that fails with an error like
+Windows caps a normal path at 260 characters, and the limit applies to every
+file inside the `.zarr` directory rather than to the path you typed. Thyra's
+deepest metadata key sits roughly 95 characters below the output path, so an
+output path over about 165 characters would once fail part-way through the
+write with a confusing error naming a file you never asked for:
 
 ```
 Error saving SpatialData: [Errno 2] No such file or directory:
   '...\output.zarr\tables\msi_dataset_z0\uns\format_specific\imzml_version\zarr.<hash>.partial'
 ```
 
-has hit the Windows 260-character path limit. Thyra stores metadata as nested
-Zarr groups, and Zarr appends a temporary `zarr.<32-hex>.partial` filename while
-writing, which together add roughly 95 characters below your output path.
+Thyra now detects this before writing and opens the store through an
+extended-length (`\\?\`) path, which is exempt from the 260-character limit, so
+long output paths convert normally. A log line records when this happens.
 
-**Fix:** write to a shorter output path -- a short directory near the drive root
-such as `C:\msi\out.zarr` is always safe. Alternatively, enable long path
-support system-wide (`HKLM\SYSTEM\CurrentControlSet\Control\FileSystem`,
-`LongPathsEnabled` = 1, requires administrator rights and a reboot).
+!!! note "Reading a store at a long path"
+    The store is written correctly, but *other* tools still face the same limit
+    when reading it. Either enable long path support system-wide
+    (`HKLM\SYSTEM\CurrentControlSet\Control\FileSystem`, `LongPathsEnabled` = 1;
+    needs administrator rights and a reboot), pass the `\\?\` prefix yourself:
+    ```python
+    import spatialdata as sd
+    sdata = sd.read_zarr(r"\\?\C:\very\long\path\output.zarr")
+    ```
+    or simply choose a shorter output path such as `C:\msi\out.zarr`.
 
 !!! info "Failed conversions exit non-zero and move the partial store aside"
     Any failed conversion exits with status 1, so a script or CI job wrapping

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -210,14 +210,11 @@ such as `C:\msi\out.zarr` is always safe. Alternatively, enable long path
 support system-wide (`HKLM\SYSTEM\CurrentControlSet\Control\FileSystem`,
 `LongPathsEnabled` = 1, requires administrator rights and a reboot).
 
-!!! warning "Check the output before relying on it"
-    A conversion that fails this way leaves a partially written `.zarr` behind,
-    and the `thyra` command still exits with status 0. Confirm the output loads
-    before treating a conversion as successful:
-    ```python
-    import spatialdata as sd
-    sd.read_zarr("output.zarr")   # raises if the store is incomplete
-    ```
+!!! info "Failed conversions exit non-zero and move the partial store aside"
+    Any failed conversion exits with status 1, so a script or CI job wrapping
+    `thyra` sees the failure. The partially written store is renamed to
+    `<output>.zarr.failed` rather than left at the destination, which keeps it
+    available for diagnosis and leaves the output path free for a retry.
 
 ### "No module named 'timsdata'" or Bruker SDK errors
 

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -179,17 +179,13 @@ produces for FlexImaging data. The count is then derived per axis type:
 |---|---|
 | `reflector_tof` | `ln(max/min) * (ref_mz / width)` |
 | `linear_tof` | `(2/k) * (sqrt(max) - sqrt(min))`, `k = width / sqrt(ref_mz)` |
-| `orbitrap` | `(1/sqrt(min) - 1/sqrt(max)) * (ref_mz^1.5 / width)` |
+| `orbitrap` | `2 * (1/sqrt(min) - 1/sqrt(max)) * (ref_mz^1.5 / width)` |
+| `fticr` | `(1/min - 1/max) * (ref_mz^2 / width)` |
 | `constant` | `(max - min) / width` |
 
+Each is the integral of `1 / width(m)` across the mass range, so the bin width
+the axis actually realizes at your reference m/z is the width you asked for.
 The result is floored at 100 bins.
-
-!!! warning "Specify `--resample-bins` explicitly for FT-ICR"
-    The bin-count calculation has no `fticr` branch, so an FT-ICR axis falls
-    through to the uniform `(max - min) / width` formula while the axis itself
-    is generated with `m/z^2` spacing. The axis is valid, but the effective
-    width at your reference m/z will not be the width you asked for. Set
-    `--resample-bins` directly for FT-ICR data.
 
 A worked example, from the [tutorial](tutorial.md)'s synthetic dataset --
 250-1200 Da, `constant` axis, default 5 mDa width:
@@ -296,7 +292,7 @@ confirming a `constant` axis at the default width.
 - **Leave it alone** unless you have a reason. The detected settings are right for the common Bruker and imzML cases.
 - **Disable it** (`--no-resample`) when you want the untouched vendor axis -- your own peak picking, centroiding, or calibration downstream.
 - **Set `tic_preserving`** if quantitation matters and your data is profile, especially profile data from a high-resolution analyser, which the automatic choice will not pick it for.
-- **Set `--resample-bins`** for FT-ICR data, and any time you need to match another tool's axis exactly.
+- **Set `--resample-bins`** any time you need to match another tool's axis exactly.
 - **Narrow the mass range** (`--resample-min-mz` / `--resample-max-mz`) before increasing bin counts; it is usually the cheaper way to get the resolution you need where you need it.
 
 ---

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -26,11 +26,15 @@ pip install thyra
 Thyra requires Python 3.11 or 3.12. Check what you have:
 
 ```bash
-python -c "import thyra, spatialdata; print(thyra.__version__, spatialdata.__version__)"
+thyra --version
 ```
 
 This tutorial was written and verified against `thyra` 1.25.5 and
-`spatialdata` 0.7.3.
+`spatialdata` 0.7.3. To check the `spatialdata` version too:
+
+```bash
+python -c "import spatialdata; print(spatialdata.__version__)"
+```
 
 ---
 

--- a/tests/unit/converters/test_bin_count_from_width.py
+++ b/tests/unit/converters/test_bin_count_from_width.py
@@ -1,0 +1,181 @@
+# tests/unit/converters/test_bin_count_from_width.py
+"""Tests for deriving a bin count from a target width at a reference m/z.
+
+``_calculate_bins_from_width`` turns "I want bins this wide at this m/z"
+into a bin count, and ``CommonAxisBuilder.build_physics_axis`` then
+distributes that many bins according to the analyser's spacing law. The
+two have to agree: if the count is derived with a different law than the
+axis is generated with, the axis is still valid but its realized width at
+``reference_mz`` is not the width that was asked for.
+
+These tests close that loop -- derive the count, build the axis, and
+measure the width actually realized near ``reference_mz``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    BaseSpatialDataConverter,
+)
+from thyra.resampling.common_axis import CommonAxisBuilder
+from thyra.resampling.types import AxisType
+
+ALL_AXIS_TYPES = [
+    AxisType.CONSTANT,
+    AxisType.LINEAR_TOF,
+    AxisType.REFLECTOR_TOF,
+    AxisType.ORBITRAP,
+    AxisType.FTICR,
+]
+
+
+def _bin_count(axis_type, width_at_mz, reference_mz, min_mz, max_mz) -> int:
+    """Derive a bin count exactly the way the converter does.
+
+    ``_calculate_bins_from_width`` reads only ``_width_at_mz`` and
+    ``_reference_mz`` off ``self``, so a stub carrying those two
+    attributes exercises it without standing up a whole converter (which
+    would need a reader and a writable output path).
+    """
+    stub = SimpleNamespace(_width_at_mz=width_at_mz, _reference_mz=reference_mz)
+    return BaseSpatialDataConverter._calculate_bins_from_width(
+        stub, min_mz, max_mz, axis_type
+    )
+
+
+def _realized_width_at(axis_type, width_at_mz, reference_mz, min_mz, max_mz) -> float:
+    """Build the axis the converter would build and measure its width.
+
+    Returns the bin width of the bin whose centre sits closest to
+    ``reference_mz``.
+    """
+    bins = _bin_count(axis_type, width_at_mz, reference_mz, min_mz, max_mz)
+    axis = CommonAxisBuilder().build_physics_axis(
+        min_mz=min_mz,
+        max_mz=max_mz,
+        num_bins=bins,
+        axis_type=axis_type,
+        reference_mz=reference_mz,
+        reference_width=width_at_mz,
+    )
+    mz = axis.mz_values
+    widths = np.diff(mz)
+    centres = (mz[:-1] + mz[1:]) / 2
+    return float(widths[int(np.argmin(np.abs(centres - reference_mz)))])
+
+
+class TestRealizedWidthMatchesRequest:
+    """The width realized at reference_mz must be the width requested."""
+
+    @pytest.mark.parametrize("axis_type", ALL_AXIS_TYPES)
+    def test_default_width_and_reference(self, axis_type):
+        realized = _realized_width_at(axis_type, 0.005, 1000.0, 100.0, 2000.0)
+
+        assert realized == pytest.approx(0.005, rel=0.03), (
+            f"{axis_type.value}: realized width {realized*1000:.4f} mDa is "
+            f"not within 3% of the requested 5.0000 mDa"
+        )
+
+    @pytest.mark.parametrize("axis_type", ALL_AXIS_TYPES)
+    def test_fticr_style_narrow_range(self, axis_type):
+        """FT-ICR data is typically a narrow high-mass window."""
+        realized = _realized_width_at(axis_type, 0.001, 700.0, 400.0, 1000.0)
+
+        assert realized == pytest.approx(0.001, rel=0.03), (
+            f"{axis_type.value}: realized width {realized*1000:.4f} mDa is "
+            f"not within 3% of the requested 1.0000 mDa"
+        )
+
+    @pytest.mark.parametrize("axis_type", ALL_AXIS_TYPES)
+    @pytest.mark.parametrize("reference_mz", [200.0, 500.0, 1500.0])
+    def test_anchoring_follows_the_reference_mz(self, axis_type, reference_mz):
+        """Moving reference_mz must move where the width is anchored."""
+        realized = _realized_width_at(axis_type, 0.01, reference_mz, 150.0, 1800.0)
+
+        assert realized == pytest.approx(0.01, rel=0.03), (
+            f"{axis_type.value} at reference m/z {reference_mz}: realized "
+            f"width {realized*1000:.4f} mDa is not within 3% of the "
+            f"requested 10.0000 mDa"
+        )
+
+
+class TestBinCount:
+    """Bin-count behaviour that does not depend on the generated axis."""
+
+    def test_fticr_uses_the_inverse_mz_formula(self):
+        """bins = (1/min - 1/max) * (reference_mz^2 / width).
+
+        Guards against the FT-ICR axis silently falling through to the
+        uniform ``(max - min) / width`` count again.
+        """
+        min_mz, max_mz, width, ref = 100.0, 2000.0, 0.005, 1000.0
+        expected = int((1 / min_mz - 1 / max_mz) * (ref**2 / width))
+
+        assert _bin_count(AxisType.FTICR, width, ref, min_mz, max_mz) == expected
+
+    def test_fticr_differs_from_the_uniform_count(self):
+        """The regression this guards had FT-ICR share the constant count."""
+        min_mz, max_mz, width, ref = 100.0, 2000.0, 0.005, 1000.0
+
+        fticr = _bin_count(AxisType.FTICR, width, ref, min_mz, max_mz)
+        constant = _bin_count(AxisType.CONSTANT, width, ref, min_mz, max_mz)
+
+        assert fticr != constant
+
+    def test_orbitrap_includes_the_factor_of_two(self):
+        """bins = 2 * (1/sqrt(min) - 1/sqrt(max)) * (reference_mz^1.5 / width)."""
+        min_mz, max_mz, width, ref = 100.0, 2000.0, 0.005, 1000.0
+        expected = int(
+            2 * (1 / np.sqrt(min_mz) - 1 / np.sqrt(max_mz)) * (ref**1.5 / width)
+        )
+
+        assert _bin_count(AxisType.ORBITRAP, width, ref, min_mz, max_mz) == expected
+
+    @pytest.mark.parametrize("axis_type", ALL_AXIS_TYPES)
+    def test_bin_count_is_floored_at_100(self, axis_type):
+        """A width wider than the whole range must still give a usable axis."""
+        assert _bin_count(axis_type, 5000.0, 1000.0, 100.0, 2000.0) == 100
+
+    @pytest.mark.parametrize("axis_type", ALL_AXIS_TYPES)
+    def test_narrower_width_gives_more_bins(self, axis_type):
+        wide = _bin_count(axis_type, 0.01, 1000.0, 100.0, 2000.0)
+        narrow = _bin_count(axis_type, 0.001, 1000.0, 100.0, 2000.0)
+
+        assert narrow > wide
+
+
+class TestDefaultWidths:
+    """With no explicit width, axis-type-specific defaults apply."""
+
+    def test_linear_tof_defaults_to_17_mda_at_300(self):
+        """The SCiLS Lab convention for FlexImaging data."""
+        stub = SimpleNamespace(_width_at_mz=None, _reference_mz=1000.0)
+        bins = BaseSpatialDataConverter._calculate_bins_from_width(
+            stub, 100.0, 2000.0, AxisType.LINEAR_TOF
+        )
+        expected = _bin_count(AxisType.LINEAR_TOF, 0.017, 300.0, 100.0, 2000.0)
+
+        assert bins == expected
+
+    @pytest.mark.parametrize(
+        "axis_type",
+        [
+            AxisType.CONSTANT,
+            AxisType.REFLECTOR_TOF,
+            AxisType.ORBITRAP,
+            AxisType.FTICR,
+        ],
+    )
+    def test_other_axis_types_default_to_5_mda_at_1000(self, axis_type):
+        stub = SimpleNamespace(_width_at_mz=None, _reference_mz=300.0)
+        bins = BaseSpatialDataConverter._calculate_bins_from_width(
+            stub, 100.0, 2000.0, axis_type
+        )
+        expected = _bin_count(axis_type, 0.005, 1000.0, 100.0, 2000.0)
+
+        assert bins == expected

--- a/tests/unit/converters/test_resampling_config_normalization.py
+++ b/tests/unit/converters/test_resampling_config_normalization.py
@@ -1,0 +1,189 @@
+# tests/unit/converters/test_resampling_config_normalization.py
+"""Tests for normalising a ``resampling_config`` dict into ResamplingConfig.
+
+The CLI is protected by ``click.Choice``, so bad method and axis-type
+values can only arrive through the Python API. They used to be dropped
+silently, which produced a conversion that ignored the caller's request
+without reporting anything.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    _normalize_resampling_config,
+)
+from thyra.resampling.types import (
+    DEFAULT_REFERENCE_MZ,
+    AxisType,
+    ResamplingConfig,
+    ResamplingMethod,
+)
+
+
+class TestRecognisedValues:
+    """Accepted spellings must resolve to the matching enum member."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("nearest_neighbor", ResamplingMethod.NEAREST_NEIGHBOR),
+            ("tic_preserving", ResamplingMethod.TIC_PRESERVING),
+        ],
+    )
+    def test_method_strings(self, name, expected):
+        assert _normalize_resampling_config({"method": name}).method is expected
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("constant", AxisType.CONSTANT),
+            ("linear_tof", AxisType.LINEAR_TOF),
+            ("reflector_tof", AxisType.REFLECTOR_TOF),
+            ("orbitrap", AxisType.ORBITRAP),
+            ("fticr", AxisType.FTICR),
+        ],
+    )
+    def test_axis_type_strings(self, name, expected):
+        assert _normalize_resampling_config({"axis_type": name}).axis_type is expected
+
+    def test_enum_members_pass_through(self):
+        config = _normalize_resampling_config(
+            {
+                "method": ResamplingMethod.TIC_PRESERVING,
+                "axis_type": AxisType.FTICR,
+            }
+        )
+
+        assert config.method is ResamplingMethod.TIC_PRESERVING
+        assert config.axis_type is AxisType.FTICR
+
+    @pytest.mark.parametrize("sentinel", ["auto", "", None])
+    def test_auto_sentinels_mean_autodetect(self, sentinel):
+        config = _normalize_resampling_config(
+            {"method": sentinel, "axis_type": sentinel}
+        )
+
+        assert config.method is None
+        assert config.axis_type is None
+
+    def test_missing_keys_mean_autodetect(self):
+        config = _normalize_resampling_config({})
+
+        assert config.method is None
+        assert config.axis_type is None
+
+    def test_dataclass_is_returned_unchanged(self):
+        original = ResamplingConfig(method=ResamplingMethod.NEAREST_NEIGHBOR)
+
+        assert _normalize_resampling_config(original) is original
+
+
+class TestUnrecognisedValues:
+    """Unknown values must raise, not fall back to auto-detection."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "tic_preserving ",  # stray trailing space
+            " tic_preserving",
+            "TIC_PRESERVING",  # wrong case
+            "tic-preserving",  # wrong separator
+            "nearest",  # truncated
+            "linear_interpolation",  # advertised once, never implemented
+            "none",
+            "typo",
+        ],
+    )
+    def test_unknown_method_raises(self, bad):
+        with pytest.raises(ValueError, match="method"):
+            _normalize_resampling_config({"method": bad})
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "fticr ",
+            "FTICR",
+            "ft-icr",
+            "tof",
+            "unknown",  # enum member exists but has no axis generator
+            "typo",
+        ],
+    )
+    def test_unknown_axis_type_raises(self, bad):
+        with pytest.raises(ValueError, match="axis_type"):
+            _normalize_resampling_config({"axis_type": bad})
+
+    def test_error_names_the_valid_values(self):
+        with pytest.raises(ValueError) as excinfo:
+            _normalize_resampling_config({"method": "typo"})
+
+        message = str(excinfo.value)
+        assert "'auto'" in message
+        assert "'nearest_neighbor'" in message
+        assert "'tic_preserving'" in message
+
+    def test_error_names_the_offending_value(self):
+        with pytest.raises(ValueError, match="tic_preserving "):
+            _normalize_resampling_config({"method": "tic_preserving "})
+
+    def test_unimplemented_method_enum_raises(self):
+        """ResamplingMethod.NONE has no strategy behind it.
+
+        Passing it used to reach the dense path and silently perform
+        TIC-preserving resampling. Callers who want no resampling pass
+        ``resampling_config=None`` instead.
+        """
+        with pytest.raises(ValueError, match="method"):
+            _normalize_resampling_config({"method": ResamplingMethod.NONE})
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(ValueError, match="method"):
+            _normalize_resampling_config({"method": 3})
+
+    def test_axis_type_enum_without_a_generator_raises(self):
+        with pytest.raises(ValueError, match="axis_type"):
+            _normalize_resampling_config({"axis_type": AxisType.UNKNOWN})
+
+
+class TestReferenceMz:
+    """The dict path and the dataclass must agree on the default."""
+
+    def test_default_matches_the_dataclass_default(self):
+        assert _normalize_resampling_config({}).reference_mz == (
+            ResamplingConfig().reference_mz
+        )
+
+    def test_default_is_the_documented_cli_default(self):
+        assert ResamplingConfig().reference_mz == 1000.0
+        assert DEFAULT_REFERENCE_MZ == 1000.0
+
+    def test_explicit_value_wins(self):
+        assert (
+            _normalize_resampling_config({"reference_mz": 250.0}).reference_mz == 250.0
+        )
+
+    def test_explicit_value_is_coerced_to_float(self):
+        config = _normalize_resampling_config({"reference_mz": 500})
+
+        assert isinstance(config.reference_mz, float)
+        assert config.reference_mz == 500.0
+
+
+class TestOtherFields:
+    """The remaining keys are passed through by name."""
+
+    def test_width_at_mz_maps_to_mass_width_da(self):
+        config = _normalize_resampling_config({"width_at_mz": 0.01})
+
+        assert config.mass_width_da == 0.01
+
+    def test_range_and_bins_pass_through(self):
+        config = _normalize_resampling_config(
+            {"target_bins": 4096, "min_mz": 300.0, "max_mz": 900.0}
+        )
+
+        assert config.target_bins == 4096
+        assert config.min_mz == 300.0
+        assert config.max_mz == 900.0

--- a/tests/unit/resampling/test_basic_structure.py
+++ b/tests/unit/resampling/test_basic_structure.py
@@ -41,7 +41,7 @@ class TestBasicImports:
         """Test dataclasses can be created."""
         config = ResamplingConfig(target_bins=300000)
         assert config.target_bins == 300000
-        assert config.reference_mz == 500.0  # default
+        assert config.reference_mz == 1000.0  # default, matches the CLI default
 
     def test_resampling_config_with_axis_type(self):
         """Test ResamplingConfig can be created with axis_type field."""

--- a/tests/unit/resampling/test_mass_axis_generators.py
+++ b/tests/unit/resampling/test_mass_axis_generators.py
@@ -20,6 +20,14 @@ import numpy as np
 import pytest
 
 from thyra.resampling.common_axis import CommonAxisBuilder
+from thyra.resampling.mass_axis import (
+    BaseAxisGenerator,
+    FTICRAxisGenerator,
+    LinearAxisGenerator,
+    LinearTOFAxisGenerator,
+    OrbitrapAxisGenerator,
+    ReflectorTOFAxisGenerator,
+)
 from thyra.resampling.types import AxisType
 
 # Every axis type reachable through build_physics_axis, with the exponent
@@ -30,6 +38,14 @@ AXIS_TYPES = [
     (AxisType.REFLECTOR_TOF, 1.0),
     (AxisType.ORBITRAP, 1.5),
     (AxisType.FTICR, 2.0),
+]
+
+GENERATORS = [
+    LinearAxisGenerator,
+    LinearTOFAxisGenerator,
+    ReflectorTOFAxisGenerator,
+    OrbitrapAxisGenerator,
+    FTICRAxisGenerator,
 ]
 
 MIN_MZ = 100.0
@@ -100,4 +116,95 @@ class TestSpacingLaw:
         assert observed == pytest.approx(expected, rel=0.02), (
             f"{axis_type.value}: width ratio {observed:.4f} does not match "
             f"the expected (m2/m1)^{exponent} = {expected:.4f}"
+        )
+
+
+class TestGeneratorInterface:
+    """All generators share one interface, and it is the one in use."""
+
+    @pytest.mark.parametrize("generator_cls", GENERATORS, ids=lambda c: c.__name__)
+    def test_is_concrete(self, generator_cls):
+        """Nothing abstract may be left unimplemented."""
+        assert isinstance(generator_cls(), BaseAxisGenerator)
+
+    @pytest.mark.parametrize("generator_cls", GENERATORS, ids=lambda c: c.__name__)
+    def test_accepts_the_unified_signature(self, generator_cls):
+        """Every generator takes the reference parameters, used or not.
+
+        LinearAxisGenerator used to take three arguments while the physics
+        generators took five, forcing build_physics_axis to branch on the
+        axis type before calling.
+        """
+        axis = generator_cls().generate_axis(MIN_MZ, MAX_MZ, 1000, REFERENCE_MZ, 0.01)
+
+        assert len(axis.mz_values) > 0
+
+    @pytest.mark.parametrize("generator_cls", GENERATORS, ids=lambda c: c.__name__)
+    def test_reported_axis_type_matches_what_is_produced(self, generator_cls):
+        generator = generator_cls()
+
+        axis = generator.generate_axis(MIN_MZ, MAX_MZ, 1000)
+
+        assert axis.axis_type == generator.get_axis_type()
+
+    @pytest.mark.parametrize("removed", ["generate_axis_bins", "generate_axis_width"])
+    @pytest.mark.parametrize("generator_cls", GENERATORS, ids=lambda c: c.__name__)
+    def test_dead_parallel_api_stays_gone(self, generator_cls, removed):
+        """Guard against the unused width/bins pair coming back.
+
+        These were a second, never-called route from a target width to an
+        axis. Nothing reached them, so they drifted: the FT-ICR variant
+        computed its step as ``k / width_da`` instead of ``k``, two of them
+        returned descending axes, and the Linear TOF one assigned its step
+        twice. Width-driven sizing goes through
+        ``_calculate_bins_from_width`` instead.
+        """
+        assert not hasattr(generator_cls(), removed)
+
+
+class TestWidthPrediction:
+    """calculate_width_at_mz must agree with the axis actually built.
+
+    This cross-checks the two independent expressions of each spacing law
+    against each other: the closed-form width prediction, and the width the
+    generated axis realizes once the bin count is derived from the physics.
+    """
+
+    PREDICTORS = [
+        (LinearTOFAxisGenerator, AxisType.LINEAR_TOF),
+        (ReflectorTOFAxisGenerator, AxisType.REFLECTOR_TOF),
+        (OrbitrapAxisGenerator, AxisType.ORBITRAP),
+        (FTICRAxisGenerator, AxisType.FTICR),
+    ]
+
+    @pytest.mark.parametrize(
+        "generator_cls,axis_type", PREDICTORS, ids=lambda v: getattr(v, "__name__", v)
+    )
+    @pytest.mark.parametrize("probe_mz", [300.0, 700.0, 1500.0])
+    def test_prediction_matches_realized_width(
+        self, generator_cls, axis_type, probe_mz
+    ):
+        from types import SimpleNamespace
+
+        from thyra.converters.spatialdata.base_spatialdata_converter import (
+            BaseSpatialDataConverter,
+        )
+
+        stub = SimpleNamespace(_width_at_mz=WIDTH_AT_REF, _reference_mz=REFERENCE_MZ)
+        bins = BaseSpatialDataConverter._calculate_bins_from_width(
+            stub, MIN_MZ, MAX_MZ, axis_type
+        )
+        mz = _build(axis_type, bins).mz_values
+        widths = np.diff(mz)
+        centres = (mz[:-1] + mz[1:]) / 2
+        realized = widths[int(np.argmin(np.abs(centres - probe_mz)))]
+
+        predicted = generator_cls().calculate_width_at_mz(
+            probe_mz, REFERENCE_MZ, WIDTH_AT_REF
+        )
+
+        assert realized == pytest.approx(predicted, rel=0.03), (
+            f"{axis_type.value} at m/z {probe_mz}: axis realizes "
+            f"{realized*1000:.4f} mDa but calculate_width_at_mz predicts "
+            f"{predicted*1000:.4f} mDa"
         )

--- a/tests/unit/resampling/test_mass_axis_generators.py
+++ b/tests/unit/resampling/test_mass_axis_generators.py
@@ -1,0 +1,103 @@
+# tests/unit/resampling/test_mass_axis_generators.py
+"""Contract tests for the physics-based mass axis generators.
+
+Every generator feeds ``CommonAxisBuilder.build_physics_axis``, whose
+output is assigned directly to the converter's common mass axis. Two
+things therefore have to hold for all of them:
+
+  * the axis is in ascending m/z order (``np.searchsorted`` binning and
+    the stored ``var["mz"]`` column both assume increasing m/z), and
+  * bin width scales with m/z as the analyser's physics dictates.
+
+Anchoring that spacing law so the width at ``reference_mz`` is the width
+the caller asked for is the bin-count calculation's job, and is covered
+by ``tests/unit/converters/test_bin_count_from_width.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from thyra.resampling.common_axis import CommonAxisBuilder
+from thyra.resampling.types import AxisType
+
+# Every axis type reachable through build_physics_axis, with the exponent
+# p in bin_width ∝ (m/z)^p that defines its spacing law.
+AXIS_TYPES = [
+    (AxisType.CONSTANT, 0.0),
+    (AxisType.LINEAR_TOF, 0.5),
+    (AxisType.REFLECTOR_TOF, 1.0),
+    (AxisType.ORBITRAP, 1.5),
+    (AxisType.FTICR, 2.0),
+]
+
+MIN_MZ = 100.0
+MAX_MZ = 2000.0
+REFERENCE_MZ = 1000.0
+WIDTH_AT_REF = 0.005  # 5 mDa, the converter's default for most axis types
+
+
+def _build(axis_type, num_bins, reference_mz=REFERENCE_MZ, width=WIDTH_AT_REF):
+    return CommonAxisBuilder().build_physics_axis(
+        min_mz=MIN_MZ,
+        max_mz=MAX_MZ,
+        num_bins=num_bins,
+        axis_type=axis_type,
+        reference_mz=reference_mz,
+        reference_width=width,
+    )
+
+
+class TestAxisOrdering:
+    """Generated axes must be ascending in m/z."""
+
+    @pytest.mark.parametrize("axis_type,_p", AXIS_TYPES)
+    def test_axis_is_ascending(self, axis_type, _p):
+        mz = _build(axis_type, 5000).mz_values
+
+        assert np.all(np.diff(mz) > 0), (
+            f"{axis_type.value} axis is not strictly ascending; "
+            f"first={mz[0]}, last={mz[-1]}"
+        )
+
+    @pytest.mark.parametrize("axis_type,_p", AXIS_TYPES)
+    def test_axis_spans_requested_range(self, axis_type, _p):
+        axis = _build(axis_type, 5000)
+        mz = axis.mz_values
+
+        # Bin-centre conventions mean the ends can sit up to one bin
+        # inside the requested range, but not outside it and not far in.
+        span = MAX_MZ - MIN_MZ
+        assert MIN_MZ - 0.01 <= mz[0] < MIN_MZ + 0.01 * span
+        assert MAX_MZ - 0.01 * span < mz[-1] <= MAX_MZ + 0.01
+        assert axis.min_mz == pytest.approx(float(mz[0]))
+        assert axis.max_mz == pytest.approx(float(mz[-1]))
+
+    @pytest.mark.parametrize("axis_type,_p", AXIS_TYPES)
+    def test_bin_widths_are_positive(self, axis_type, _p):
+        widths = np.diff(_build(axis_type, 5000).mz_values)
+
+        assert np.all(widths > 0)
+
+
+class TestSpacingLaw:
+    """Bin width must scale with m/z as the analyser physics dictates."""
+
+    @pytest.mark.parametrize("axis_type,exponent", AXIS_TYPES)
+    def test_width_ratio_matches_exponent(self, axis_type, exponent):
+        """width(m2) / width(m1) must be (m2/m1)^p."""
+        mz = _build(axis_type, 200000).mz_values
+        widths = np.diff(mz)
+        centres = (mz[:-1] + mz[1:]) / 2
+
+        low = int(np.argmin(np.abs(centres - 300.0)))
+        high = int(np.argmin(np.abs(centres - 1500.0)))
+
+        observed = widths[high] / widths[low]
+        expected = (centres[high] / centres[low]) ** exponent
+
+        assert observed == pytest.approx(expected, rel=0.02), (
+            f"{axis_type.value}: width ratio {observed:.4f} does not match "
+            f"the expected (m2/m1)^{exponent} = {expected:.4f}"
+        )

--- a/tests/unit/test_cli_exit_status.py
+++ b/tests/unit/test_cli_exit_status.py
@@ -1,0 +1,136 @@
+# tests/unit/test_cli_exit_status.py
+"""Tests for the exit status the ``thyra`` command reports to the shell.
+
+A conversion that fails must not look like a success to a calling script
+or CI job, and it must not leave an unreadable store sitting at the
+destination path where it can be mistaken for a finished conversion.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from thyra.__main__ import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _invoke(runner, imzml_path, output_path, *extra):
+    return runner.invoke(
+        main,
+        [str(imzml_path), str(output_path), "--pixel-size", "1.0", *extra],
+    )
+
+
+class TestExitStatus:
+    """The process exit code must track conversion success."""
+
+    def test_failed_conversion_exits_nonzero(
+        self, create_minimal_imzml, temp_dir, monkeypatch, runner
+    ):
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+
+        monkeypatch.setattr("thyra.__main__.convert_msi", lambda *a, **k: False)
+
+        result = _invoke(runner, imzml_path, output_path)
+
+        assert result.exit_code != 0, (
+            "a failed conversion must report a non-zero exit status; "
+            f"got {result.exit_code}"
+        )
+
+    def test_successful_conversion_exits_zero(
+        self, create_minimal_imzml, temp_dir, monkeypatch, runner
+    ):
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+
+        monkeypatch.setattr("thyra.__main__.convert_msi", lambda *a, **k: True)
+
+        result = _invoke(runner, imzml_path, output_path)
+
+        assert result.exit_code == 0, result.output
+
+    def test_real_failing_conversion_exits_one(self, temp_dir, runner):
+        """End-to-end: an undetectable input format must exit 1.
+
+        ``convert_msi`` catches the format-detection error and returns
+        False, so this exercises the real CLI path rather than a
+        monkeypatched stub. Exit code 1 rather than click's 2 confirms the
+        failure came from the conversion, not from argument parsing.
+        """
+        unknown_input = temp_dir / "not_an_msi_file.txt"
+        unknown_input.write_text("not MSI data")
+        output_path = temp_dir / "out.zarr"
+
+        result = _invoke(runner, unknown_input, output_path)
+
+        assert result.exit_code == 1, result.output
+
+
+class TestPartialOutputQuarantine:
+    """A failed conversion must not leave an unreadable store in place."""
+
+    def test_partial_output_is_moved_aside(
+        self, create_minimal_imzml, temp_dir, monkeypatch, runner
+    ):
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+
+        def fake_convert(*_args, **_kwargs):
+            # Stand in for a conversion that dies part-way through the
+            # zarr write, leaving an incomplete store behind.
+            output_path.mkdir(parents=True)
+            (output_path / "zarr.json").write_text("{}")
+            return False
+
+        monkeypatch.setattr("thyra.__main__.convert_msi", fake_convert)
+
+        result = _invoke(runner, imzml_path, output_path)
+
+        assert result.exit_code != 0
+        assert not output_path.exists(), (
+            "the destination path must be cleared so the partial store "
+            "cannot be mistaken for a finished conversion"
+        )
+        assert (temp_dir / "out.zarr.failed").is_dir()
+
+    def test_quarantine_does_not_overwrite_an_earlier_failure(
+        self, create_minimal_imzml, temp_dir, monkeypatch, runner
+    ):
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+        (temp_dir / "out.zarr.failed").mkdir()
+
+        def fake_convert(*_args, **_kwargs):
+            output_path.mkdir(parents=True)
+            return False
+
+        monkeypatch.setattr("thyra.__main__.convert_msi", fake_convert)
+
+        result = _invoke(runner, imzml_path, output_path)
+
+        assert result.exit_code != 0
+        assert not output_path.exists()
+        assert (temp_dir / "out.zarr.failed2").is_dir()
+
+    def test_nothing_to_quarantine_is_not_an_error(
+        self, create_minimal_imzml, temp_dir, monkeypatch, runner
+    ):
+        """Failing before anything is written must still exit non-zero."""
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+
+        monkeypatch.setattr("thyra.__main__.convert_msi", lambda *a, **k: False)
+
+        result = _invoke(runner, imzml_path, output_path)
+
+        assert result.exit_code != 0
+        assert not output_path.exists()
+        assert not (temp_dir / "out.zarr.failed").exists()
+        assert result.exception is None or isinstance(result.exception, SystemExit)

--- a/tests/unit/test_cli_exit_status.py
+++ b/tests/unit/test_cli_exit_status.py
@@ -134,3 +134,22 @@ class TestPartialOutputQuarantine:
         assert not output_path.exists()
         assert not (temp_dir / "out.zarr.failed").exists()
         assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+class TestVersionOption:
+    """``thyra --version`` must report the installed package version."""
+
+    def test_version_flag_reports_package_version(self, runner):
+        from thyra import __version__
+
+        result = runner.invoke(main, ["--version"])
+
+        assert result.exit_code == 0
+        assert __version__ in result.output
+
+    def test_version_flag_does_not_require_arguments(self, runner):
+        """--version must work without INPUT and OUTPUT."""
+        result = runner.invoke(main, ["--version"])
+
+        assert result.exit_code == 0
+        assert "Missing argument" not in result.output

--- a/tests/unit/utils/test_windows_paths.py
+++ b/tests/unit/utils/test_windows_paths.py
@@ -1,0 +1,199 @@
+# tests/unit/utils/test_windows_paths.py
+"""Tests for extended-length output paths on Windows.
+
+A Zarr store's deepest key sits far below the path the caller named, so an
+output path well inside the 260 character Windows limit can still push an
+internal key past it. The path rewriting is pure string work and is tested
+on every platform; the end-to-end conversion is Windows-only.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from thyra.utils import windows_paths
+from thyra.utils.windows_paths import (
+    DEEPEST_KEY_RESERVE,
+    WINDOWS_MAX_PATH,
+    prepare_zarr_output_path,
+    projected_deepest_key_length,
+    to_extended_length_path,
+)
+
+EXTENDED_PREFIX = "\\\\?\\"
+
+
+class TestToExtendedLengthPath:
+    """Rewriting must produce syntax Windows actually accepts."""
+
+    def test_drive_path_gets_the_prefix(self):
+        result = to_extended_length_path(Path("C:\\data\\out.zarr"))
+
+        assert str(result) == "\\\\?\\C:\\data\\out.zarr"
+
+    def test_already_extended_path_is_unchanged(self):
+        original = Path("\\\\?\\C:\\data\\out.zarr")
+
+        assert str(to_extended_length_path(original)) == str(original)
+
+    def test_applying_twice_is_idempotent(self):
+        once = to_extended_length_path(Path("C:\\data\\out.zarr"))
+        twice = to_extended_length_path(once)
+
+        assert str(twice) == str(once)
+
+    def test_unc_share_uses_the_unc_spelling(self):
+        """A bare prefix on a UNC path is invalid syntax."""
+        result = to_extended_length_path(Path("\\\\server\\share\\out.zarr"))
+
+        assert str(result) == "\\\\?\\UNC\\server\\share\\out.zarr"
+        assert not str(result).startswith("\\\\?\\\\\\")
+
+
+class TestProjectedLength:
+    """The projection must account for the store's internal depth."""
+
+    def test_includes_the_dataset_id_and_reserve(self):
+        out = Path("C:\\data\\out.zarr")
+
+        projected = projected_deepest_key_length(out, "msi_dataset")
+
+        assert projected == len(str(out)) + 1 + len("msi_dataset") + DEEPEST_KEY_RESERVE
+
+    def test_longer_dataset_id_projects_further(self):
+        out = Path("C:\\data\\out.zarr")
+
+        short = projected_deepest_key_length(out, "ds")
+        long = projected_deepest_key_length(out, "a_much_longer_dataset_id")
+
+        assert long > short
+
+    def test_reserve_covers_the_observed_deepest_key(self):
+        """The deepest key measured in a real conversion was 95 characters
+        below the store root, excluding the dataset id."""
+        assert DEEPEST_KEY_RESERVE >= 95
+
+
+class TestPrepareZarrOutputPath:
+    """The prefix must appear only when it is needed."""
+
+    @pytest.fixture
+    def on_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(windows_paths, "_long_paths_enabled", lambda: False)
+
+    def _long_path(self, dataset_id="msi_dataset"):
+        """A path just long enough to need the prefix."""
+        needed = WINDOWS_MAX_PATH - DEEPEST_KEY_RESERVE - len(dataset_id)
+        return Path("C:\\" + "d" * (needed + 10))
+
+    def _short_path(self):
+        return Path("C:\\data\\out.zarr")
+
+    def test_short_path_is_untouched_on_windows(self, on_windows):
+        out = self._short_path()
+
+        assert prepare_zarr_output_path(out, "msi_dataset") == out
+
+    def test_long_path_is_extended_on_windows(self, on_windows):
+        out = self._long_path()
+
+        result = prepare_zarr_output_path(out, "msi_dataset")
+
+        assert str(result).startswith(EXTENDED_PREFIX)
+        assert str(result).endswith(str(out))
+
+    def test_no_op_off_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        out = self._long_path()
+
+        assert prepare_zarr_output_path(out, "msi_dataset") == out
+
+    def test_no_op_when_long_paths_are_enabled(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(windows_paths, "_long_paths_enabled", lambda: True)
+        out = self._long_path()
+
+        assert prepare_zarr_output_path(out, "msi_dataset") == out
+
+    def test_the_registry_is_only_consulted_when_needed(self, monkeypatch):
+        """A short path must not pay for a registry read."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        calls = {"n": 0}
+
+        def counting():
+            calls["n"] += 1
+            return False
+
+        monkeypatch.setattr(windows_paths, "_long_paths_enabled", counting)
+
+        prepare_zarr_output_path(self._short_path(), "msi_dataset")
+
+        assert calls["n"] == 0
+
+    def test_a_longer_dataset_id_can_tip_a_path_over(self, on_windows):
+        """The dataset id is part of the deepest key, so it matters."""
+        dataset_id = "a" * 60
+        needed = WINDOWS_MAX_PATH - DEEPEST_KEY_RESERVE
+        out = Path("C:\\" + "d" * (needed - 30))
+
+        with_short = prepare_zarr_output_path(out, "ds")
+        with_long = prepare_zarr_output_path(out, dataset_id)
+
+        assert not str(with_short).startswith(EXTENDED_PREFIX)
+        assert str(with_long).startswith(EXTENDED_PREFIX)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows path limit only")
+class TestLongPathConversion:
+    """End to end: a store deeper than MAX_PATH must still convert."""
+
+    def test_conversion_succeeds_past_the_limit(self):
+        from thyra.convert import convert_msi
+
+        base = Path(tempfile.mkdtemp())
+        try:
+            deep = base
+            while len(str(deep)) < 175:
+                deep = deep / "nested_directory_segment"
+                deep.mkdir(exist_ok=True)
+
+            src = base / "src"
+            src.mkdir()
+            imzml = self._write_imzml(src)
+
+            out = deep / "out.zarr"
+            assert len(str(out)) > 165, "path must be long enough to matter"
+
+            assert convert_msi(
+                str(imzml), str(out), dataset_id="msi_dataset", pixel_size_um=2.5
+            ), "a long output path must not fail the conversion"
+
+            import spatialdata as sd
+
+            sdata = sd.read_zarr(EXTENDED_PREFIX + str(out))
+            assert "msi_dataset_z0" in sdata.tables
+            assert len(sdata.images) >= 1
+        finally:
+            # rmtree itself trips the limit without the prefix.
+            shutil.rmtree(EXTENDED_PREFIX + str(base), ignore_errors=True)
+
+    @staticmethod
+    def _write_imzml(directory: Path) -> Path:
+        import numpy as np
+        from pyimzml.ImzMLWriter import ImzMLWriter
+
+        path = directory / "minimal.imzML"
+        mzs = np.linspace(100, 1000, 50)
+        with ImzMLWriter(str(path), mode="processed") as writer:
+            for x, y, z in [(1, 1, 1), (1, 2, 1), (2, 1, 1), (2, 2, 1)]:
+                intensities = np.zeros_like(mzs)
+                intensities[10] = 100.0 * x
+                intensities[30] = 150.0 * y
+                writer.addSpectrum(mzs, intensities, (x, y, z))
+        return path

--- a/tests/unit/utils/test_zarr_atomic_write.py
+++ b/tests/unit/utils/test_zarr_atomic_write.py
@@ -1,0 +1,328 @@
+# tests/unit/utils/test_zarr_atomic_write.py
+"""Tests for the bounded retry around Zarr's atomic metadata writes.
+
+The failure being guarded against is Windows-only, but the retry logic
+itself is plain Python and is tested on every platform by injecting the
+errors rather than racing for them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from thyra.utils import zarr_atomic_write
+from thyra.utils.zarr_atomic_write import (
+    _is_transient,
+    _move_with_retry,
+    install_windows_atomic_write_retry,
+)
+
+
+def _unwrapped_stub(*_args, **_kwargs):
+    """Stand-in for an unpatched zarr._atomic_write."""
+    raise AssertionError("should not be called")
+
+
+def _oserror(winerror: int | None) -> OSError:
+    """Build an OSError shaped like the one MoveFileEx failures produce."""
+    error = OSError("Access is denied")
+    if winerror is not None:
+        error.winerror = winerror  # type: ignore[attr-defined]
+    return error
+
+
+class TestIsTransient:
+    """Only a busy destination counts as retryable."""
+
+    @pytest.mark.parametrize("winerror", [5, 32])
+    def test_busy_destination_is_transient(self, winerror):
+        assert _is_transient(_oserror(winerror)) is True
+
+    @pytest.mark.parametrize("winerror", [2, 3, 13, 183, None])
+    def test_other_errors_are_not_transient(self, winerror):
+        assert _is_transient(_oserror(winerror)) is False
+
+
+class TestMoveWithRetry:
+    """A move blocked by a transient lock must be retried, then give up."""
+
+    def test_succeeds_without_retry_when_the_move_works(self):
+        calls = []
+
+        _move_with_retry(Path("src"), Path("dst"), lambda s, d: calls.append((s, d)))
+
+        assert calls == [(Path("src"), Path("dst"))]
+
+    @pytest.mark.parametrize("failures_before_success", [1, 2, 3])
+    def test_recovers_after_transient_failures(self, failures_before_success):
+        attempts = {"n": 0}
+
+        def flaky(src, dst):
+            attempts["n"] += 1
+            if attempts["n"] <= failures_before_success:
+                raise _oserror(5)
+
+        _move_with_retry(Path("src"), Path("dst"), flaky)
+
+        assert attempts["n"] == failures_before_success + 1
+
+    def test_gives_up_after_a_bounded_number_of_attempts(self):
+        attempts = {"n": 0}
+
+        def always_locked(src, dst):
+            attempts["n"] += 1
+            raise _oserror(5)
+
+        with pytest.raises(OSError) as excinfo:
+            _move_with_retry(Path("src"), Path("dst"), always_locked)
+
+        assert attempts["n"] == len(zarr_atomic_write._RETRY_DELAYS)
+        assert getattr(excinfo.value, "winerror", None) == 5
+
+    def test_non_transient_errors_are_not_retried(self):
+        attempts = {"n": 0}
+
+        def missing(src, dst):
+            attempts["n"] += 1
+            raise _oserror(2)  # ERROR_FILE_NOT_FOUND
+
+        with pytest.raises(OSError):
+            _move_with_retry(Path("src"), Path("dst"), missing)
+
+        assert attempts["n"] == 1, "a real error must surface immediately"
+
+    def test_retry_delays_are_bounded(self):
+        """Retries must not stall a conversion for long."""
+        assert sum(zarr_atomic_write._RETRY_DELAYS) < 1.0
+
+
+@pytest.fixture
+def pristine_zarr(monkeypatch):
+    """Restore zarr's real _atomic_write, and undo any install afterwards.
+
+    Earlier tests (or an earlier conversion in the same session) may have
+    already installed the shim, so capture and restore the exact object
+    rather than assuming it is unpatched.
+    """
+    import zarr.storage._local as zarr_local
+
+    saved = zarr_local._atomic_write
+    monkeypatch.setattr(zarr_atomic_write, "_installed", False, raising=False)
+    yield zarr_local
+    zarr_local._atomic_write = saved
+    zarr_atomic_write._installed = False
+
+
+class TestInstall:
+    """Installation must be idempotent and confined to Windows."""
+
+    def test_is_a_noop_off_windows(self, pristine_zarr, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        pristine_zarr._atomic_write = _unwrapped_stub
+        install_windows_atomic_write_retry()
+
+        assert pristine_zarr._atomic_write is _unwrapped_stub
+
+    def test_patches_zarr_on_windows(self, pristine_zarr, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        pristine_zarr._atomic_write = _unwrapped_stub
+
+        install_windows_atomic_write_retry()
+
+        assert (
+            getattr(pristine_zarr._atomic_write, "_thyra_retry_wrapped", False) is True
+        )
+
+    def test_repeated_installs_do_not_stack_wrappers(self, pristine_zarr, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        pristine_zarr._atomic_write = _unwrapped_stub
+
+        install_windows_atomic_write_retry()
+        first = pristine_zarr._atomic_write
+        zarr_atomic_write._installed = False
+        install_windows_atomic_write_retry()
+
+        assert pristine_zarr._atomic_write is first
+
+    def test_an_already_wrapped_zarr_is_left_alone(self, pristine_zarr, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        already = zarr_atomic_write.make_atomic_write_with_retry(lambda s, d: None)
+        pristine_zarr._atomic_write = already
+
+        install_windows_atomic_write_retry()
+
+        assert pristine_zarr._atomic_write is already
+
+    def test_missing_zarr_internals_leaves_zarr_alone(self, pristine_zarr, monkeypatch):
+        """A future Zarr that reworks _atomic_write must not be patched."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.delattr(pristine_zarr, "_atomic_write", raising=False)
+
+        install_windows_atomic_write_retry()
+
+        assert not hasattr(pristine_zarr, "_atomic_write")
+
+
+class TestPatchedWriteBehaviour:
+    """The replacement must behave like Zarr's own atomic write."""
+
+    @pytest.fixture
+    def real_move(self):
+        """Zarr's own non-clobbering move, for the exclusive path."""
+        import zarr.storage._local as zarr_local
+
+        return zarr_local._safe_move
+
+    @pytest.fixture
+    def patched(self, real_move):
+        return zarr_atomic_write.make_atomic_write_with_retry(real_move)
+
+    def test_writes_content_to_the_destination(self, patched, tmp_path):
+        target = tmp_path / "zarr.json"
+
+        with patched(target, "wb") as f:
+            f.write(b'{"zarr_format":3}')
+
+        assert target.read_bytes() == b'{"zarr_format":3}'
+
+    def test_replaces_existing_content(self, patched, tmp_path):
+        target = tmp_path / "zarr.json"
+        target.write_bytes(b"stale")
+
+        with patched(target, "wb") as f:
+            f.write(b"fresh")
+
+        assert target.read_bytes() == b"fresh"
+
+    def test_leaves_no_partial_file_behind(self, patched, tmp_path):
+        target = tmp_path / "zarr.json"
+
+        with patched(target, "wb") as f:
+            f.write(b"{}")
+
+        assert list(tmp_path.glob("*.partial")) == []
+
+    def test_partial_file_is_cleaned_up_when_the_body_raises(self, patched, tmp_path):
+        target = tmp_path / "zarr.json"
+
+        with pytest.raises(RuntimeError):
+            with patched(target, "wb") as f:
+                f.write(b"half")
+                raise RuntimeError("writer blew up")
+
+        assert list(tmp_path.glob("*.partial")) == []
+        assert not target.exists()
+
+    def test_exclusive_writes_use_the_non_clobbering_move(self, patched, tmp_path):
+        target = tmp_path / "zarr.json"
+
+        with patched(target, "wb", exclusive=True) as f:
+            f.write(b"fresh")
+
+        assert target.read_bytes() == b"fresh"
+
+    def test_exclusive_moves_also_retry(self, real_move, tmp_path):
+        """Zarr's non-clobbering move must get the same treatment."""
+        state = {"blocked": 1}
+
+        def flaky_safe_move(src, dst):
+            if state["blocked"]:
+                state["blocked"] -= 1
+                raise _oserror(5)
+            return real_move(src, dst)
+
+        write = zarr_atomic_write.make_atomic_write_with_retry(flaky_safe_move)
+        target = tmp_path / "zarr.json"
+
+        with write(target, "wb", exclusive=True) as f:
+            f.write(b"fresh")
+
+        assert target.read_bytes() == b"fresh"
+        assert state["blocked"] == 0, "the flaky move was never exercised"
+
+    def test_recovers_from_a_transient_lock_on_the_destination(
+        self, patched, tmp_path, monkeypatch
+    ):
+        """The end-to-end path: a blocked rename must still land."""
+        target = tmp_path / "zarr.json"
+        target.write_bytes(b"stale")
+
+        real_replace = Path.replace
+        state = {"blocked": 1}
+
+        def flaky_replace(self, dst):
+            if state["blocked"]:
+                state["blocked"] -= 1
+                raise _oserror(5)
+            return real_replace(self, dst)
+
+        monkeypatch.setattr(Path, "replace", flaky_replace)
+
+        with patched(target, "wb") as f:
+            f.write(b"fresh")
+
+        assert target.read_bytes() == b"fresh"
+        assert list(tmp_path.glob("*.partial")) == []
+        assert state["blocked"] == 0, "the flaky replace was never exercised"
+
+    def test_a_permanently_locked_destination_still_raises(
+        self, patched, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "zarr.json"
+
+        def always_locked(self, dst):
+            raise _oserror(5)
+
+        monkeypatch.setattr(Path, "replace", always_locked)
+
+        with pytest.raises(OSError):
+            with patched(target, "wb") as f:
+                f.write(b"fresh")
+
+        assert list(tmp_path.glob("*.partial")) == []
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only behaviour")
+class TestWiring:
+    """The retry has to be in place by the time a converter writes."""
+
+    def test_importing_thyra_does_not_patch_zarr(self):
+        """A library should not reach into another library on import."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import zarr.storage._local as z; import thyra; "
+                "print(getattr(z._atomic_write, '_thyra_retry_wrapped', False))",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.stdout.strip().endswith("False"), result.stdout
+
+    def test_constructing_a_converter_installs_the_retry(
+        self, create_minimal_imzml, temp_dir
+    ):
+        import zarr.storage._local as zarr_local
+
+        from thyra.converters.spatialdata.spatialdata_2d_converter import (
+            SpatialData2DConverter,
+        )
+        from thyra.readers.imzml import ImzMLReader
+
+        imzml_path, _, _, _ = create_minimal_imzml
+        reader = ImzMLReader(imzml_path)
+        try:
+            SpatialData2DConverter(
+                reader, temp_dir / "out.zarr", dataset_id="ds", pixel_size_um=2.5
+            )
+        finally:
+            reader.close()
+
+        assert getattr(zarr_local._atomic_write, "_thyra_retry_wrapped", False) is True

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -10,6 +10,7 @@ from typing import Literal, Optional  # noqa: E402
 
 import click  # noqa: E402
 
+from thyra import __version__  # noqa: E402
 from thyra.convert import convert_msi  # noqa: E402
 from thyra.utils.data_processors import optimize_zarr_chunks  # noqa: E402
 from thyra.utils.logging_config import setup_logging  # noqa: E402
@@ -422,6 +423,7 @@ class GroupedCommand(click.Command):
 
 
 @click.command(cls=GroupedCommand)
+@click.version_option(version=__version__, prog_name="thyra")
 @click.argument("input", type=click.Path(exists=True, path_type=Path))
 @click.argument("output", type=click.Path(path_type=Path))
 # -- Conversion --

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -276,6 +276,49 @@ def _parse_streaming_option(streaming: str) -> bool | Literal["auto"]:
     return "auto"
 
 
+def _quarantine_partial_output(output: Path) -> None:
+    """Move a partially written store aside after a failed conversion.
+
+    A conversion that fails part-way through writing leaves an
+    incomplete ``.zarr`` at the destination. That store cannot be opened
+    (``spatialdata.read_zarr()`` raises), but it looks like a plausible
+    artifact, and it also blocks a retry because the CLI refuses to write
+    to an existing path. Rename it to a sibling ``.failed`` path so the
+    destination is clear while the partial store remains available for
+    diagnosis.
+
+    The CLI validates that the output path does not exist before
+    converting, so anything present at this point was written by this
+    run and is safe to move.
+    """
+    if not output.exists():
+        return
+
+    quarantine = output.with_name(f"{output.name}.failed")
+    attempt = 1
+    while quarantine.exists():
+        attempt += 1
+        quarantine = output.with_name(f"{output.name}.failed{attempt}")
+
+    try:
+        output.rename(quarantine)
+    except OSError as e:
+        logger.error(
+            "The incomplete output was left at %s because it could not be "
+            "moved aside (%s). It will not open with "
+            "spatialdata.read_zarr(); delete it before retrying.",
+            output,
+            e,
+        )
+        return
+
+    logger.error(
+        "The incomplete output was moved to %s. It will not open with "
+        "spatialdata.read_zarr(); delete it once you no longer need it.",
+        quarantine,
+    )
+
+
 def _handle_post_conversion(
     success: bool,
     optimize_chunks: bool,
@@ -284,13 +327,14 @@ def _handle_post_conversion(
     dataset_id: str,
 ) -> None:
     """Handle chunk optimization and result logging after conversion."""
-    if success and optimize_chunks and format == "spatialdata":
-        optimize_zarr_chunks(str(output), f"tables/{dataset_id}/X")
-
     if success:
+        if optimize_chunks and format == "spatialdata":
+            optimize_zarr_chunks(str(output), f"tables/{dataset_id}/X")
         logger.info(f"Conversion completed successfully. Output stored at {output}")
-    else:
-        logger.error("Conversion failed.")
+        return
+
+    logger.error("Conversion failed.")
+    _quarantine_partial_output(output)
 
 
 class GroupedCommand(click.Command):
@@ -609,6 +653,11 @@ def main(
     )
 
     _handle_post_conversion(success, optimize_chunks, format, output, dataset_id)
+
+    # Surface failure to the shell: without this a script or CI wrapper
+    # calling `thyra` sees success even though nothing usable was written.
+    if not success:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 from .core.base_converter import PixelSizeSource
 from .core.registry import detect_format, get_converter_class, get_reader_class
+from .utils.windows_paths import prepare_zarr_output_path
 
 logger = logging.getLogger(__name__)
 
@@ -320,6 +321,11 @@ def convert_msi(
 
     if not _validate_paths(input_path, output_path):
         return False
+
+    # A Zarr store's deepest key sits far below the path the caller named,
+    # so a legal-looking output path can still blow the Windows 260
+    # character limit part-way through the write. No-op elsewhere.
+    output_path = prepare_zarr_output_path(output_path, dataset_id)
 
     # Merge region into reader_options if provided
     if region is not None:

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -18,6 +18,7 @@ from ...core.base_reader import BaseMSIReader
 from ...metadata.types import ComprehensiveMetadata, EssentialMetadata
 from ...resampling import ResamplingDecisionTree, ResamplingMethod
 from ...resampling.types import ResamplingConfig
+from ...utils.zarr_atomic_write import install_windows_atomic_write_retry
 from ._chunking import image_chunks
 
 logger = logging.getLogger(__name__)
@@ -270,6 +271,12 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 f"conflicts."
             )
             raise ImportError(error_msg)
+
+        # Every Zarr write below this point goes through Zarr's atomic
+        # rename, which on Windows intermittently loses a race against
+        # whatever else has the destination open. Idempotent and a no-op
+        # off Windows.
+        install_windows_atomic_write_retry()
 
         # Validate inputs
         if pixel_size_um <= 0:

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -43,6 +43,51 @@ def _suppress_upstream_warnings():
         yield
 
 
+def _resolve_config_enum(raw: Any, by_name: Dict[str, Any], key: str) -> Any:
+    """Resolve one resampling-config value to its enum member.
+
+    ``None``, ``"auto"`` and ``""`` all mean "decide this automatically"
+    and resolve to ``None``.
+
+    The CLI is protected by ``click.Choice``, but the Python API takes
+    whatever the caller passes. Reject anything unrecognised rather than
+    dropping it: silently treating ``"tic_preserving "`` or a typo as
+    "auto-detect" hands back a conversion that ignored the request
+    without saying so.
+
+    Args:
+        raw: The value as supplied by the caller.
+        by_name: Accepted string spellings mapped to enum members.
+        key: The config key, used in error messages.
+
+    Raises:
+        ValueError: If ``raw`` names no accepted value, or is neither a
+            string nor one of the accepted enum members.
+    """
+    if raw is None:
+        return None
+
+    valid = ", ".join(repr(name) for name in ["auto", *by_name])
+
+    if isinstance(raw, str):
+        if raw in ("auto", ""):
+            return None
+        if raw not in by_name:
+            raise ValueError(
+                f"Unknown resampling_config[{key!r}] value {raw!r}. "
+                f"Valid values are: {valid}."
+            )
+        return by_name[raw]
+
+    if raw in by_name.values():
+        return raw
+
+    raise ValueError(
+        f"Unsupported resampling_config[{key!r}] value {raw!r}. "
+        f"Pass one of {valid}, or the matching enum member."
+    )
+
+
 def _normalize_resampling_config(
     config: Union[Dict[str, Any], "ResamplingConfig"],
 ) -> "ResamplingConfig":
@@ -51,44 +96,43 @@ def _normalize_resampling_config(
     Accepts either a plain dict (as produced by _build_resampling_config in
     __main__.py) or an already-constructed ResamplingConfig dataclass and
     returns a ResamplingConfig in both cases.
+
+    Raises:
+        ValueError: If ``method`` or ``axis_type`` is not a recognised
+            value.
     """
     if isinstance(config, ResamplingConfig):
         return config
 
-    from ...resampling.types import AxisType
+    from ...resampling.types import DEFAULT_REFERENCE_MZ, AxisType
 
-    method_raw = config.get("method")
-    axis_type_raw = config.get("axis_type")
+    # Only the methods the resampling pipeline actually implements, and
+    # only the axis types CommonAxisBuilder has a generator for. These
+    # deliberately match the CLI's click.Choice lists.
+    method_by_name = {
+        "nearest_neighbor": ResamplingMethod.NEAREST_NEIGHBOR,
+        "tic_preserving": ResamplingMethod.TIC_PRESERVING,
+    }
+    axis_type_by_name = {
+        "constant": AxisType.CONSTANT,
+        "linear_tof": AxisType.LINEAR_TOF,
+        "reflector_tof": AxisType.REFLECTOR_TOF,
+        "orbitrap": AxisType.ORBITRAP,
+        "fticr": AxisType.FTICR,
+    }
 
-    method = None
-    if isinstance(method_raw, str) and method_raw not in ("auto", ""):
-        method_map = {
-            "nearest_neighbor": ResamplingMethod.NEAREST_NEIGHBOR,
-            "tic_preserving": ResamplingMethod.TIC_PRESERVING,
-        }
-        method = method_map.get(method_raw)
-    elif isinstance(method_raw, ResamplingMethod):
-        method = method_raw
-
-    axis_type = None
-    if isinstance(axis_type_raw, str) and axis_type_raw not in ("auto", ""):
-        axis_type_map = {
-            "constant": AxisType.CONSTANT,
-            "linear_tof": AxisType.LINEAR_TOF,
-            "reflector_tof": AxisType.REFLECTOR_TOF,
-            "orbitrap": AxisType.ORBITRAP,
-            "fticr": AxisType.FTICR,
-        }
-        axis_type = axis_type_map.get(axis_type_raw)
-    elif isinstance(axis_type_raw, AxisType):
-        axis_type = axis_type_raw
+    reference_mz = config.get("reference_mz")
 
     return ResamplingConfig(
-        method=method,
-        axis_type=axis_type,
+        method=_resolve_config_enum(config.get("method"), method_by_name, "method"),
+        axis_type=_resolve_config_enum(
+            config.get("axis_type"), axis_type_by_name, "axis_type"
+        ),
         target_bins=config.get("target_bins"),
         mass_width_da=config.get("width_at_mz"),
-        reference_mz=config.get("reference_mz", 1000.0),
+        reference_mz=(
+            DEFAULT_REFERENCE_MZ if reference_mz is None else float(reference_mz)
+        ),
         min_mz=config.get("min_mz"),
         max_mz=config.get("max_mz"),
     )

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -609,11 +609,27 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             bins = int((2.0 / k) * (np.sqrt(max_mz) - np.sqrt(min_mz)))
 
         elif axis_name == "orbitrap":
-            # ORBITRAP: width ∝ m/z^1.5
-            # For 1/sqrt spacing: bins ≈ (1/sqrt(min_mz) - 1/sqrt(max_mz)) *
-            # (reference_mz^1.5 / width_at_mz)
+            # ORBITRAP: bin_width = k * (m/z)^1.5 with k = width_at_mz /
+            # reference_mz^1.5. Integrating dm / w(m) over the range gives
+            #   bins = 2 * (1/sqrt(min_mz) - 1/sqrt(max_mz)) *
+            #          (reference_mz^1.5 / width_at_mz)
+            # The factor 2 comes from d(m^-0.5)/dm = -1/2 * m^-1.5 and was
+            # missing, which halved the bin count and made every bin twice
+            # the requested width.
             scaling_factor = (reference_mz**1.5) / width_at_mz
-            bins = int((1 / np.sqrt(min_mz) - 1 / np.sqrt(max_mz)) * scaling_factor)
+            bins = int(2 * (1 / np.sqrt(min_mz) - 1 / np.sqrt(max_mz)) * scaling_factor)
+
+        elif axis_name == "fticr":
+            # FTICR: width ∝ m/z^2, i.e. bin_width = k * (m/z)^2 with
+            # k = width_at_mz / reference_mz^2. FTICRAxisGenerator lays the
+            # axis out uniformly in 1/mz, so the bin count is the 1/mz span
+            # divided by the step k:
+            #   bins = (1/min_mz - 1/max_mz) * (reference_mz^2 / width_at_mz)
+            # Without this branch an FT-ICR axis took its bin count from the
+            # uniform formula below, so the realized width at reference_mz was
+            # not the width that was asked for.
+            scaling_factor = (reference_mz**2) / width_at_mz
+            bins = int((1 / min_mz - 1 / max_mz) * scaling_factor)
 
         else:
             # LINEAR/CONSTANT: uniform spacing

--- a/thyra/resampling/common_axis.py
+++ b/thyra/resampling/common_axis.py
@@ -96,13 +96,6 @@ class CommonAxisBuilder:
 
         generator = generator_map[axis_type]
 
-        if axis_type == AxisType.CONSTANT:
-            # LinearAxisGenerator has different signature
-            return generator.generate_axis(  # type: ignore[attr-defined, no-any-return]
-                min_mz, max_mz, num_bins
-            )
-        else:
-            # Physics generators support reference parameters
-            return generator.generate_axis(  # type: ignore[attr-defined, no-any-return]
-                min_mz, max_mz, num_bins, reference_mz, reference_width
-            )
+        return generator.generate_axis(
+            min_mz, max_mz, num_bins, reference_mz, reference_width
+        )

--- a/thyra/resampling/mass_axis/base_generator.py
+++ b/thyra/resampling/mass_axis/base_generator.py
@@ -1,61 +1,60 @@
 """Abstract base class for mass axis generators."""
 
 from abc import ABC, abstractmethod
-from typing import Any
 
-import numpy as np
-import numpy.typing as npt
+from ..types import AxisType, MassAxis
 
 
 class BaseAxisGenerator(ABC):
-    """Abstract base class for mass axis generators."""
+    """Abstract base class for mass axis generators.
+
+    A generator distributes ``target_bins`` bins across a mass range
+    according to one analyser's spacing law. It does not decide *how many*
+    bins to use: that comes from
+    ``BaseSpatialDataConverter._calculate_bins_from_width``, which
+    integrates ``1 / width(m)`` over the range so the width realized at
+    ``reference_mz`` is the width the caller asked for. Generators are
+    reached through :meth:`~thyra.resampling.common_axis.CommonAxisBuilder.build_physics_axis`.
+    """
 
     @abstractmethod
-    def generate_axis_bins(
-        self, min_mz: float, max_mz: float, num_bins: int
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate axis with fixed number of bins.
-
-        Parameters
-        ----------
-        min_mz : float
-            Minimum m/z value
-        max_mz : float
-            Maximum m/z value
-        num_bins : int
-            Number of bins to generate
-
-        Returns
-        -------
-        np.ndarray
-            Generated mass axis
-        """
-        pass
-
-    @abstractmethod
-    def generate_axis_width(
+    def generate_axis(
         self,
         min_mz: float,
         max_mz: float,
-        width_da: float,
-        reference_mz: float = 500.0,
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate axis based on mass width at reference m/z using analyzer physics.
+        target_bins: int,
+        reference_mz: float = 1000.0,
+        reference_width: float = 0.005,
+    ) -> MassAxis:
+        """Distribute ``target_bins`` bins across the mass range.
+
+        The returned axis must be in ascending m/z order: it is assigned
+        directly to the converter's common mass axis, where downstream
+        binning and the stored ``var["mz"]`` column both require increasing
+        m/z.
 
         Parameters
         ----------
         min_mz : float
-            Minimum m/z value
+            Minimum m/z value.
         max_mz : float
-            Maximum m/z value
-        width_da : float
-            Mass width in Da at reference m/z
+            Maximum m/z value.
+        target_bins : int
+            Number of bins to distribute.
         reference_mz : float
-            Reference m/z for width specification
+            Reference m/z the bin count was anchored to. Implementations
+            that need only the bin count to realize their spacing law may
+            ignore this.
+        reference_width : float
+            Bin width requested at ``reference_mz``. May likewise be
+            ignored when the bin count already determines the spacing.
 
         Returns
         -------
-        np.ndarray
-            Generated mass axis with physics-based spacing
+        MassAxis
+            The generated axis, ascending in m/z.
         """
-        pass
+
+    @abstractmethod
+    def get_axis_type(self) -> AxisType:
+        """Return the axis type this generator produces."""

--- a/thyra/resampling/mass_axis/fticr_generator.py
+++ b/thyra/resampling/mass_axis/fticr_generator.py
@@ -56,8 +56,12 @@ class FTICRAxisGenerator(BaseAxisGenerator):
         inv_max = 1.0 / max_mz
         # inv_range = inv_min - inv_max  # Note: min > max in 1/mz space
 
-        # Create uniform grid in 1/mz space
-        inv_values = np.linspace(inv_max, inv_min, target_bins + 1)
+        # Create uniform grid in 1/mz space. Walk 1/mz downwards, from
+        # 1/min_mz to 1/max_mz, so the resulting m/z axis comes out
+        # ascending: it is assigned straight to the converter's common mass
+        # axis, and everything downstream (np.searchsorted binning, the
+        # stored var["mz"] column) requires increasing m/z.
+        inv_values = np.linspace(inv_min, inv_max, target_bins + 1)
         mz_values = 1.0 / inv_values
 
         # Use bin centers

--- a/thyra/resampling/mass_axis/fticr_generator.py
+++ b/thyra/resampling/mass_axis/fticr_generator.py
@@ -1,9 +1,6 @@
 """FT-ICR mass axis generator with bin size ∝ m/z^2 spacing."""
 
-from typing import Any
-
 import numpy as np
-import numpy.typing as npt
 
 from ..types import AxisType, MassAxis
 from .base_generator import BaseAxisGenerator
@@ -22,8 +19,8 @@ class FTICRAxisGenerator(BaseAxisGenerator):
         min_mz: float,
         max_mz: float,
         target_bins: int,
-        reference_mz: float = 500.0,
-        reference_width: float = 0.1,
+        reference_mz: float = 1000.0,
+        reference_width: float = 0.005,
     ) -> MassAxis:
         """Generate FT-ICR mass axis with m/z^2 spacing.
 
@@ -102,32 +99,3 @@ class FTICRAxisGenerator(BaseAxisGenerator):
     def get_axis_type(self) -> AxisType:
         """Return the axis type for FT-ICR."""
         return AxisType.FTICR
-
-    def generate_axis_bins(
-        self, min_mz: float, max_mz: float, num_bins: int
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate FT-ICR axis with fixed number of bins."""
-        axis = self.generate_axis(min_mz, max_mz, num_bins)
-        return axis.mz_values
-
-    def generate_axis_width(
-        self,
-        min_mz: float,
-        max_mz: float,
-        width_da: float,
-        reference_mz: float = 500.0,
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate FT-ICR axis based on mass width at reference m/z."""
-        # For FT-ICR: bin_width = k * mz^2
-        k = width_da / (reference_mz**2)
-
-        # Generate axis in 1/mz space for proportional m/z^2 spacing
-        inv_min = 1.0 / min_mz
-        inv_max = 1.0 / max_mz
-
-        # Calculate number of bins needed for desired resolution
-        inv_step = k / width_da  # Based on integral derivative
-        num_bins = int((inv_min - inv_max) / inv_step) + 1
-
-        inv_values = np.linspace(inv_max, inv_min, num_bins)
-        return 1.0 / inv_values

--- a/thyra/resampling/mass_axis/linear_generator.py
+++ b/thyra/resampling/mass_axis/linear_generator.py
@@ -1,9 +1,6 @@
 """Linear/uniform mass axis generator with constant spacing."""
 
-from typing import Any
-
 import numpy as np
-import numpy.typing as npt
 
 from ..types import AxisType, MassAxis
 from .base_generator import BaseAxisGenerator
@@ -17,7 +14,14 @@ class LinearAxisGenerator(BaseAxisGenerator):
     generation.
     """
 
-    def generate_axis(self, min_mz: float, max_mz: float, target_bins: int) -> MassAxis:
+    def generate_axis(
+        self,
+        min_mz: float,
+        max_mz: float,
+        target_bins: int,
+        reference_mz: float = 1000.0,
+        reference_width: float = 0.005,
+    ) -> MassAxis:
         """Generate uniform mass axis with constant spacing.
 
         Parameters
@@ -28,6 +32,13 @@ class LinearAxisGenerator(BaseAxisGenerator):
             Maximum m/z value
         target_bins : int
             Number of bins
+        reference_mz : float
+            Unused. Constant spacing has no reference-m/z dependence; the
+            parameter exists so every generator shares one signature.
+        reference_width : float
+            Unused, for the same reason. The realized width is
+            ``(max_mz - min_mz) / (target_bins - 1)``, and the caller sizes
+            ``target_bins`` to make that the width it wants.
 
         Returns
         -------
@@ -47,21 +58,3 @@ class LinearAxisGenerator(BaseAxisGenerator):
     def get_axis_type(self) -> AxisType:
         """Return the axis type for uniform spacing."""
         return AxisType.CONSTANT
-
-    def generate_axis_bins(
-        self, min_mz: float, max_mz: float, num_bins: int
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate uniform axis with fixed number of bins."""
-        return np.linspace(min_mz, max_mz, num_bins)
-
-    def generate_axis_width(
-        self,
-        min_mz: float,
-        max_mz: float,
-        width_da: float,
-        reference_mz: float = 500.0,
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate uniform axis based on constant mass width."""
-        # For uniform spacing, width is constant across the range
-        num_bins = int((max_mz - min_mz) / width_da) + 1
-        return np.linspace(min_mz, max_mz, num_bins)

--- a/thyra/resampling/mass_axis/linear_tof_generator.py
+++ b/thyra/resampling/mass_axis/linear_tof_generator.py
@@ -1,9 +1,6 @@
 """Linear TOF mass axis generator with bin size ∝ √m/z spacing."""
 
-from typing import Any
-
 import numpy as np
-import numpy.typing as npt
 
 from ..types import AxisType, MassAxis
 from .base_generator import BaseAxisGenerator
@@ -22,8 +19,8 @@ class LinearTOFAxisGenerator(BaseAxisGenerator):
         min_mz: float,
         max_mz: float,
         target_bins: int,
-        reference_mz: float = 500.0,
-        reference_width: float = 0.1,
+        reference_mz: float = 1000.0,
+        reference_width: float = 0.005,
     ) -> MassAxis:
         """Generate Linear TOF mass axis with √m/z spacing.
 
@@ -99,35 +96,3 @@ class LinearTOFAxisGenerator(BaseAxisGenerator):
     def get_axis_type(self) -> AxisType:
         """Return the axis type for Linear TOF."""
         return AxisType.LINEAR_TOF
-
-    def generate_axis_bins(
-        self, min_mz: float, max_mz: float, num_bins: int
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate Linear TOF axis with fixed number of bins."""
-        axis = self.generate_axis(min_mz, max_mz, num_bins)
-        return axis.mz_values
-
-    def generate_axis_width(
-        self,
-        min_mz: float,
-        max_mz: float,
-        width_da: float,
-        reference_mz: float = 500.0,
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate Linear TOF axis based on mass width at reference m/z."""
-        # For Linear TOF: bin_width = k * sqrt(mz)
-        k = width_da / np.sqrt(reference_mz)
-
-        # Generate axis in sqrt(mz) space for proportional √m/z spacing
-        sqrt_min = np.sqrt(min_mz)
-        sqrt_max = np.sqrt(max_mz)
-
-        # Calculate number of bins needed for desired resolution
-        sqrt_step = width_da / (
-            k * np.sqrt(reference_mz)
-        )  # This simplifies to width_da / width_da = 1
-        sqrt_step = k  # Constant step in sqrt space
-        num_bins = int((sqrt_max - sqrt_min) / sqrt_step) + 1
-
-        sqrt_values = np.linspace(sqrt_min, sqrt_max, num_bins)
-        return sqrt_values**2

--- a/thyra/resampling/mass_axis/orbitrap_generator.py
+++ b/thyra/resampling/mass_axis/orbitrap_generator.py
@@ -1,9 +1,6 @@
 """Orbitrap mass axis generator with bin size ∝ m/z^1.5 spacing."""
 
-from typing import Any
-
 import numpy as np
-import numpy.typing as npt
 
 from ..types import AxisType, MassAxis
 from .base_generator import BaseAxisGenerator
@@ -23,8 +20,8 @@ class OrbitrapAxisGenerator(BaseAxisGenerator):
         min_mz: float,
         max_mz: float,
         target_bins: int,
-        reference_mz: float = 500.0,
-        reference_width: float = 0.1,
+        reference_mz: float = 1000.0,
+        reference_width: float = 0.005,
     ) -> MassAxis:
         """Generate Orbitrap mass axis with m/z^1.5 spacing.
 
@@ -104,32 +101,3 @@ class OrbitrapAxisGenerator(BaseAxisGenerator):
     def get_axis_type(self) -> AxisType:
         """Return the axis type for Orbitrap."""
         return AxisType.ORBITRAP
-
-    def generate_axis_bins(
-        self, min_mz: float, max_mz: float, num_bins: int
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate Orbitrap axis with fixed number of bins."""
-        axis = self.generate_axis(min_mz, max_mz, num_bins)
-        return axis.mz_values
-
-    def generate_axis_width(
-        self,
-        min_mz: float,
-        max_mz: float,
-        width_da: float,
-        reference_mz: float = 500.0,
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate Orbitrap axis based on mass width at reference m/z."""
-        # For Orbitrap: bin_width = k * mz^1.5
-        k = width_da / (reference_mz**1.5)
-
-        # Generate axis in 1/sqrt(mz) space for proportional m/z^1.5 spacing
-        inv_sqrt_min = 1.0 / np.sqrt(min_mz)
-        inv_sqrt_max = 1.0 / np.sqrt(max_mz)
-
-        # Calculate number of bins needed for desired resolution
-        inv_sqrt_step = k / (2 * width_da)  # Based on integral derivative
-        num_bins = int((inv_sqrt_min - inv_sqrt_max) / inv_sqrt_step) + 1
-
-        inv_sqrt_values = np.linspace(inv_sqrt_max, inv_sqrt_min, num_bins)
-        return 1.0 / (inv_sqrt_values**2)

--- a/thyra/resampling/mass_axis/orbitrap_generator.py
+++ b/thyra/resampling/mass_axis/orbitrap_generator.py
@@ -58,8 +58,12 @@ class OrbitrapAxisGenerator(BaseAxisGenerator):
         inv_sqrt_max = 1.0 / np.sqrt(max_mz)
         # inv_sqrt_range = inv_sqrt_min - inv_sqrt_max  # Note: min > max in 1/sqrt space
 
-        # Create uniform grid in 1/sqrt(mz) space
-        inv_sqrt_values = np.linspace(inv_sqrt_max, inv_sqrt_min, target_bins + 1)
+        # Create uniform grid in 1/sqrt(mz) space. Walk 1/sqrt(mz) downwards,
+        # from 1/sqrt(min_mz) to 1/sqrt(max_mz), so the resulting m/z axis
+        # comes out ascending: it is assigned straight to the converter's
+        # common mass axis, and everything downstream (np.searchsorted
+        # binning, the stored var["mz"] column) requires increasing m/z.
+        inv_sqrt_values = np.linspace(inv_sqrt_min, inv_sqrt_max, target_bins + 1)
         mz_values = 1.0 / (inv_sqrt_values**2)
 
         # Use bin centers

--- a/thyra/resampling/mass_axis/reflector_tof_generator.py
+++ b/thyra/resampling/mass_axis/reflector_tof_generator.py
@@ -1,9 +1,6 @@
 """Reflector TOF mass axis generator with bin size ∝ m/z spacing."""
 
-from typing import Any
-
 import numpy as np
-import numpy.typing as npt
 
 from ..types import AxisType, MassAxis
 from .base_generator import BaseAxisGenerator
@@ -23,8 +20,8 @@ class ReflectorTOFAxisGenerator(BaseAxisGenerator):
         min_mz: float,
         max_mz: float,
         target_bins: int,
-        reference_mz: float = 500.0,
-        reference_width: float = 0.1,
+        reference_mz: float = 1000.0,
+        reference_width: float = 0.005,
     ) -> MassAxis:
         """Generate Reflector TOF mass axis with m/z-proportional spacing.
 
@@ -99,32 +96,3 @@ class ReflectorTOFAxisGenerator(BaseAxisGenerator):
     def get_axis_type(self) -> AxisType:
         """Return the axis type for Reflector TOF."""
         return AxisType.REFLECTOR_TOF
-
-    def generate_axis_bins(
-        self, min_mz: float, max_mz: float, num_bins: int
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate Reflector TOF axis with fixed number of bins."""
-        axis = self.generate_axis(min_mz, max_mz, num_bins)
-        return axis.mz_values
-
-    def generate_axis_width(
-        self,
-        min_mz: float,
-        max_mz: float,
-        width_da: float,
-        reference_mz: float = 500.0,
-    ) -> npt.NDArray[np.floating[Any]]:
-        """Generate Reflector TOF axis based on mass width at reference m/z."""
-        # For Reflector TOF: constant relative resolution R = m/Δm
-        # relative_resolution = reference_mz / width_da  # Used for scaling
-
-        # Generate axis in log space for constant relative resolution
-        ln_min = np.log(min_mz)
-        ln_max = np.log(max_mz)
-
-        # Calculate number of bins needed for desired resolution
-        ln_step = width_da / reference_mz  # Δ(ln(m)) ≈ Δm/m for small Δm
-        num_bins = int((ln_max - ln_min) / ln_step) + 1
-
-        ln_values = np.linspace(ln_min, ln_max, num_bins)
-        return np.exp(ln_values)

--- a/thyra/resampling/types.py
+++ b/thyra/resampling/types.py
@@ -17,14 +17,11 @@ class ResamplingMethod(Enum):
         TIC_PRESERVING: Redistribute intensity so the total ion count
             is preserved after rebinning (recommended for quantitative
             work).
-        LINEAR_INTERPOLATION: Linear interpolation between neighbouring
-            bins.
     """
 
     NONE = "none"
     NEAREST_NEIGHBOR = "nearest_neighbor"
     TIC_PRESERVING = "tic_preserving"
-    LINEAR_INTERPOLATION = "linear_interpolation"
 
 
 class AxisType(Enum):

--- a/thyra/resampling/types.py
+++ b/thyra/resampling/types.py
@@ -7,6 +7,11 @@ from typing import Any, Optional
 import numpy as np
 import numpy.typing as npt
 
+#: Reference m/z that ``mass_width_da`` is anchored to when the caller
+#: does not pick one. Matches the ``--resample-reference-mz`` CLI default
+#: so the dataclass default and the CLI default cannot drift apart.
+DEFAULT_REFERENCE_MZ = 1000.0
+
 
 class ResamplingMethod(Enum):
     """Available resampling methods.
@@ -91,7 +96,8 @@ class ResamplingConfig:
         mass_width_da: Bin width in Daltons at ``reference_mz``.
             Alternative to ``target_bins`` -- specify one or the other.
         reference_mz: Reference m/z for ``mass_width_da``.  Default
-            500.0 Da.
+            1000.0 Da, matching the ``--resample-reference-mz`` CLI
+            default.
         min_mz: Override the lower bound of the mass range.
         max_mz: Override the upper bound of the mass range.
     """
@@ -100,6 +106,6 @@ class ResamplingConfig:
     axis_type: Optional[AxisType] = None
     target_bins: Optional[int] = None
     mass_width_da: Optional[float] = None
-    reference_mz: float = 500.0
+    reference_mz: float = DEFAULT_REFERENCE_MZ
     min_mz: Optional[float] = None
     max_mz: Optional[float] = None

--- a/thyra/utils/windows_paths.py
+++ b/thyra/utils/windows_paths.py
@@ -1,0 +1,132 @@
+r"""Extended-length path support for Zarr stores on Windows.
+
+Windows caps a normal path at 260 characters including the terminating
+NUL, so 259 usable. A Zarr store is a directory tree and the limit applies
+to each key inside it, not to the path the user typed. Thyra's deepest key
+is a metadata document about 95 characters below the store root::
+
+    <out>.zarr\tables\<dataset_id>_z0\uns\<section>\<key>\zarr.<32-hex>.partial
+
+so an output path of roughly 165 characters is already enough to push the
+deepest key past the limit. It surfaces as::
+
+    Error saving SpatialData: [Errno 2] No such file or directory:
+      '...\imzml_version\zarr.<hash>.partial'
+
+which points at a file the user never named and gives no hint that path
+length is the problem.
+
+Prefixing the store path with ``\\?\`` opts that path out of the 260
+character limit entirely. Verified here on Windows 11 with
+``LongPathsEnabled=0``: a 207 character output path fails, and the same
+path with the prefix converts cleanly.
+
+The prefix is applied only when the projected deepest key would not fit
+otherwise, so ordinary paths are handled exactly as before. It is not
+applied to input paths: readers reach vendor SDKs that may not accept
+extended-length syntax.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Longest usable normal Windows path, excluding the terminating NUL.
+WINDOWS_MAX_PATH = 259
+
+#: Characters Thyra needs below the store root for its deepest key, not
+#: counting the dataset id. Measured at 95 for the longest section/key
+#: pair Thyra emits (``raw_metadata\\max count of pixels x``) plus the
+#: ``zarr.<32-hex>.partial`` name Zarr writes through. Metadata key names
+#: come from the source file and can be longer, so this carries headroom
+#: above the observed worst case.
+DEEPEST_KEY_RESERVE = 128
+
+_EXTENDED_PREFIX = "\\\\?\\"
+
+
+def _long_paths_enabled() -> bool:
+    """Whether Windows long-path support is switched on system-wide.
+
+    When it is, normal paths already work past 260 characters and there is
+    nothing to work around.
+    """
+    try:
+        import winreg
+
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\FileSystem",
+        ) as key:
+            value, _ = winreg.QueryValueEx(key, "LongPathsEnabled")
+        return bool(value)
+    except (ImportError, OSError):
+        # Missing key, no permission, or not Windows: assume the limit
+        # applies, which only ever means using the prefix when it was not
+        # strictly needed.
+        return False
+
+
+def to_extended_length_path(path: Path) -> Path:
+    r"""Rewrite an absolute Windows path into extended-length form.
+
+    ``\\?\`` disables all path normalisation, so the input must already be
+    absolute and free of ``..`` and forward slashes. Callers should pass a
+    ``Path.resolve()`` result.
+
+    Already-extended paths are returned unchanged, and UNC shares get the
+    ``\\?\UNC\`` spelling rather than an invalid double prefix.
+    """
+    text = str(path)
+
+    if text.startswith(_EXTENDED_PREFIX):
+        return path
+
+    if text.startswith("\\\\"):
+        # \\server\share -> \\?\UNC\server\share
+        return Path(f"{_EXTENDED_PREFIX}UNC\\{text.lstrip(chr(92))}")
+
+    return Path(f"{_EXTENDED_PREFIX}{text}")
+
+
+def projected_deepest_key_length(output_path: Path, dataset_id: str) -> int:
+    """Length of the longest path Thyra expects to write inside the store."""
+    return len(str(output_path)) + 1 + len(dataset_id) + DEEPEST_KEY_RESERVE
+
+
+def prepare_zarr_output_path(output_path: Path, dataset_id: str) -> Path:
+    """Return the path to hand to Zarr, extended if the store needs it.
+
+    A no-op off Windows, and a no-op on Windows when long-path support is
+    enabled or the projected deepest key fits inside the normal limit.
+
+    Args:
+        output_path: The resolved, absolute output store path.
+        dataset_id: The dataset identifier, which appears in the deepest key.
+    """
+    if sys.platform != "win32":
+        return output_path
+
+    projected = projected_deepest_key_length(output_path, dataset_id)
+    if projected <= WINDOWS_MAX_PATH:
+        return output_path
+
+    if _long_paths_enabled():
+        logger.debug(
+            "Output path is long (projected deepest key %d characters) but "
+            "Windows long-path support is enabled; using it as given",
+            projected,
+        )
+        return output_path
+
+    extended = to_extended_length_path(output_path)
+    logger.info(
+        "Output path is long enough that the deepest Zarr key would exceed "
+        "the %d character Windows limit (projected %d). Writing through an "
+        "extended-length path so the conversion is not truncated.",
+        WINDOWS_MAX_PATH,
+        projected,
+    )
+    return extended

--- a/thyra/utils/zarr_atomic_write.py
+++ b/thyra/utils/zarr_atomic_write.py
@@ -1,0 +1,181 @@
+"""Bounded retry for Zarr's atomic metadata writes on Windows.
+
+Zarr writes every metadata document by streaming it to a
+``zarr.<32-hex>.partial`` sibling, closing that file, and then renaming it
+over the real name (``zarr/storage/_local.py::_atomic_write``). On POSIX
+the rename is atomic and silently replaces whatever is there. On Windows
+there is no atomic replace: ``MoveFileEx`` has to delete the destination
+first, and if any handle is open on it at that instant the call fails with
+``[WinError 5] Access is denied`` instead of waiting.
+
+Thyra writes several metadata documents repeatedly during one conversion
+-- the store root ``zarr.json`` is rewritten once per element added, and a
+single conversion issues a few hundred metadata renames -- so the
+destination is genuinely contended. Measured on Windows 11 with
+zarr 3.1.3: across 150 conversions and roughly 64,500 metadata renames, 40
+failed with WinError 5, and every one of them succeeded on an immediate
+retry with no delay. Left unhandled each of those aborts the whole
+conversion, which is why it surfaced as intermittent test failures and as
+``Error saving SpatialData: [WinError 5] Access is denied: ...partial ->
+...zarr.json`` in real runs.
+
+The file handle is already closed before the rename, so there is nothing
+for Thyra to close earlier; the contention is on the destination. A
+bounded retry is the fix.
+"""
+
+import contextlib
+import logging
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any, BinaryIO, Callable, Iterator, Literal
+
+logger = logging.getLogger(__name__)
+
+# Codes MoveFileEx reports when the destination cannot be replaced *right
+# now*, as opposed to a genuine permission problem. Both are worth a
+# retry; anything else propagates untouched.
+_TRANSIENT_WINERRORS = frozenset(
+    {
+        5,  # ERROR_ACCESS_DENIED
+        32,  # ERROR_SHARING_VIOLATION
+    }
+)
+
+# Delay before each successive attempt. The leading 0.0 is the original
+# attempt. Every observed failure cleared on the first retry, so the later
+# delays are headroom for a busier machine rather than an expected path.
+_RETRY_DELAYS = (0.0, 0.001, 0.005, 0.02, 0.05, 0.2)
+
+_installed = False
+
+
+def _is_transient(exc: OSError) -> bool:
+    """Whether the destination was merely busy rather than forbidden."""
+    return getattr(exc, "winerror", None) in _TRANSIENT_WINERRORS
+
+
+def _move_with_retry(
+    tmp_path: Path,
+    path: Path,
+    move: Callable[[Path, Path], Any],
+) -> None:
+    """Run ``move(tmp_path, path)``, retrying while the target is busy.
+
+    Args:
+        tmp_path: The freshly written temporary file.
+        path: The destination to move it onto.
+        move: The move to perform, as Zarr would have performed it.
+
+    Raises:
+        OSError: The last error seen, if every attempt is exhausted, or
+            immediately for any error that is not a transient lock.
+    """
+    last_error: OSError
+
+    for attempt, delay in enumerate(_RETRY_DELAYS):
+        if delay:
+            time.sleep(delay)
+        try:
+            move(tmp_path, path)
+            if attempt:
+                logger.debug(
+                    "Zarr metadata rename to %s succeeded on attempt %d "
+                    "after a transient Windows lock",
+                    path,
+                    attempt + 1,
+                )
+            return
+        except OSError as e:
+            if not _is_transient(e):
+                raise
+            last_error = e
+
+    logger.error(
+        "Zarr metadata rename to %s still blocked after %d attempts. "
+        "Something is holding the file open -- check for a Python session, "
+        "napari, or a notebook with the store loaded.",
+        path,
+        len(_RETRY_DELAYS),
+    )
+    raise last_error
+
+
+def make_atomic_write_with_retry(
+    safe_move: Callable[[Path, Path], Any],
+) -> Callable[..., Any]:
+    """Build a replacement for Zarr's ``_atomic_write`` with retries.
+
+    Mirrors ``zarr.storage._local._atomic_write`` (zarr 3.0-3.1, the range
+    pinned in pyproject.toml) with the final move retried while the
+    destination is busy.
+
+    Args:
+        safe_move: Zarr's non-clobbering move, used for exclusive writes.
+    """
+
+    @contextlib.contextmanager
+    def _atomic_write_with_retry(
+        path: Path,
+        mode: Literal["r+b", "wb"],
+        exclusive: bool = False,
+    ) -> Iterator[BinaryIO]:
+        tmp_path = path.with_suffix(f".{uuid.uuid4().hex}.partial")
+        try:
+            with tmp_path.open(mode) as f:
+                yield f
+            # Zarr uses a non-replacing move when it must not clobber an
+            # existing key, and a replacing one otherwise. Keep both.
+            if exclusive:
+                _move_with_retry(tmp_path, path, safe_move)
+            else:
+                _move_with_retry(tmp_path, path, lambda src, dst: src.replace(dst))
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+    _atomic_write_with_retry._thyra_retry_wrapped = True  # type: ignore[attr-defined]
+    return _atomic_write_with_retry
+
+
+def install_windows_atomic_write_retry() -> None:
+    """Add a bounded retry to Zarr's atomic metadata writes on Windows.
+
+    A no-op off Windows, where the underlying rename replaces the
+    destination atomically and cannot hit this failure, and a no-op if
+    called more than once.
+
+    If Zarr's private atomic-write helpers are not shaped as expected -- a
+    newer Zarr having reworked them -- nothing is patched and the caller
+    keeps Zarr's own behaviour.
+    """
+    global _installed
+
+    if _installed or sys.platform != "win32":
+        return
+
+    try:
+        import zarr.storage._local as zarr_local
+    except ImportError:  # pragma: no cover - zarr is a hard dependency
+        logger.debug("Could not import zarr.storage._local; not patching")
+        return
+
+    original = getattr(zarr_local, "_atomic_write", None)
+    safe_move = getattr(zarr_local, "_safe_move", None)
+
+    if original is None or safe_move is None:
+        logger.debug(
+            "zarr.storage._local does not expose the expected atomic-write "
+            "helpers; leaving Zarr's write path untouched"
+        )
+        return
+
+    if getattr(original, "_thyra_retry_wrapped", False):
+        _installed = True
+        return
+
+    zarr_local._atomic_write = make_atomic_write_with_retry(safe_move)
+    _installed = True
+    logger.debug("Installed bounded retry for Zarr atomic metadata writes")


### PR DESCRIPTION
Fixes the defects found while writing the PR #103 documentation, plus the
three follow-ups that surfaced while doing so.

Every item was reproduced before fixing and verified after. Test suite:
596 passed, 11 skipped. `mkdocs build --strict` and `poetry run flake8`
both clean.

## Correctness

**CLI exited 0 on failure** (`1584f10`) — `main()` logged "Conversion
failed." but never set an exit status, so any script or CI wrapper saw
success. Now exits 1. A failed conversion also left an unreadable partial
`.zarr` at the destination that looked plausible and blocked a retry; it is
renamed to `<output>.zarr.failed` instead.

This one had been masking a real bug: `test_cli_convert` asserted only that
the output path existed, so it passed on failed conversions.

**FT-ICR and Orbitrap bin counts** (`20e39de`) — `_calculate_bins_from_width`
had no `fticr` branch, so an FT-ICR axis took a uniform bin count while the
generator distributed those bins with m/z² spacing. Added the branch:

```
bins = (1/min_mz - 1/max_mz) * (reference_mz² / width_at_mz)
```

The same integral showed the `orbitrap` branch was missing a factor of 2
(`d(m^-0.5)/dm = -½m^-1.5`), which halved its bin count and made **every
Orbitrap bin twice the requested width**. All five axis types now realize
the requested width at `reference_mz` to better than 0.1%.

**Orbitrap and FT-ICR axes were descending** (`40a191e`) — both generators
built their grid from `1/max_mz` up to `1/min_mz`, which inverts to a
descending m/z axis. That output is assigned straight to the converter's
common mass axis, where descending m/z breaks `searchsorted` binning and
leaves the stored `var["mz"]` reversed with `min_mz`/`max_mz` swapped.

**Windows metadata renames** (`af19db6`) — conversions intermittently died
with `[WinError 5] Access is denied: '...partial' -> '...zarr.json'`. Zarr
closes the file before renaming, so nothing needed closing earlier: the
contention is on the *destination*. POSIX `rename` replaces atomically;
Windows `MoveFileEx` must delete the destination first and fails outright if
any handle is open on it.

Thyra rewrites the store root `zarr.json` once per element added, a few
hundred renames per conversion, so the destination is genuinely contended by
Zarr's own asyncio workers. Measured across 150 conversions and ~64,500
renames: 40 failed, **every one succeeded on an immediate retry**.
Reproduced standalone only under same-key contention, which is why it never
appears on Linux or macOS. Windows-only, idempotent, no-op if a future Zarr
reworks the internals it mirrors.

**Windows 260-character path limit** (`f9c0199`) — the limit applies to every
key inside the store, not the path you typed, and Thyra's deepest key sits
~95 characters below the root. Output paths over ~165 characters failed
mid-write. Now projected before converting and written through a `\?\`
path when it would not fit. Verified with `LongPathsEnabled=0`: a
207-character path fails as given, converts cleanly through the prefix, and
reads back complete with no prefix leaking into stored metadata.

## API hygiene

- **`LINEAR_INTERPOLATION` removed** (`23f8f76`) — promised in the docstring
  and published by mkdocstrings, but no strategy existed; passing it via the
  Python API silently performed TIC-preserving resampling.
- **Unknown method/axis strings now raise** (`4840b7d`) — `.get()` turned a
  typo or `"tic_preserving "` into `None`, silently falling back to
  auto-detection. Also rejects enum members with nothing behind them.
- **`reference_mz` default aligned** (`de33301`) — the dataclass said 500.0
  while the dict path used 1000.0, so the dataclass default was never
  effective. Now one `DEFAULT_REFERENCE_MZ`.
- **`thyra --version`** (`b19f989`) — plus an exit-status table in the CLI
  reference.

## Follow-ups

- **Lint config** (`e144f2d`) — `.flake8` said 88 while the pre-commit hook
  overrode it to 100, so the documented `poetry run flake8` reported ~120
  violations the real gate ignored. All settings now live in `.flake8`.
  `scripts/` is excluded: ad-hoc developer diagnostics, outside the package,
  two with C901 complexity of 16 and 35. black and isort still cover them.
- **Dead axis-generator methods** (`c6bf58d`) — `BaseAxisGenerator` declared
  `generate_axis_bins`/`generate_axis_width` as its contract but nothing
  called either, while the method actually in use wasn't on the base class
  at all. Unreachable and untested, they had drifted: FT-ICR computed its
  step as `k / width_da` rather than `k`, two returned descending axes,
  LinearTOF assigned `sqrt_step` twice. Removed; the real contract
  (`generate_axis` + `get_axis_type`) is declared instead, all five
  generators share one signature, and `build_physics_axis` collapses to a
  single call with no `type: ignore`.
- **`.cache/`** (`0f1feac`) — mkdocs-jupyter's cache is now gitignored.

## Notes

- Two pre-existing `no-any-return` mypy errors remain in
  `make_example_data.py` and `waters_extractor.py`. Confirmed identical at
  `45b3680`; untouched here.
- `pre-commit run --all-files` is not safe as a check on this repo: the
  `mixed-line-ending` hook rewrites ~140 files because the working tree is
  CRLF and the hook forces LF. Per-commit hook runs are unaffected.
