### PR TITLE
docs(handouts): fold in findings from spatialdata PR #1055

### DIFF
--- a/handouts/README.md
+++ b/handouts/README.md
@@ -14,6 +14,35 @@ spatialdata 0.7.3 / zarr 3.1.3.
 | B | [optimize-chunks.md](optimize-chunks.md) | `fix/optimize-chunks-sparse` | `../Thyra-chunks` | independent |
 | C | [write-amplification.md](write-amplification.md) | `perf/write-amplification` | `../Thyra-perf` | after A |
 | D | [toolchain-hygiene.md](toolchain-hygiene.md) | `chore/toolchain-hygiene` | `../Thyra-toolchain` | independent |
+| E | [upstream-lazy-table-pr.md](upstream-lazy-table-pr.md) | *upstream* | *scverse/spatialdata* | independent |
+
+Handout E is work in `scverse/spatialdata`, not here. It is listed because
+it is the critical path for Ousia reading Thyra output lazily, and because
+its findings change how B and C should be judged.
+
+## The lazy-reading picture
+
+Worth reading before B or C. spatialdata PR #1055 (yours) adds
+`read_zarr(..., lazy=True)`. It was tested against stores from all three
+Thyra write paths and **works today**:
+
+```
+in_memory      X=Array  obs=Dataset2D  block_equal=True
+streaming_pcs  X=Array  obs=Dataset2D  block_equal=True
+streaming_coo  X=Array  obs=Dataset2D  block_equal=True
+```
+
+Two consequences:
+
+- **Thyra's on-disk format is already right for lazy reading.** Nothing
+  needs to change here to support it. What must not happen is a change that
+  breaks it, which is why B and C both carry a "assert `read_lazy` still
+  works" constraint.
+- **Wide `var` axes are the design target, not a defect.** The PR's own
+  benchmark is 100,000 pixels x 100,000 m/z bins. That materially weakens
+  handout C's lead 2 (default bin counts upsampling 45x): lazy loading is
+  the answer to wide axes, so shrinking the default is less obviously
+  right than it looked. Handout C says so.
 
 ## Ordering and overlap
 

--- a/handouts/optimize-chunks.md
+++ b/handouts/optimize-chunks.md
@@ -82,6 +82,20 @@ Compare against what `thyra/converters/spatialdata/_chunking.py` already
 does. That module was introduced as "the sharding seam" and may already set
 sensible chunks at write time, making a post-hoc pass pointless.
 
+There is a live reason it might buy something. spatialdata PR #1055 — see
+[handout E](upstream-lazy-table-pr.md) — adds `read_zarr(..., lazy=True)`,
+and it already works on Thyra output. Under lazy reading the chunk sizes of
+`data`, `indices`, and `indptr` **directly determine read performance**,
+because a lazy consumer pulls chunks rather than the whole array. So
+"chunking is right for the access pattern" stops being cosmetic.
+
+If you take Option 1, benchmark against the lazy access pattern, not just
+the eager one: an ion image over an m/z window, and a single pixel's
+spectrum, via `read_zarr(..., lazy=True)`. That is how Ousia will read
+these stores. Note that whole-array dask reductions over sparse `X` do not
+work at all (a dask/scipy-sparse limitation described in handout E), so do
+not build a benchmark around `X.sum()`.
+
 ### Option 2: remove the flag and the function
 
 If `_chunking.py` already covers it, deleting is the better answer: a

--- a/handouts/pandas-3-string-dtypes.md
+++ b/handouts/pandas-3-string-dtypes.md
@@ -63,6 +63,13 @@ Checked directly:
 - **spatialdata-io #364** is the same failure hitting spatialdata's own
   Xenium writer, so this is an ecosystem gap, not a Thyra bug.
 
+The repo owner is a spatialdata contributor with an open PR there (#1055,
+see [handout E](upstream-lazy-table-pr.md)). The same coercion arguably
+belongs in spatialdata's own table write path, which would make Thyra's
+copy redundant. That is a good thing to raise on #364, but it is not a
+reason to delay this handout: Thyra cannot wait on an upstream release
+cycle for a bug that breaks conversions today.
+
 `pyproject.toml` pins `anndata = ">=0.11.0, <0.13"`, so even 0.13's warnings
 are out of range and 0.14 is far out.
 

--- a/handouts/upstream-lazy-table-pr.md
+++ b/handouts/upstream-lazy-table-pr.md
@@ -1,0 +1,145 @@
+# E. Upstream: land spatialdata PR #1055 (lazy table loading)
+
+**Repo:** `scverse/spatialdata`, not this one
+**PR:** https://github.com/scverse/spatialdata/pull/1055
+**Branch:** `Tomatokeftes:spatialdata:feature/lazy-table-loading`
+**Priority:** highest leverage for Ousia. Independent of everything else here.
+
+This is the only handout whose work happens outside the Thyra repo. It is
+included because it is on the critical path for Ousia consuming Thyra
+output lazily, and because its state changes how handouts B and C should be
+judged.
+
+---
+
+## State as of 2026-07-30
+
+| | |
+|---|---|
+| Status | **open, mergeable, zero human reviews** |
+| Opened | 2026-01-27 (six months) |
+| Last touched | 2026-07-13 |
+| Size | 8 files, +208 / -58 |
+| Divergence | 13 ahead, **5 behind** `main` |
+| Patch coverage | 96.55% (codecov, 1 line uncovered) |
+| Only comment | the codecov bot |
+
+Nothing has been requested by a maintainer. It is not blocked on changes; it
+is simply unattended. Five commits behind is nothing — this is very
+rebasable.
+
+## What it does
+
+Adds `lazy: bool = False` to `SpatialData.read()` / `read_zarr()` and
+`_read_table()`, backing tables with `anndata.experimental.read_lazy()`
+instead of loading them into memory. Plus a `_is_lazy_anndata()` helper,
+validation that skips eager checks for lazy tables, and fixes to
+`_filter_table_by_element_names`, `_filter_table_by_elements`,
+`get_values`, and `_inplace_fix_subset_categorical_obs` so
+`bounding_box_query` and `aggregate` work on lazy tables.
+
+Reported benchmark, 100,000 pixels x 100,000 m/z bins, ~296M non-zeros:
+15.4 MB versus 2,270.7 MB, 0.13s versus 1.57s.
+
+---
+
+## Verified: Thyra output already works with it
+
+This was tested directly, by checking out the PR head
+(`bfd2b5f`) and pointing it at stores produced by every Thyra write path:
+
+```
+in_memory      X=Array  obs=Dataset2D  block_equal=True  nnz=12  var=60
+streaming_pcs  X=Array  obs=Dataset2D  block_equal=True  nnz=12  var=60
+streaming_coo  X=Array  obs=Dataset2D  block_equal=True  nnz=12  var=60
+```
+
+`block_equal=True` means a lazy `X[:6, :30].compute()` is identical to the
+eager read of the same block, and `obs["x"]` resolves to the right values.
+
+**So no change is needed in Thyra for the lazy path to work.** The
+`encoding-type` / `encoding-version` attrs `main` already writes are
+sufficient. This also confirms the Thyra branch
+`feature/lazy-loading-support` is genuinely redundant, not merely stale.
+
+### One practical caveat worth knowing
+
+Dask reductions over the sparse `X` do not work:
+
+```python
+lazy.X.sum().compute()
+# TypeError: _cs_matrix.sum() got an unexpected keyword argument 'keepdims'
+```
+
+Dask passes `keepdims` into `scipy.sparse`'s `sum`, which does not accept
+it. This is a dask/scipy-sparse interop limitation, not something the PR or
+Thyra causes, and not something either can fix. Slicing and `.compute()`
+work fine, which is the realistic MSI access pattern (extract an ion image,
+pull one pixel's spectrum). Ousia should avoid whole-array dask reductions
+on lazy tables, or call `.to_memory()` on a slice first.
+
+---
+
+## The real blocker for Ousia: dependency ceilings
+
+Even once this merges, **Thyra users cannot reach it** without Thyra moving
+three pins. The PR branch declares:
+
+```
+dask>=2026.3.0
+ome_zarr>=0.16.0
+distributed>=2026.3.0
+```
+
+Thyra's `pyproject.toml` pins:
+
+```
+dask         = ">=2025.12.0, <2026.2"   # installed: 2026.1.1
+ome-zarr     = ">=0.14.0, <0.16"        # installed: 0.15.0
+spatialdata  = ">=0.7.3, <0.8"          # installed: 0.7.3
+```
+
+spatialdata is **already at v0.8.0** (released 2026-07-02), which Thyra's
+ceiling excludes. Whatever release carries #1055 will be further out still.
+
+Those ceilings are deliberate and well-commented — there is a long note in
+`pyproject.toml` explaining that this cluster releases frequently with
+breaking cross-version interactions, and that the clean-venv CI job exists
+to keep them honest. They are not accidental and should not be bumped
+casually.
+
+Encouraging data point: the PR branch **imported and ran correctly against
+Thyra's installed dask 2026.1.1 and ome_zarr 0.15.0**, below its declared
+floors. So the floors may be conservative and the real compatibility window
+may be wider than the metadata claims. Worth establishing rather than
+assuming.
+
+---
+
+## Suggested work
+
+1. **Rebase onto `main`** (only 5 commits behind) so it is trivially
+   mergeable and CI is green against current `main`.
+2. **Ping for review.** Six months with no maintainer response usually means
+   it fell off the queue rather than that anyone objects. A comment with the
+   benchmark table and a concrete downstream consumer named (MSI data via
+   Thyra, for Ousia) is the useful nudge. Consider the scverse Zulip.
+3. **Cover the caveat.** A note in the docstring or docs that dask
+   reductions over sparse `X` are unsupported would save the next person the
+   confusion, and pre-empts a "lazy loading is broken" issue.
+4. **Once it lands**, open a follow-up in Thyra to raise the
+   `spatialdata` / `dask` / `ome-zarr` ceilings together, exercised by the
+   existing clean-venv CI job. That is the step that actually delivers lazy
+   reading to Ousia.
+
+## Related upstream gap you are positioned to fix
+
+`spatialdata-io` issue #364 reports `spatialdata.write` failing on Xenium
+data under pandas 3.0, with the same `IORegistryError` on
+`ArrowStringArray` that handout A works around inside Thyra. anndata #2221
+tracks the root cause and is milestoned 0.14.0.
+
+Handout A fixes this downstream in Thyra because Thyra cannot wait. But the
+same coercion belongs in spatialdata's own table write path, and you already
+have commit rights to a PR there. If you fix it upstream, Thyra's workaround
+eventually deletes itself. Worth raising on #364 at least.

--- a/handouts/write-amplification.md
+++ b/handouts/write-amplification.md
@@ -66,17 +66,34 @@ The default is 5 mDa at m/z 1000 for every axis type except `linear_tof`
 **190,000 bins from 4,000 source m/z values**, a 45x upsample.
 
 The store stays small (~29 MB) because it is sparse, so this is not a disk
-problem. It is a problem for every consumer, which pays for a 190k-wide
-`var` axis, and for lead 4 below.
+problem. It costs every consumer that materialises the table, and it feeds
+lead 4 below.
 
 See `_calculate_bins_from_width` in
 `thyra/converters/spatialdata/base_spatialdata_converter.py` and the
 bin-count table in `docs/resampling.md`.
 
-Consider deriving the default from observed source spacing — `peak density`
-is already collected in `DataCharacteristics` — instead of a fixed width.
-Then measure what that does to real Bruker and imzML data, not just the
-synthetic phantom.
+**Treat this lead sceptically.** It looked stronger before the upstream
+lazy-loading work was taken into account. spatialdata PR #1055 — see
+[handout E](upstream-lazy-table-pr.md) — benchmarks itself at **100,000
+pixels x 100,000 m/z bins** and works on Thyra output today. Wide `var`
+axes are the design target of the lazy path, not a pathology it struggles
+with. If the intended consumption mode is `read_zarr(..., lazy=True)`, a
+190k-wide axis is largely free to the consumer and shrinking the default
+buys much less than it appears to.
+
+So the question to answer is not "are 190,000 bins too many" but:
+
+- who actually pays for the width, once lazy reading is in play? Measure a
+  realistic Ousia-style access (ion image over an m/z window, single-pixel
+  spectrum) against a wide and a narrow axis.
+- is 45x upsampling scientifically meaningful, or is it inventing
+  resolution the instrument never had? That is a different argument from
+  the performance one and may be the stronger reason to change.
+
+Deriving the default from observed source spacing — `peak density` is
+already collected in `DataCharacteristics` — remains a reasonable idea. But
+justify it on the numbers above, not on the raw bin count looking large.
 
 **This is a behaviour change with compatibility impact.** Thyra is a library
 with an external consumer (Ousia). Changing default bin counts changes the


### PR DESCRIPTION
Follow-up to #105 after reviewing the upstream lazy-table PR.

**Verified against the PR head:** Thyra output works with `read_zarr(..., lazy=True)` on all three write paths — lazy `X[:6,:30].compute()` is identical to the eager read of the same block, `obs` resolves correctly. So Thyra's on-disk format already supports lazy reading and needs no change.

Adds handout E for the upstream PR (open, mergeable, zero human reviews in six months, only 5 commits behind main) and reframes two existing handouts:

- **Lead 2 of C is weakened** — the PR benchmarks at 100k x 100k, so wide `var` axes are the lazy path's design target, not a pathology.
- **B gains a reason to keep the flag** — under lazy reading, chunk sizes on `data`/`indices`/`indptr` directly determine read performance.

Also records the dependency-ceiling problem that blocks Ousia from actually reaching this: the PR declares `dask>=2026.3.0` / `ome_zarr>=0.16.0` while Thyra pins `dask<2026.2` / `ome-zarr<0.16`, and spatialdata is already at v0.8.0 against a `<0.8` ceiling.