### PR TITLE
docs: handouts for the four parallel workstreams

### DIFF
--- a/handouts/README.md
+++ b/handouts/README.md
@@ -1,0 +1,97 @@
+# Parallel workstream handouts
+
+Four independent pieces of work, written to be run in parallel in separate
+git worktrees. Each handout is self-contained: it states what is wrong, the
+evidence, the constraints that must not be broken, and how to verify.
+
+Everything here was investigated against `main` at **v1.27.0** on
+Windows 11, Python 3.12.7, with pandas 2.3.2 / anndata 0.12.2 /
+spatialdata 0.7.3 / zarr 3.1.3.
+
+| # | Handout | Branch | Worktree | Priority |
+|---|---|---|---|---|
+| A | [pandas-3-string-dtypes.md](pandas-3-string-dtypes.md) | `fix/pandas3-string-dtypes` | `../Thyra-pandas3` | **first** |
+| B | [optimize-chunks.md](optimize-chunks.md) | `fix/optimize-chunks-sparse` | `../Thyra-chunks` | independent |
+| C | [write-amplification.md](write-amplification.md) | `perf/write-amplification` | `../Thyra-perf` | after A |
+| D | [toolchain-hygiene.md](toolchain-hygiene.md) | `chore/toolchain-hygiene` | `../Thyra-toolchain` | independent |
+
+## Ordering and overlap
+
+**A must land first.** It is the only one fixing a defect users can hit
+today, and it touches `_save_output` in
+`thyra/converters/spatialdata/base_spatialdata_converter.py`.
+
+**C also touches that file** (`_process_single_spectrum`, the write
+orchestration). C should rebase on `main` once A has merged rather than
+racing it. If C starts before A lands, expect one small conflict in
+`_save_output`.
+
+**B and D share no files with anything else** and can run start-to-finish
+independently.
+
+## Worktree setup
+
+Each handout repeats this, but for convenience:
+
+```bash
+git worktree add -b <branch> ../<Thyra-dir> main
+```
+
+Two things to know about working in a worktree here:
+
+1. **The venv is shared.** `thyra` is installed into the Poetry venv as an
+   editable install pointing at the *main* checkout, so
+   `poetry run python` from a worktree still imports the main checkout's
+   code. To exercise worktree code, put the worktree first on the path:
+
+   ```bash
+   PYTHONPATH=$(pwd) poetry run pytest
+   ```
+
+   This bit me while verifying handout A: two runs reported identical
+   results because both imported `main`.
+
+2. **Line endings.** Every commit that touches a file will fail the
+   `mixed-line-ending` hook once, rewrite the file to LF, and need a second
+   `git add` + `git commit`. This is expected until handout D lands. Do not
+   run `pre-commit run --all-files` as a check: it rewrites ~137 unrelated
+   files.
+
+## Shared conventions
+
+- Conventional commits (`feat`, `fix`, `docs`, `refactor`, `chore`, `perf`,
+  `build`, `style`, `test`).
+- Never mention Claude or AI authorship in commit messages.
+- No emojis anywhere: code, comments, docstrings, commits, docs.
+- Before every commit:
+  ```bash
+  poetry run black . && poetry run isort . && poetry run flake8 && poetry run pytest
+  ```
+- `poetry run mkdocs build --strict` must stay clean.
+- Two pre-existing `no-any-return` mypy errors exist in
+  `thyra/tools/make_example_data.py:62` and
+  `thyra/metadata/extractors/waters_extractor.py:130`. They are not yours
+  unless you are on handout D.
+
+## Branch cleanup (do this once, anywhere)
+
+Two remote branches are dead and should be deleted so they stop looking
+like work in progress:
+
+- `origin/fix/streaming-pcs-image-write` — already merged. `git cherry -v
+  main origin/fix/streaming-pcs-image-write` reports `-`, and
+  `tests/unit/converters/test_streaming_pcs_roundtrip.py` is on `main`.
+- `origin/feature/lazy-loading-support` — superseded, 83 commits behind.
+  `main` already writes every `encoding-type` / `encoding-version` attr the
+  branch adds, and does it **better**: `main` distinguishes `"string"` for
+  0-d scalars in `uns` from `"string-array"` for arrays, which the branch's
+  binary `_set_encoding_attrs(is_string=...)` helper cannot express.
+  Verified that `anndata.experimental.read_lazy()` already works on `main`
+  output (see handout C for the transcript).
+
+`origin/fix/streaming-coo-arrow-string-write` is **live and wanted** — it is
+the subject of handout A. Do not delete it.
+
+The stale worktree at `../Thyra-coo-fix` sits on that branch 19 commits
+behind `main`. Handout A supersedes it; remove it with
+`git worktree remove ../Thyra-coo-fix` once A has landed.

--- a/handouts/optimize-chunks.md
+++ b/handouts/optimize-chunks.md
@@ -1,0 +1,153 @@
+# B. `--optimize-chunks` has never worked
+
+**Branch:** `fix/optimize-chunks-sparse`
+**Worktree:** `../Thyra-chunks`
+**Priority:** independent, shares no files with the other handouts.
+
+```bash
+git worktree add -b fix/optimize-chunks-sparse ../Thyra-chunks main
+```
+
+---
+
+## The defect
+
+The documented `--optimize-chunks` CLI flag fails on every conversion.
+
+Reproduce on `main` at v1.27.0, with any imzML and a perfectly ordinary
+short output path:
+
+```python
+from thyra.convert import convert_msi
+from thyra.utils.data_processors import optimize_zarr_chunks
+
+convert_msi(imzml, out, dataset_id="ds", pixel_size_um=2.5)
+optimize_zarr_chunks(str(out), "tables/ds_z0/X")
+```
+
+```
+ERROR Error optimizing chunks: 'Group' object has no attribute 'shape'
+-> returns False
+```
+
+### Why
+
+`tables/<dataset_id>/X` is a Zarr **Group**, not an Array. It holds a SciPy
+sparse matrix:
+
+```
+encoding-type attr: csc_matrix
+members: ['data', 'indices', 'indptr']
+```
+
+`optimize_zarr_chunks` (`thyra/utils/data_processors.py:38-39`) does
+`zarr_store[array_path]` and then reads `array.shape`. Its chunk-selection
+logic branches on `len(shape) == 4` for a `(c, z, y, x)` layout, which says
+plainly that it was written for a dense image layout predating the sparse
+CSC tables the converter now writes. It is stale code from an earlier
+architecture.
+
+### A second, separate defect
+
+`thyra/__main__.py::_handle_post_conversion` calls it and **ignores the
+return value**:
+
+```python
+if success:
+    if optimize_chunks and format == "spatialdata":
+        optimize_zarr_chunks(str(output), f"tables/{dataset_id}/X")
+    logger.info(f"Conversion completed successfully. Output stored at {output}")
+```
+
+So `--optimize-chunks` logs an error, does nothing, and the CLI still
+reports success and exits 0. This is the same shape of bug as the exit-code
+defect fixed in `1584f10`, one layer down: a step fails and nothing
+propagates.
+
+---
+
+## What to do
+
+Decide between fixing and removing. Investigate before choosing.
+
+### Option 1: make it work on the sparse layout
+
+`data`, `indices`, and `indptr` are 1-D, so the existing 4-D and 2-D
+branches do not apply at all — the whole chunk-selection body needs
+rewriting, not patching. Rechunking a CSC store means picking chunk sizes
+for three 1-D arrays whose lengths are `nnz`, `nnz`, and `n_cols + 1`.
+
+Before writing any of it, answer: **does this actually buy anything?**
+Compare against what `thyra/converters/spatialdata/_chunking.py` already
+does. That module was introduced as "the sharding seam" and may already set
+sensible chunks at write time, making a post-hoc pass pointless.
+
+### Option 2: remove the flag and the function
+
+If `_chunking.py` already covers it, deleting is the better answer: a
+documented flag that silently does nothing is worse than no flag. Remove
+`--optimize-chunks` from the CLI, drop `optimize_zarr_chunks` and its tests,
+and update `docs/cli.md` (Performance section) and `docs/getting-started.md`
+if it appears there.
+
+Removing a public CLI flag is a breaking change for anyone scripting it.
+Since it has never done anything, nobody can be depending on its effect —
+but a script passing the flag would start failing on an unknown option.
+Consider accepting it as a deprecated no-op that warns, or note the break
+clearly in the commit message. Your call; state the reasoning.
+
+### Either way
+
+`_handle_post_conversion` must not report success when the step failed.
+
+---
+
+## Constraints
+
+**Do not break the AnnData encoding attributes.** This is the important one.
+
+`main` writes `encoding-type` / `encoding-version` attrs throughout the
+store, and they are what makes `anndata.experimental.read_lazy()` work — the
+lazy path the Ousia software depends on. Verified working on `main`:
+
+```
+read_lazy OK: 36 x 40, X=Array
+  obs columns: ['y', 'region', 'region_number', 'x', 'spatial_y', 'spatial_x']
+```
+
+Relevant attrs on the table's `X` group and its members:
+
+```
+X_group.attrs["encoding-type"]  = "csc_matrix"   (or "csr_matrix")
+X_group.attrs["encoding-version"]
+data/indices/indptr each: encoding-type = "array", encoding-version = "0.2.0"
+```
+
+If you rewrite those arrays to rechunk them, **the attrs must survive**.
+`zarr` will not carry them across a create-and-copy. A regression here would
+silently break lazy reading, which is exactly the class of change to avoid.
+
+Add a test asserting `read_lazy` still works after whatever you do, not just
+that the arrays exist.
+
+**If you keep the flag, it needs the extended-length path treatment.** The
+CLI passes the user's unprefixed path, while `convert_msi` may have written
+through a `\\?\` path — see `prepare_zarr_output_path` in
+`thyra/utils/windows_paths.py`. Opening deep keys inside a long-path store
+with a plain path will fail on Windows. Use the same helper.
+
+## Verification
+
+```bash
+cd ../Thyra-chunks
+PYTHONPATH=$(pwd) poetry run pytest -q
+poetry run black . && poetry run isort . && poetry run flake8
+poetry run mkdocs build --strict
+```
+
+Plus, whichever option you take, a test that fails on `main`:
+
+- If fixed: `optimize_zarr_chunks` returns `True` on a real converted store,
+  chunk shapes actually changed, and `read_lazy` still works.
+- If removed: the CLI no longer advertises the flag, and
+  `_handle_post_conversion` surfaces failures.

--- a/handouts/pandas-3-string-dtypes.md
+++ b/handouts/pandas-3-string-dtypes.md
@@ -1,0 +1,209 @@
+# A. pandas 3.0 string dtypes break SpatialData writes
+
+**Branch:** `fix/pandas3-string-dtypes`
+**Worktree:** `../Thyra-pandas3`
+**Priority:** land this first. It is the only handout fixing something a
+user can hit today, and handout C waits on it.
+
+```bash
+git worktree add -b fix/pandas3-string-dtypes ../Thyra-pandas3 main
+```
+
+---
+
+## The defect
+
+Under pandas 3.0 — or pandas 2.x with `future.infer_string=True`, which is
+what 3.0 makes the default — writing a converted dataset fails:
+
+```
+Error saving SpatialData: No method registered for writing
+<class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'>
+into <class 'zarr.core.group.Group'>
+```
+
+`convert_msi` catches it and returns `False`. Since v1.27.0 the CLI exits 1
+rather than silently reporting success, so this now fails loudly — but it
+still fails.
+
+### Reproduced on main at v1.27.0
+
+Setting `pd.set_option("future.infer_string", True)` before converting:
+
+| Path | Result |
+|---|---|
+| in-memory (`streaming=False`) | **FAIL** |
+| streaming PCS (`streaming=True, use_csc=True`) | PASS |
+| streaming COO (`streaming=True, use_csc=False`) | **FAIL** |
+
+The PCS path survives because it hand-writes the AnnData layout straight to
+Zarr and never goes through anndata's writer. Everything that reaches
+`SpatialData.write()` fails.
+
+Note this is **not** COO-specific, contrary to what the existing branch's
+commit message implies. The in-memory path — the default for any dataset
+under the 10 GB streaming threshold, i.e. most conversions — fails too.
+
+### Why it happens
+
+With `infer_string=True`, the table's obs index (`instance_id`), the
+`instance_key` column, and the var index (`mz_*`) are inferred as pandas'
+`str` dtype, backed by `ArrowStringArrayNumpySemantics`. anndata's IO
+registry has a writer for `pandas.core.arrays.string_.StringArray` but not
+for the `*NumpySemantics` subclasses pandas 3 actually produces, and the
+registry matches exact types rather than subclasses.
+
+### Upstream will not fix this in a version we can use
+
+Checked directly:
+
+- **anndata #2377** is our exact error. Closed as a duplicate of #2221.
+- **anndata #2221** ("Pandas 3.0 compatibility") is **open**, milestoned
+  **0.14.0**. The plan is to warn in 0.13 and flip defaults in 0.14.
+- **spatialdata-io #364** is the same failure hitting spatialdata's own
+  Xenium writer, so this is an ecosystem gap, not a Thyra bug.
+
+`pyproject.toml` pins `anndata = ">=0.11.0, <0.13"`, so even 0.13's warnings
+are out of range and 0.14 is far out.
+
+**anndata's documented escape hatches do not work on our pinned version.**
+Verified against anndata 0.12.2 with `infer_string=True`:
+
+| Attempt | Result |
+|---|---|
+| default | `IORegistryError` on `ArrowStringArrayNumpySemantics` |
+| `ad.settings.allow_write_nullable_strings = True` | still `IORegistryError` |
+| `pd.set_option("mode.string_storage", "python")` | still fails, now on `StringArrayNumpySemantics` |
+
+So a Thyra-side fix is the only option short of raising the anndata ceiling
+past a release that does not exist yet.
+
+### It is reachable today
+
+`pyproject.toml` line 74 is `pandas = ">=2.0.0"` with **no upper bound**. A
+fresh `pip install thyra` can resolve pandas 3.x and every non-PCS
+conversion breaks.
+
+---
+
+## What to do
+
+There is an existing commit that does the right thing:
+`b23e636` on `origin/fix/streaming-coo-arrow-string-write`. It adds
+`_coerce_table_strings_to_object()` and calls it in the base `_save_output()`
+for every table's `obs` and `var` before `SpatialData.write()`.
+
+**It cherry-picks cleanly onto current main** (verified) and **it works**:
+with it applied, all three write paths pass under `infer_string=True`.
+
+So:
+
+1. `git cherry-pick b23e636`
+2. Add the test coverage it lacks (below).
+3. Decide the pandas bound (below).
+4. Correct the commit message's claim that this is COO-specific.
+
+### Why this is the right layer, not a patch
+
+Worth stating in the commit message, because it is the crux:
+
+- It sits at the single serialization chokepoint, so the 2D, 3D, and COO
+  converters are all covered by one call.
+- **It does not change the on-disk format.** Verified: after the coercion,
+  `sd.read_zarr()` returns `obs.index.dtype == str` (i.e. pandas' native
+  string dtype). The coercion is write-time only; readers get the modern
+  dtype. Nothing about the stored SpatialData/AnnData layout differs from a
+  pandas 2 write.
+- It is a no-op on pandas < 3, where those columns are already `object`.
+
+### Required: a removal trigger
+
+This *should* become dead code once anndata 0.14 ships pandas 3 support.
+Leave something that makes that obvious rather than letting it calcify:
+
+- A module-level comment naming **anndata #2221** and the 0.14.0 milestone,
+  stating the coercion can be deleted when the `anndata` ceiling moves to
+  `>=0.14` with pandas-3 support.
+- Ideally a test that fails loudly when the installed anndata *can* write
+  Arrow-backed strings, so the workaround announces its own obsolescence
+  instead of silently pessimising. Something like: if
+  `ad.io.write_elem` succeeds on a `str`-dtype frame, the coercion is no
+  longer needed. Mark it `xfail(strict=False)` or skip-with-reason so it is
+  informative rather than a CI blocker.
+
+### Required: tests
+
+The branch has none, which is the main thing wrong with it. The commit
+message claims validation via
+`test_streaming_pcs_roundtrip.py::test_coo_path_roundtrips` under pandas
+3.0, but nothing in CI runs under `infer_string=True`, so the fix can
+regress silently.
+
+Add a test module that, per test, sets `future.infer_string=True` and
+restores it afterwards (a fixture with `pd.option_context` is cleanest), and
+covers:
+
+- all three write paths (`streaming=False`, `streaming=True` with
+  `use_csc=True` and `use_csc=False`) convert successfully;
+- the store reads back via `sd.read_zarr()` with the expected shape;
+- `_coerce_table_strings_to_object` leaves values unchanged — same order,
+  same content, only dtype differs;
+- a string-backed **categorical** (the `region` column) keeps its codes and
+  category values;
+- it is a no-op when dtypes are already `object`.
+
+Give each conversion its own output path. My first attempt at this shared
+one filename between the two streaming cases and the second run failed with
+"Destination already exists", which looked like a real failure for a while.
+
+### Decide: pandas upper bound
+
+Two defensible options. Pick one and say why in the commit message.
+
+- **Coercion only.** Thyra keeps working on pandas 3. Preferred if you want
+  users on current pandas.
+- **Coercion plus `pandas = ">=2.0.0, <4"`** or similar. The coercion
+  handles the write; a bound documents what has actually been tested. Note
+  the neighbouring dependency block already carries deliberate upper bounds
+  with a long comment explaining why, so adding one here is consistent with
+  house style.
+
+Do **not** pin `pandas < 3` as the whole fix. It papers over a defect that
+is already solved by a commit sitting in the repo, and it will strand users
+whose other packages want pandas 3.
+
+---
+
+## Constraints
+
+- Do not touch the PCS hand-written Zarr path in
+  `thyra/converters/spatialdata/streaming_converter.py`. It already works
+  and its `encoding-type` / `encoding-version` attrs are what makes
+  `anndata.experimental.read_lazy()` work for Ousia. Breaking those breaks
+  lazy reading.
+- Do not "simplify" by building obs/var with `dtype=object` at construction
+  instead. It would scatter the workaround across the 2D, 3D, and streaming
+  converters instead of keeping it at one chokepoint, and it would fight
+  pandas' inference in more places than it fixes.
+
+## Verification
+
+```bash
+cd ../Thyra-pandas3
+PYTHONPATH=$(pwd) poetry run pytest -q
+PYTHONPATH=$(pwd) poetry run python -c "
+import pandas as pd; pd.set_option('future.infer_string', True)
+# then run a conversion on each of the three paths
+"
+poetry run black . && poetry run isort . && poetry run flake8
+poetry run mkdocs build --strict
+```
+
+`PYTHONPATH=$(pwd)` matters — see the note in [README.md](README.md).
+
+Once merged, delete the superseded branch and worktree:
+
+```bash
+git worktree remove ../Thyra-coo-fix
+git push origin --delete fix/streaming-coo-arrow-string-write
+```

--- a/handouts/toolchain-hygiene.md
+++ b/handouts/toolchain-hygiene.md
@@ -1,0 +1,148 @@
+# D. Line-ending churn and hook config drift
+
+**Branch:** `chore/toolchain-hygiene`
+**Worktree:** `../Thyra-toolchain`
+**Priority:** independent, touches no Python in `thyra/`. Do this one first
+if the commit friction is annoying you day to day.
+
+```bash
+git worktree add -b chore/toolchain-hygiene ../Thyra-toolchain main
+```
+
+---
+
+## 1. Line-ending churn (the annoying one)
+
+The working tree holds CRLF files, but the pre-commit `mixed-line-ending`
+hook runs with `args: [--fix=lf]`. The two fight, every time.
+
+Consequences, both observed:
+
+- **Every commit that touches a file fails the hook once**, has the file
+  rewritten to LF, and needs a second `git add` + `git commit`. This
+  happened on all 12 commits of PR #104 without exception.
+- **`pre-commit run --all-files` rewrote 137 unrelated files** in one go,
+  including `.env`, `poetry.lock`, `LICENSE`, `CHANGELOG.md`,
+  `pyproject.toml`, and every docs page. That makes the standard "run all
+  the hooks" command actively unsafe as a pre-push check, which is a shame
+  because it is otherwise exactly what you want to run before pushing.
+
+`.gitattributes` exists. Work out what the intended policy actually is, then
+make `.gitattributes`, the hook, and git's `core.autocrlf` agree so that
+neither a checkout nor the hook keeps rewriting files.
+
+**Acceptance test:** on a clean checkout, `pre-commit run --all-files` twice
+in a row. The second run must report no changes and `git status` must be
+clean. Today the first run modifies 137 files.
+
+Be careful with two things:
+
+- `poetry.lock` and `.env` were among the rewritten files. Whatever policy
+  you pick should probably leave the lock file alone.
+- Committing a mass line-ending normalisation will produce an enormous diff
+  that pollutes `git blame`. If you go that route, do it as a single
+  isolated commit that touches nothing else, and consider adding it to
+  `.git-blame-ignore-revs`.
+
+## 2. pydocstyle config drift
+
+```bash
+poetry run pre-commit run pydocstyle --all-files
+```
+
+fails with `D104: Missing docstring in public package` on
+`thyra/core/__init__.py` and `thyra/metadata/ontology/__init__.py` — even
+though the hook passes `--add-ignore=D100,D104,D105`.
+
+`pyproject.toml` also has:
+
+```toml
+[tool.pydocstyle]
+convention = "google"
+add_ignore = ["D100", "D104", "D105"]
+```
+
+One is overriding the other. This is the same class of drift that PR #104
+fixed for flake8 in commit `e144f2d`: identical settings duplicated between
+hook args and a config file, silently disagreeing.
+
+Pick one home and strip the duplicate. `pyproject.toml` is probably right,
+matching how mypy and bandit are already configured — but verify the hook
+actually reads it, which is exactly the assumption that turned out to be
+false for flake8's `exclude` list. Test both invocation styles:
+`poetry run pydocstyle thyra` and `pre-commit run pydocstyle --all-files`.
+
+## 3. bandit on `--all-files`
+
+```bash
+poetry run pre-commit run bandit --all-files
+```
+
+fails with `B404` (blacklist: consider possible security implications
+associated with the subprocess module) at
+`.github/scripts/complexity_monitor.py:173`.
+
+That file is CI tooling and the import is legitimate. Either add
+`# nosec B404` with a short reason, or extend the bandit exclude in
+`pyproject.toml`, which currently reads `exclude_dirs = ["tests", "docs"]`
+and does not cover `.github/`.
+
+## 4. Two pre-existing mypy errors
+
+A full-repo mypy run is red:
+
+```
+thyra/tools/make_example_data.py:62: error: Returning Any from function
+  declared to return "ndarray[...]"  [no-any-return]
+thyra/metadata/extractors/waters_extractor.py:130: error: Returning Any from
+  function declared to return "ndarray[...] | None"  [no-any-return]
+```
+
+These predate PR #104 — verified identical at commit `45b3680`. They surface
+because `warn_return_any = true` in `[tool.mypy]`, and they never fail the
+hook because pre-commit only passes changed files.
+
+Both are almost certainly a missing `cast` or an untyped third-party return.
+Fix them if cheap so a full mypy run is green.
+
+---
+
+## The goal
+
+`poetry run pre-commit run --all-files` should pass cleanly **and
+idempotently** on an unmodified checkout, so it can be trusted as a
+pre-push check. Right now it modifies 137 files and fails three hooks.
+
+## Constraints
+
+- Do not relax a check to make it pass. `--add-ignore` for a rule that is
+  genuinely being violated, or a blanket bandit skip, trades a real signal
+  for a green tick. Narrow, justified exclusions are fine; that is what
+  PR #104 did for `scripts/`, with the reasoning written into `.flake8`.
+- Leave `.flake8` and the flake8 hook alone. They were just reconciled in
+  `e144f2d` and both invocations are clean. Use them as the model.
+
+## Verification
+
+```bash
+cd ../Thyra-toolchain
+poetry run pre-commit run --all-files   # must pass
+git status --short                       # must be empty
+poetry run pre-commit run --all-files   # must pass again, still empty
+poetry run mypy thyra                   # should be green
+poetry run pytest -q
+poetry run mkdocs build --strict
+```
+
+## While you are here
+
+Delete the two dead remote branches, since they currently look like work in
+progress:
+
+```bash
+git push origin --delete fix/streaming-pcs-image-write
+git push origin --delete feature/lazy-loading-support
+```
+
+Justification for both is in [README.md](README.md). Do **not** delete
+`fix/streaming-coo-arrow-string-write`; it is handout A's subject.

--- a/handouts/write-amplification.md
+++ b/handouts/write-amplification.md
@@ -1,0 +1,172 @@
+# C. Write amplification and resampling memory
+
+**Branch:** `perf/write-amplification`
+**Worktree:** `../Thyra-perf`
+**Priority:** start after handout A merges, then branch from the updated
+`main`. A touches `_save_output` in the same file you will be working in.
+
+```bash
+git fetch origin && git worktree add -b perf/write-amplification ../Thyra-perf origin/main
+```
+
+---
+
+## Framing
+
+This is an **investigation**, not a list of fixes. Thyra's stated purpose is
+converting 100+ GB datasets, and there are four measured or observed leads
+suggesting the conversion path does substantially more work than it needs
+to. Measure each at scale first. Report numbers before proposing changes,
+and do not assume a lead is real because it is written down here — two of
+the four are observations rather than measurements, and are marked as such.
+
+There are existing benchmarks in `benchmarks/`. Check what they already
+cover before writing new ones.
+
+---
+
+## Lead 1: metadata rewritten dozens of times per conversion (measured)
+
+Instrumenting `zarr.storage._local._atomic_write` during **one conversion of
+a 4-spectrum dataset** showed 40 distinct Zarr keys written but 22 of them
+written more than once:
+
+| key | times written |
+|---|---|
+| `<store>/zarr.json` | **28** |
+| `<store>/tables/zarr.json` | 21 |
+| `<store>/tables/ds_z0/zarr.json` | 20 |
+| `<store>/tables/ds_z0/obs/zarr.json` | 15 |
+| `<store>/images/ds_z0_tic/zarr.json` | 8 |
+| `<store>/tables/ds_z0/X/zarr.json` | 7 |
+
+Roughly 430 metadata renames total, for four pixels.
+
+This is not cosmetic. It is the direct cause of the Windows `WinError 5`
+race that v1.27.0 works around with a bounded retry — see the analysis in
+`thyra/utils/zarr_atomic_write.py`. Reducing the rewriting would remove the
+cause rather than retrying past it.
+
+Find out:
+
+- Is this `SpatialData.write()` re-serialising the store root once per
+  element added? Compare against `write_element` used incrementally.
+- **How does it scale?** The suspicion is that it scales with *element
+  count*, not pixel count, which would make it a fixed overhead rather than
+  a large-dataset problem. Confirm or kill that. If it is fixed overhead of
+  a few hundred renames, it matters for robustness but not for throughput,
+  and the finding is "keep the retry, close the issue".
+- Whether the streaming converter's own `zarr.open_group` /
+  `consolidate_metadata` calls add to it.
+
+## Lead 2: default bin counts upsample heavily (measured)
+
+The default is 5 mDa at m/z 1000 for every axis type except `linear_tof`
+(17 mDa at m/z 300). On the tutorial's 250-1200 Da synthetic dataset that is
+**190,000 bins from 4,000 source m/z values**, a 45x upsample.
+
+The store stays small (~29 MB) because it is sparse, so this is not a disk
+problem. It is a problem for every consumer, which pays for a 190k-wide
+`var` axis, and for lead 4 below.
+
+See `_calculate_bins_from_width` in
+`thyra/converters/spatialdata/base_spatialdata_converter.py` and the
+bin-count table in `docs/resampling.md`.
+
+Consider deriving the default from observed source spacing — `peak density`
+is already collected in `DataCharacteristics` — instead of a fixed width.
+Then measure what that does to real Bruker and imzML data, not just the
+synthetic phantom.
+
+**This is a behaviour change with compatibility impact.** Thyra is a library
+with an external consumer (Ousia). Changing default bin counts changes the
+`var` axis of every future conversion. Do not change it quietly: if the
+numbers support a change, propose it with before/after figures and let the
+owner decide.
+
+## Lead 3: processed-mode imzML scans every spectrum twice (observed)
+
+With `--no-resample` on processed data, the raw-axis path iterates all
+spectra to collect unique m/z values. The code already says so:
+
+```
+Building RAW mass axis (no resampling) - processed mode, iterating ALL
+spectra to collect unique m/z values. This is slow for large datasets!
+```
+
+There is also a separate "Scanning mass range and counting peaks" pass
+before it.
+
+Measure both passes on something large. Then see whether they can be merged
+into one, and whether the unique-m/z collection can use something cheaper
+than a Python set over every value.
+
+## Lead 4: the dense resampling path allocates per pixel (observed)
+
+`_resample_spectrum_to_indices` returns `np.arange(len(common_mass_axis))`
+for **every spectrum**, and the non-nearest-neighbor branch of
+`_process_single_spectrum` builds a dense array of the full axis width per
+pixel (`base_spatialdata_converter.py`, roughly lines 890-970).
+
+`nearest_neighbor` has a sparse fast path that returns only non-zero bins.
+`tic_preserving` does not. At 190k bins that is ~1.5 MB allocated per pixel
+before sparsification, so a 10,000-pixel dataset with `tic_preserving` does
+15 GB of allocation churn.
+
+Check whether `tic_preserving` can produce sparse output directly. Note the
+constraint that makes it non-trivial: TIC preservation is defined over the
+whole spectrum, so the rescaling factor needs the full interpolated
+spectrum's sum. That may be computable without materialising the dense
+array.
+
+---
+
+## Constraints
+
+**Do not change the on-disk format in a way that breaks lazy reading.**
+`anndata.experimental.read_lazy()` currently works on Thyra output and Ousia
+depends on it. Verified on `main`:
+
+```
+read_lazy OK: 36 x 40, X=Array
+  obs columns: ['y', 'region', 'region_number', 'x', 'spatial_y', 'spatial_x']
+```
+
+That works because the streaming PCS path hand-writes `encoding-type` /
+`encoding-version` attrs for every array, group, categorical, and 0-d
+scalar. `main` is deliberately granular here: `"string"` for scalars in
+`uns` versus `"string-array"` for arrays. If you touch how the store is
+written — and lead 1 is squarely about that — **assert `read_lazy` still
+works**, not merely that the files exist.
+
+**Do not "fix" the WinError 5 retry by removing it** even if lead 1 reduces
+the rewriting. Fewer renames lowers the probability of the race; it does not
+eliminate it, since the race needs only one contended rename.
+
+**Coordinate systems are contract-tested.** `tests/unit/converters/
+test_coordinate_systems.py` pins that the TIC image and pixel polygons agree
+at `"global"`. If a write-path change moves transforms, that is a real
+regression, not a stale test.
+
+## Verification
+
+```bash
+cd ../Thyra-perf
+PYTHONPATH=$(pwd) poetry run pytest -q
+poetry run black . && poetry run isort . && poetry run flake8
+poetry run mkdocs build --strict
+```
+
+For lead 1, the instrumentation that produced the numbers above is worth
+recreating: wrap `zarr.storage._local._atomic_write`, count writes per key
+path, and report the distribution. Be aware that instrumenting it perturbs
+timing enough to change the `WinError 5` failure rate substantially, so do
+not use write counts and race frequency from the same run to draw
+conclusions about both.
+
+## Deliverable
+
+A findings report with measurements, then separate commits per change that
+the measurements justify. It is a perfectly good outcome for this handout to
+conclude that two of the four leads are not worth acting on — say so with
+the numbers that show it.


### PR DESCRIPTION
Adds `handouts/` documenting the outstanding work, written so each piece can be picked up independently in its own worktree.

Also records the triage of the three live branches:

- `fix/streaming-pcs-image-write` — **already upstream**. `git cherry -v main` reports `-`, and its test is on main.
- `feature/lazy-loading-support` — **superseded**. main already writes every encoding attr the branch adds, more granularly (it distinguishes `"string"` for 0-d scalars from `"string-array"` for arrays, which the branch's binary `is_string` helper cannot express). Verified `anndata.experimental.read_lazy()` already works on main output.
- `fix/streaming-coo-arrow-string-write` — **live and wanted**, and more urgent than it looks: the failure is not COO-specific, the in-memory path fails too, and `pandas` has no upper bound so pandas 3 is installable today.

Kept out of `docs/` so the mkdocs `--strict` nav check stays clean.