### PR TITLE
docs(handouts): add handout F and record the branch sweep

### DIFF
--- a/handouts/README.md
+++ b/handouts/README.md
@@ -15,10 +15,15 @@ spatialdata 0.7.3 / zarr 3.1.3.
 | C | [write-amplification.md](write-amplification.md) | `perf/write-amplification` | `../Thyra-perf` | after A |
 | D | [toolchain-hygiene.md](toolchain-hygiene.md) | `chore/toolchain-hygiene` | `../Thyra-toolchain` | independent |
 | E | [upstream-lazy-table-pr.md](upstream-lazy-table-pr.md) | *upstream* | *scverse/spatialdata* | independent |
+| F | [interpolation-resampling.md](interpolation-resampling.md) | *not created* | `../Thyra-interp` | backlog |
 
 Handout E is work in `scverse/spatialdata`, not here. It is listed because
 it is the critical path for Ousia reading Thyra output lazily, and because
 its findings change how B and C should be judged.
+
+Handout F is backlog, not a defect: a capability `main` does not have, whose
+only prior art was about to be deleted with a stale branch. It is written up
+so the decision can be made deliberately rather than by attrition.
 
 ## The lazy-reading picture
 
@@ -102,25 +107,35 @@ Two things to know about working in a worktree here:
   `thyra/metadata/extractors/waters_extractor.py:130`. They are not yours
   unless you are on handout D.
 
-## Branch cleanup (do this once, anywhere)
+## Branch cleanup — done 2026-07-30
 
-Two remote branches are dead and should be deleted so they stop looking
-like work in progress:
+This section used to list two dead branches. The sweep it asked for has
+happened and went further: 56 stale local branches and 5 remote ones are
+gone, leaving `main`, `gh-pages`, and the three live lane branches.
 
-- `origin/fix/streaming-pcs-image-write` — already merged. `git cherry -v
-  main origin/fix/streaming-pcs-image-write` reports `-`, and
-  `tests/unit/converters/test_streaming_pcs_roundtrip.py` is on `main`.
-- `origin/feature/lazy-loading-support` — superseded, 83 commits behind.
-  `main` already writes every `encoding-type` / `encoding-version` attr the
-  branch adds, and does it **better**: `main` distinguishes `"string"` for
-  0-d scalars in `uns` from `"string-array"` for arrays, which the branch's
-  binary `_set_encoding_attrs(is_string=...)` helper cannot express.
-  Verified that `anndata.experimental.read_lazy()` already works on `main`
-  output (see handout C for the transcript).
+Each was classified before deletion, not deleted by age:
 
-`origin/fix/streaming-coo-arrow-string-write` is **live and wanted** — it is
-the subject of handout A. Do not delete it.
+| Basis | Count |
+|---|---|
+| ancestor of `main` (`git branch -d`, git verifies the merge itself) | 22 |
+| squash/rebase-merged — every commit's patch already upstream (`git cherry` all `-`) | 14 |
+| superseded, verified individually | 20 |
 
-The stale worktree at `../Thyra-coo-fix` sits on that branch 19 commits
-behind `main`. Handout A supersedes it; remove it with
-`git worktree remove ../Thyra-coo-fix` once A has landed.
+SHAs are recorded in `.git/deleted-branches-2026-07-30.txt`; restore any with
+`git branch <name> <sha>`.
+
+Two findings came out of the sweep and are the reason it was worth doing
+branch by branch rather than in bulk:
+
+- `feature/lazy-loading-support` carried the **only** test of the
+  `encoding-type` / `encoding-version` attrs the PCS path hand-writes —
+  `git grep encoding-type tests/` on `main` was empty. Its implementation
+  was genuinely superseded (`main` distinguishes `"string"` for 0-d scalars
+  in `uns` from `"string-array"` for arrays, which the branch's binary
+  `_set_encoding_attrs(is_string=...)` helper could not express), but the
+  test was not. Ported to `main` in #108 *before* the branch was deleted.
+- `feature/conservative-interpolation-implementation` held a capability
+  `main` still lacks. Archived as tag `archive/conservative-interpolation`
+  and written up as handout F.
+
+Everything else was already on `main` in equal or better form.

--- a/handouts/interpolation-resampling.md
+++ b/handouts/interpolation-resampling.md
@@ -1,0 +1,119 @@
+# F. PCHIP interpolation: designed, half-built, never shipped
+
+**Branch:** `feat/pchip-resampling` (not created)
+**Worktree:** `../Thyra-interp`
+**Priority:** backlog. Nothing is broken; this is a capability gap.
+
+This handout exists because the work behind it was about to be lost. A
+2026-07-30 sweep deleted 38 stale local branches whose content was already on
+`main`, and 18 more that had genuinely unique commits. Of those 18, exactly
+one held something `main` still does not have. Everything else was
+superseded, reimplemented, or abandoned.
+
+The code is preserved at tag **`archive/conservative-interpolation`**
+(`106d6ff`). Tags are refs, so it will survive `git gc`; the branch it came
+from is gone.
+
+---
+
+## The gap
+
+`main` offers three resampling methods and no interpolation:
+
+```python
+class ResamplingMethod(Enum):
+    NONE = "none"
+    NEAREST_NEIGHBOR = "nearest_neighbor"
+    TIC_PRESERVING = "tic_preserving"
+```
+
+`thyra/resampling/strategies/` holds `nearest_neighbor.py` and
+`tic_preserving.py`. There is no interpolating strategy, and
+`git grep -i pchip thyra/` is empty.
+
+That is a real limitation for profile-mode data. Nearest-neighbour snaps each
+peak to a bin and distorts peak shape; TIC-preserving redistributes intensity
+so the total ion count survives rebinning, which is the right call for
+quantitative work but still does not reconstruct the profile between samples.
+Shape-preserving cubic interpolation is the third option, and it is the one
+mMass-style pipelines reach for when the m/z grid changes.
+
+Whether that matters enough to build is the open question. It is a judgement
+about the science, not about the code, which is why this is a handout rather
+than a ticket.
+
+## What already shipped, so you do not rebuild it
+
+The archived branch carries `INTERPOLATION_PLAN.md`, a two-phase plan.
+**Phase 1 shipped**, reimplemented and improved, and is on `main` today:
+
+| Plan item | Status on `main` |
+|---|---|
+| `BaseMassAxisGenerator` abstract class | `thyra/resampling/mass_axis/base_generator.py` |
+| `LinearMassAxisGenerator` | `mass_axis/linear_generator.py` |
+| Physics-based TOF / Orbitrap / FTICR generators | `mass_axis/linear_tof_generator.py`, `reflector_tof_generator.py`, `orbitrap_generator.py`, `fticr_generator.py` |
+| Auto-select generator from instrument metadata | `thyra/resampling/instrument_detectors.py` + `decision_tree.py` |
+
+So the axis half of the plan is done, and done better than the archived
+branch did it -- the branch only had a linear generator.
+
+**Phase 2 did not ship.** The archived branch has a working first cut:
+
+```
+msiconvert/interpolators/base_interpolator.py    172 lines
+msiconvert/interpolators/pchip_interpolator.py   125 lines
+tests/unit/interpolators/test_pchip_interpolator.py    281 lines
+tests/unit/interpolators/test_integration_phase2.py    296 lines
+```
+
+## Read it, do not merge it
+
+The archived code is from **August 2025** and cannot be applied:
+
+- It targets the `msiconvert/` package, before the rename to `thyra/`.
+- It predates `thyra/resampling/` entirely, so its own mass-axis generators
+  duplicate what `main` now has and its `BaseInterpolator` does not implement
+  the `strategies/base.py` interface a resampling strategy has to satisfy
+  today.
+- Its `poetry.lock` is a year stale.
+
+Treat it as a design document with tests attached, not as a patch. The
+useful parts are the plan's edge-case list (single points, duplicate m/z
+values, NaN handling) and the test cases, which encode what "correct"
+looked like to whoever wrote them.
+
+## What to do, if it is worth doing
+
+1. Decide the science question first: does profile-mode conversion need
+   shape-preserving interpolation, given `TIC_PRESERVING` already exists?
+   If the answer is no, delete the tag and this handout.
+2. If yes, add `PCHIP = "pchip"` to `ResamplingMethod` and implement it as a
+   normal strategy in `thyra/resampling/strategies/pchip.py` against
+   `strategies/base.py`. Do not resurrect the `interpolators/` package
+   layout -- `main`'s resampling module is the architecture now.
+3. Port the archived tests to the current interfaces rather than writing
+   fresh ones. They are the most valuable thing in the tag.
+4. Wire it into `ResamplingDecisionTree` only if there is a rule for when it
+   should be chosen automatically. Otherwise leave it opt-in.
+
+## Constraints
+
+- Do not add an `interpolators/` package. `thyra/resampling/` is the home for
+  anything that changes the mass axis, and splitting that across two package
+  trees is what made the 2025 attempt unmergeable.
+- `scipy` is already a dependency (`>=1.7.0`), so `scipy.interpolate.PchipInterpolator`
+  needs no new dependency. Do not add one.
+- Interpolation must stay opt-in. `NONE` is the default for a reason: the
+  cheapest conversion is the one that does not touch the data.
+
+## Verification
+
+```bash
+PYTHONPATH=$(pwd) poetry run pytest -q
+poetry run black . && poetry run isort . && poetry run flake8
+```
+
+A new strategy needs a round-trip test proving that interpolating onto the
+*same* axis is the identity, and a TIC-drift test quantifying how much total
+ion count the method loses relative to `TIC_PRESERVING`. Without the second
+one there is no way to advise users which to pick.


### PR DESCRIPTION
The repo carried 60 local branches. This is the writeup of the sweep that cut them to four, plus the one piece of work that turned out to be worth keeping.

## How they were classified

Not by age -- each was checked against `main` first:

| Basis | Count |
|---|---|
| ancestor of `main` (`git branch -d`, git verifies the merge itself) | 22 |
| squash/rebase-merged, every commit's patch already upstream (`git cherry` all `-`) | 14 |
| superseded, checked individually | 20 |

56 local and 5 remote branches deleted; `main`, `gh-pages` and the three live lane branches (B, C, D) remain. SHAs are in `.git/deleted-branches-2026-07-30.txt` -- inside `.git`, so it cannot be committed by accident. Restore any with `git branch <name> <sha>`.

## The two that were not safe to delete blind

This is the argument for doing it branch by branch.

**`feature/lazy-loading-support`** carried the only test of the `encoding-type` / `encoding-version` attrs the PCS path hand-writes. `git grep encoding-type tests/` on `main` was empty, against 39 places that write them. The implementation was genuinely superseded and improved on; the test was not. Ported in #108 *before* the branch was deleted.

**`feature/conservative-interpolation-implementation`** held a capability `main` still lacks. `ResamplingMethod` offers `NONE`, `NEAREST_NEIGHBOR`, `TIC_PRESERVING`; `git grep -i pchip thyra/` is empty. Archived as tag `archive/conservative-interpolation` (pushed -- tags are refs, so it survives `gc`) and written up as handout F.

## Why F is a handout and not a ticket

Phase 1 of that branch's plan -- mass axis generation including the physics-based TOF/Orbitrap/FTICR generators -- **already shipped** on `main` as `thyra/resampling/mass_axis/`, and did it better than the branch (which only had a linear generator). Only Phase 2, the PCHIP interpolator, is missing.

Whether that is worth building is a question about the science, not the code: `TIC_PRESERVING` already conserves total ion count, and the open question is whether profile-mode conversion also needs shape-preserving reconstruction between samples. The handout says so plainly and puts that decision first, with "delete the tag and this handout" as an acceptable answer.

It also records what `main` already supersedes so nobody rebuilds it, and is explicit that the archived code must be **read, not merged** -- it targets the pre-rename `msiconvert/` package, predates `thyra/resampling/` entirely, and its `BaseInterpolator` does not implement the `strategies/base.py` interface a resampling strategy has to satisfy today. The reusable part is its edge-case list and its ~577 lines of tests.

## Also

Replaces the README's branch-cleanup section, which asked for a sweep that has since happened and named branches that no longer exist.

Docs only -- no code, and `docs` is not a releasable tag, so this cuts no version.