### PR TITLE
fix(resampling): make tic_preserving actually preserve TIC

### DIFF
--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -137,11 +137,16 @@ quantitation.
 Use it whenever the total ion count per pixel has to stay comparable before and
 after conversion.
 
-The total that is preserved is the one inside the axis range. If you crop with
-`--resample-min-mz` or `--resample-max-mz`, intensity outside the window is
-dropped rather than redistributed over the bins you kept, so the per-pixel total
-falls by whatever you cropped out. With the default axis, which spans the
-dataset's own mass range, nothing is dropped and the total is unchanged.
+The total that is preserved is the share of the spectrum inside the axis range.
+If you crop with `--resample-min-mz` or `--resample-max-mz`, intensity outside
+the window is dropped rather than redistributed over the bins you kept, so the
+per-pixel total falls by whatever you cropped out -- a cropped window should not
+claim ions from the parts that were cut away. That share is measured by area, so
+a window narrower than the spacing between source points still keeps a
+proportionate amount instead of collapsing to zero.
+
+With the default axis, which spans the dataset's own mass range, nothing is
+dropped and the total is preserved exactly.
 
 ---
 

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -137,6 +137,12 @@ quantitation.
 Use it whenever the total ion count per pixel has to stay comparable before and
 after conversion.
 
+The total that is preserved is the one inside the axis range. If you crop with
+`--resample-min-mz` or `--resample-max-mz`, intensity outside the window is
+dropped rather than redistributed over the bins you kept, so the per-pixel total
+falls by whatever you cropped out. With the default axis, which spans the
+dataset's own mass range, nothing is dropped and the total is unchanged.
+
 ---
 
 ## Axis types

--- a/tests/unit/converters/test_tic_preserving_resample.py
+++ b/tests/unit/converters/test_tic_preserving_resample.py
@@ -123,15 +123,19 @@ class TestCroppedAxis:
     """
 
     def test_out_of_range_intensity_is_not_redistributed(self):
-        # Three peaks; the axis covers only the middle one.
+        # Five points; the axis covers a window around the middle one.
         mzs = np.array([300.0, 400.0, 500.0, 600.0, 700.0])
         intensities = np.array([100.0, 100.0, 50.0, 100.0, 100.0])
         axis = _axis(5_000, lo=450.0, hi=550.0)
 
         out = _resample(axis, mzs, intensities)
 
-        # Only the 500.0 peak is inside [450, 550].
-        assert out.sum() == pytest.approx(50.0, rel=1e-9)
+        # The kept share is measured by area, not by counting the source
+        # points that happen to fall inside. Trapezoid area over the whole
+        # spectrum is 35,000; over [450, 550] -- taking the interpolated
+        # value 75 at each cut point and the sample 50 at 500 -- it is
+        # 6,250. So 6250/35000 of a 450 TIC survives.
+        assert out.sum() == pytest.approx(450.0 * 6250.0 / 35000.0, rel=1e-9)
         assert out.sum() < intensities.sum()
 
     def test_full_range_axis_preserves_whole_tic(self):
@@ -139,6 +143,36 @@ class TestCroppedAxis:
         mzs, intensities = _centroid_spectrum()
         out = _resample(_axis(10_000), mzs, intensities)
         assert out.sum() == pytest.approx(intensities.sum(), rel=1e-9)
+
+    def test_window_narrower_than_source_spacing_is_not_blanked(self):
+        """A window containing no source point must still carry signal.
+
+        Counting the source points inside the range reports zero here --
+        the nearest samples sit at 500.0 and 501.0, outside a window of
+        [500.2, 500.8] -- and would blank a spectrum that interpolation
+        represents perfectly well. Measuring the kept share by area does
+        not have that discontinuity.
+        """
+        mzs = np.arange(400.0, 601.0, 1.0)
+        intensities = np.full_like(mzs, 10.0)
+        axis = _axis(500, lo=500.2, hi=500.8)
+
+        out = _resample(axis, mzs, intensities)
+
+        assert out.sum() > 0.0
+        # Flat spectrum: the window holds 0.6 Da of a 200 Da span.
+        assert out.sum() == pytest.approx(intensities.sum() * 0.6 / 200.0, rel=1e-6)
+
+    def test_kept_share_grows_with_window_width(self):
+        """Widening the window must not shrink what is preserved."""
+        mzs = np.arange(400.0, 601.0, 1.0)
+        intensities = np.full_like(mzs, 10.0)
+
+        totals = [
+            _resample(_axis(500, lo=500.0 - w, hi=500.0 + w), mzs, intensities).sum()
+            for w in (0.3, 1.0, 5.0, 25.0)
+        ]
+        assert totals == sorted(totals)
 
 
 class TestDegenerateInput:

--- a/tests/unit/converters/test_tic_preserving_resample.py
+++ b/tests/unit/converters/test_tic_preserving_resample.py
@@ -1,0 +1,198 @@
+# tests/unit/converters/test_tic_preserving_resample.py
+"""Tests that ``tic_preserving`` resampling preserves total ion current.
+
+``_tic_preserving_resample`` used to be a bare ``np.interp`` with no
+rescaling step, which meant the one property it is named for did not hold.
+Interpolation samples the spectrum at every target point, so the output TIC
+scaled with the width of the target axis: onto the default 190,000-bin axis
+a 4,000-point profile spectrum came back with 47x its input TIC, and a
+150-peak centroid spectrum with over 1000x. Nothing caught it because the
+method had no direct test coverage.
+
+The invariant these tests pin is that output TIC equals input TIC
+*independently of bin count*. A test at a single bin count would have
+passed against the broken implementation at 4,000 bins, where the inflation
+factor happens to be 1.0 for this data, so the parametrisation over bin
+counts is the point rather than incidental thoroughness.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    BaseSpatialDataConverter,
+)
+
+MZ_MIN, MZ_MAX = 250.0, 1200.0
+
+# Spans the realistic range: far below the source density, matched to it,
+# and the 190,000 the auto default resolves to on this mass range.
+BIN_COUNTS = [1_000, 4_000, 10_000, 50_000, 190_000]
+
+
+def _resample(axis, mzs, intensities):
+    """Call the resampler the way the converter does.
+
+    ``_tic_preserving_resample`` reads only ``_common_mass_axis`` off
+    ``self``, so a stub carrying it exercises the method without standing
+    up a converter (which would need a reader and a writable output path).
+    """
+    stub = SimpleNamespace(_common_mass_axis=axis)
+    return BaseSpatialDataConverter._tic_preserving_resample(stub, mzs, intensities)
+
+
+def _axis(bins, lo=MZ_MIN, hi=MZ_MAX):
+    return np.linspace(lo, hi, bins)
+
+
+def _profile_spectrum():
+    """A 4,000-point profile spectrum: peaks spread over many points."""
+    mzs = np.linspace(MZ_MIN, MZ_MAX, 4000)
+    intensities = np.zeros(4000)
+    for centre, amplitude in [(760.6, 1.0), (782.6, 0.85), (888.6, 0.6)]:
+        intensities += amplitude * np.exp(-((mzs - centre) ** 2) / (2 * 0.5**2))
+    return mzs, intensities + 4.0
+
+
+def _centroid_spectrum():
+    """A sparse centroid spectrum: 150 discrete peaks."""
+    rng = np.random.default_rng(0)
+    mzs = np.sort(rng.uniform(MZ_MIN, MZ_MAX, 150))
+    return mzs, rng.uniform(10.0, 1000.0, 150)
+
+
+class TestTICIsPreserved:
+    """The property the method is named for, across axis widths."""
+
+    @pytest.mark.parametrize("bins", BIN_COUNTS)
+    def test_profile_spectrum(self, bins):
+        mzs, intensities = _profile_spectrum()
+        out = _resample(_axis(bins), mzs, intensities)
+        assert out.sum() == pytest.approx(intensities.sum(), rel=1e-9)
+
+    @pytest.mark.parametrize("bins", BIN_COUNTS)
+    def test_centroid_spectrum(self, bins):
+        mzs, intensities = _centroid_spectrum()
+        out = _resample(_axis(bins), mzs, intensities)
+        assert out.sum() == pytest.approx(intensities.sum(), rel=1e-9)
+
+    def test_tic_does_not_drift_with_bin_count(self):
+        """The regression: TIC must not track the target axis width.
+
+        Against the unrescaled implementation the ratio between the widest
+        and narrowest axis was ~190x rather than 1.
+        """
+        mzs, intensities = _profile_spectrum()
+        tics = [_resample(_axis(b), mzs, intensities).sum() for b in BIN_COUNTS]
+        assert max(tics) / min(tics) == pytest.approx(1.0, rel=1e-9)
+
+    @pytest.mark.parametrize("bins", [1_000, 190_000])
+    def test_unsorted_input_is_handled(self, bins):
+        mzs, intensities = _centroid_spectrum()
+        order = np.random.default_rng(1).permutation(len(mzs))
+        out = _resample(_axis(bins), mzs[order], intensities[order])
+        assert out.sum() == pytest.approx(intensities.sum(), rel=1e-9)
+
+
+class TestShapeAndDtype:
+    """Callers index the result against the full axis."""
+
+    @pytest.mark.parametrize("bins", [1_000, 10_000])
+    def test_output_spans_the_axis(self, bins):
+        mzs, intensities = _profile_spectrum()
+        out = _resample(_axis(bins), mzs, intensities)
+        assert out.shape == (bins,)
+        assert out.dtype == np.float64
+
+    def test_output_is_non_negative(self):
+        mzs, intensities = _profile_spectrum()
+        out = _resample(_axis(10_000), mzs, intensities)
+        assert (out >= 0).all()
+
+
+class TestCroppedAxis:
+    """Cropping must drop signal, not redistribute it.
+
+    ``np.interp`` zeroes anything outside the axis. Rescaling against the
+    whole input TIC would push that dropped intensity back into the bins
+    that survive, inventing signal inside the window the caller asked for.
+    """
+
+    def test_out_of_range_intensity_is_not_redistributed(self):
+        # Three peaks; the axis covers only the middle one.
+        mzs = np.array([300.0, 400.0, 500.0, 600.0, 700.0])
+        intensities = np.array([100.0, 100.0, 50.0, 100.0, 100.0])
+        axis = _axis(5_000, lo=450.0, hi=550.0)
+
+        out = _resample(axis, mzs, intensities)
+
+        # Only the 500.0 peak is inside [450, 550].
+        assert out.sum() == pytest.approx(50.0, rel=1e-9)
+        assert out.sum() < intensities.sum()
+
+    def test_full_range_axis_preserves_whole_tic(self):
+        """The default path: axis spans the spectrum, nothing is dropped."""
+        mzs, intensities = _centroid_spectrum()
+        out = _resample(_axis(10_000), mzs, intensities)
+        assert out.sum() == pytest.approx(intensities.sum(), rel=1e-9)
+
+
+class TestDegenerateInput:
+    """Empty, single-point and zero-intensity spectra must not blow up."""
+
+    def test_empty_spectrum_returns_zeros(self):
+        out = _resample(_axis(1_000), np.array([]), np.array([]))
+        assert out.shape == (1_000,)
+        assert not out.any()
+
+    def test_zero_intensity_spectrum_returns_zeros(self):
+        mzs = np.linspace(MZ_MIN, MZ_MAX, 100)
+        out = _resample(_axis(1_000), mzs, np.zeros(100))
+        assert not out.any()
+        assert np.isfinite(out).all()
+
+    @pytest.mark.parametrize("bins", [1_000, 190_000])
+    def test_single_peak_survives_and_keeps_its_intensity(self, bins):
+        """A lone peak must not be interpolated away to nothing."""
+        mzs = np.array([760.6])
+        intensities = np.array([1234.5])
+        out = _resample(_axis(bins), mzs, intensities)
+
+        assert out.sum() == pytest.approx(1234.5, rel=1e-9)
+        assert np.count_nonzero(out) == 1
+        # It lands in the bin nearest its m/z.
+        assert np.argmax(out) == np.argmin(np.abs(_axis(bins) - 760.6))
+
+    def test_single_peak_outside_axis_is_dropped(self):
+        out = _resample(_axis(1_000), np.array([50.0]), np.array([999.0]))
+        assert not out.any()
+
+
+class TestAgreementWithStrategyImplementation:
+    """The converter must agree with the repo's other TIC-preserving code.
+
+    ``thyra/resampling/strategies/tic_preserving.py`` already rescaled. The
+    converter's inline copy did not, and the divergence is what the fix
+    closes.
+    """
+
+    @pytest.mark.parametrize("bins", [1_000, 10_000])
+    def test_same_tic_as_strategy(self, bins):
+        from thyra.resampling.strategies.base import Spectrum
+        from thyra.resampling.strategies.tic_preserving import TICPreservingStrategy
+
+        mzs, intensities = _profile_spectrum()
+        axis = _axis(bins)
+
+        converter_out = _resample(axis, mzs, intensities)
+        strategy_out = TICPreservingStrategy().resample(
+            Spectrum(mz=mzs, intensity=intensities, coordinates=(0, 0, 0)), axis
+        )
+
+        assert converter_out.sum() == pytest.approx(
+            float(np.sum(strategy_out.intensity)), rel=1e-9
+        )

--- a/tests/unit/resampling/test_strategies.py
+++ b/tests/unit/resampling/test_strategies.py
@@ -3,6 +3,7 @@ Tests for resampling strategies - Phase 2.
 """
 
 import numpy as np
+import pytest
 
 from thyra.resampling.strategies import NearestNeighborStrategy, TICPreservingStrategy
 from thyra.resampling.strategies.base import Spectrum
@@ -117,8 +118,11 @@ class TestTICPreservingStrategy:
 
         original_tic = np.sum(original_intensity)  # 7000.0
 
-        # Target axis with different spacing
-        target_axis = np.array([120.0, 160.0, 220.0, 280.0])
+        # Target axis with different spacing. It spans the spectrum: this
+        # test is about resampling onto a different grid, and the whole TIC
+        # is preserved only when nothing is cropped away. Cropping is
+        # covered separately by test_cropped_axis_drops_the_cropped_share.
+        target_axis = np.array([100.0, 160.0, 220.0, 300.0])
 
         result = self.strategy.resample(spectrum, target_axis)
 
@@ -224,6 +228,46 @@ class TestTICPreservingStrategy:
             "acquisition_mode": "profile",
         }
 
+    def test_cropped_axis_drops_the_cropped_share(self):
+        """An axis narrower than the spectrum must not keep the whole TIC.
+
+        Rescaling to the full input TIC would push the intensity that
+        interpolation dropped back into the bins that survive, so a cropped
+        window would claim ions from the parts that were cut away.
+        """
+        # Flat spectrum over [400, 600]; keep the middle 50 Da.
+        original_mz = np.arange(400.0, 601.0, 1.0)
+        original_intensity = np.full_like(original_mz, 10.0)
+        spectrum = Spectrum(original_mz, original_intensity, (0, 0, 0))
+
+        target_axis = np.linspace(475.0, 525.0, 51)
+        result = self.strategy.resample(spectrum, target_axis)
+
+        kept = np.sum(result.intensity)
+        assert kept < np.sum(original_intensity)
+        # 50 Da of a 200 Da span, on a flat spectrum.
+        assert kept == pytest.approx(
+            np.sum(original_intensity) * 50.0 / 200.0, rel=1e-6
+        )
+
+    def test_axis_spanning_spectrum_preserves_tic_exactly(self):
+        """The uncropped case is exact, not merely close."""
+        original_mz = np.linspace(100.0, 300.0, 51)
+        original_intensity = np.linspace(500.0, 1500.0, 51)
+        spectrum = Spectrum(original_mz, original_intensity, (0, 0, 0))
+
+        result = self.strategy.resample(spectrum, np.linspace(100.0, 300.0, 977))
+
+        assert np.sum(result.intensity) == pytest.approx(
+            np.sum(original_intensity), rel=1e-12
+        )
+
+    def test_single_point_outside_axis_is_dropped(self):
+        """A lone peak outside the axis is cropped like any other."""
+        spectrum = Spectrum(np.array([50.0]), np.array([999.0]), (0, 0, 0))
+        result = self.strategy.resample(spectrum, np.array([200.0, 250.0, 300.0]))
+        assert not result.intensity.any()
+
     def test_no_negative_intensities(self):
         """Test that no negative intensities are produced."""
         # Create a case that might produce negative values with interpolation
@@ -261,8 +305,9 @@ class TestStrategyComparison:
         )
         profile_spectrum = Spectrum(profile_mz, profile_intensity, (0, 0, 0))
 
-        # Common target axis
-        target_axis = np.linspace(120, 280, 9)
+        # Common target axis. Spans the profile spectrum so its whole TIC
+        # is preserved; a narrower axis would legitimately preserve less.
+        target_axis = np.linspace(100, 300, 9)
 
         # Apply both strategies
         nn_strategy = NearestNeighborStrategy()

--- a/tests/unit/resampling/test_tic.py
+++ b/tests/unit/resampling/test_tic.py
@@ -1,0 +1,216 @@
+# tests/unit/resampling/test_tic.py
+"""Tests for the shared TIC-preservation rule.
+
+``thyra.resampling.tic`` holds the single definition of *which* total
+``tic_preserving`` preserves, used by both the converters' per-pixel path
+and ``TICPreservingStrategy``. The two used to implement it separately and
+drifted: the converter lost its rescaling step entirely, inflating TIC by
+47x on the default axis. Pinning the rule here, rather than only through
+its two callers, is what keeps them honest.
+
+The rule: preserve the share of the spectrum lying inside the target axis
+range, measured by area. Measuring by area rather than by counting the
+source points inside the range is what keeps a window narrower than the
+source spacing from collapsing to zero.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from thyra.resampling.tic import preserved_tic, rescale_to_preserved_tic
+
+
+def _flat(lo=400.0, hi=600.0, step=1.0, value=10.0):
+    mzs = np.arange(lo, hi + step / 2, step)
+    return mzs, np.full_like(mzs, value)
+
+
+class TestUncroppedIsExact:
+    """When the axis spans the spectrum, the whole TIC survives."""
+
+    def test_axis_wider_than_spectrum(self):
+        mzs, intensities = _flat()
+        assert preserved_tic(mzs, intensities, 100.0, 900.0) == intensities.sum()
+
+    def test_axis_exactly_matching_spectrum(self):
+        mzs, intensities = _flat()
+        # Exact equality, not approx: the common case is short-circuited
+        # rather than computed through the integral ratio.
+        assert preserved_tic(mzs, intensities, 400.0, 600.0) == intensities.sum()
+
+    def test_result_is_a_plain_float(self):
+        mzs, intensities = _flat()
+        assert isinstance(preserved_tic(mzs, intensities, 100.0, 900.0), float)
+
+
+class TestCropping:
+    """A narrower axis keeps proportionally less."""
+
+    @pytest.mark.parametrize(
+        "lo,hi,expected_fraction",
+        [
+            (500.0, 600.0, 0.5),
+            (450.0, 550.0, 0.5),
+            (400.0, 500.0, 0.5),
+            (475.0, 525.0, 0.25),
+            (400.0, 600.0, 1.0),
+        ],
+    )
+    def test_flat_spectrum_keeps_width_fraction(self, lo, hi, expected_fraction):
+        mzs, intensities = _flat()
+        kept = preserved_tic(mzs, intensities, lo, hi)
+        assert kept == pytest.approx(intensities.sum() * expected_fraction, rel=1e-6)
+
+    def test_kept_share_is_monotonic_in_width(self):
+        mzs, intensities = _flat()
+        widths = [0.2, 1.0, 5.0, 25.0, 100.0]
+        kept = [preserved_tic(mzs, intensities, 500.0 - w, 500.0 + w) for w in widths]
+        assert kept == sorted(kept)
+
+    def test_never_exceeds_the_input_tic(self):
+        mzs, intensities = _flat()
+        for lo, hi in [(0.0, 1e6), (400.0, 600.0), (399.0, 601.0)]:
+            assert preserved_tic(mzs, intensities, lo, hi) <= intensities.sum()
+
+
+class TestNarrowWindow:
+    """The case that a sample-counting rule gets wrong.
+
+    A window between two adjacent source points contains no source point at
+    all, so counting samples reports zero and blanks the spectrum.
+    """
+
+    def test_window_between_two_samples_is_not_zero(self):
+        mzs, intensities = _flat(step=1.0)
+        # Source points at 500.0 and 501.0; this window contains neither.
+        kept = preserved_tic(mzs, intensities, 500.2, 500.8)
+        assert kept > 0.0
+        assert kept == pytest.approx(intensities.sum() * 0.6 / 200.0, rel=1e-6)
+
+    def test_no_source_point_inside_still_scales_with_width(self):
+        mzs, intensities = _flat(step=1.0)
+        narrow = preserved_tic(mzs, intensities, 500.2, 500.4)
+        wider = preserved_tic(mzs, intensities, 500.2, 500.8)
+        assert 0.0 < narrow < wider
+
+
+class TestNoOverlap:
+    """Disjoint ranges keep nothing."""
+
+    @pytest.mark.parametrize("lo,hi", [(0.0, 100.0), (900.0, 1000.0), (600.0, 700.0)])
+    def test_disjoint_or_touching_returns_zero(self, lo, hi):
+        mzs, intensities = _flat()
+        assert preserved_tic(mzs, intensities, lo, hi) == 0.0
+
+
+class TestDegenerateInput:
+    """Empty, zero and single-point spectra must not raise or divide by zero."""
+
+    def test_empty_spectrum(self):
+        assert preserved_tic(np.array([]), np.array([]), 100.0, 200.0) == 0.0
+
+    def test_zero_intensity_spectrum(self):
+        mzs, _ = _flat()
+        assert preserved_tic(mzs, np.zeros_like(mzs), 100.0, 900.0) == 0.0
+
+    def test_single_point_inside_range(self):
+        mzs = np.array([500.0])
+        intensities = np.array([42.0])
+        assert preserved_tic(mzs, intensities, 400.0, 600.0) == 42.0
+
+    def test_single_point_outside_range(self):
+        mzs = np.array([50.0])
+        intensities = np.array([42.0])
+        assert preserved_tic(mzs, intensities, 400.0, 600.0) == 0.0
+
+    def test_repeated_mz_values_do_not_divide_by_zero(self):
+        """Zero-width spectra integrate to nothing; fall back to samples."""
+        mzs = np.array([500.0, 500.0, 500.0])
+        intensities = np.array([1.0, 2.0, 3.0])
+        kept = preserved_tic(mzs, intensities, 400.0, 600.0)
+        assert np.isfinite(kept)
+        assert kept == pytest.approx(6.0)
+
+
+class TestRescale:
+    """The in-place scaling wrapper."""
+
+    def test_scales_to_the_preserved_total(self):
+        mzs, intensities = _flat()
+        axis = np.linspace(400.0, 600.0, 5_000)
+        resampled = np.interp(axis, mzs, intensities, left=0.0, right=0.0)
+
+        out = rescale_to_preserved_tic(resampled, axis, mzs, intensities)
+
+        assert out.sum() == pytest.approx(intensities.sum(), rel=1e-9)
+
+    def test_modifies_in_place_and_returns_the_same_array(self):
+        mzs, intensities = _flat()
+        axis = np.linspace(400.0, 600.0, 1_000)
+        resampled = np.interp(axis, mzs, intensities, left=0.0, right=0.0)
+
+        out = rescale_to_preserved_tic(resampled, axis, mzs, intensities)
+
+        assert out is resampled
+
+    def test_zero_preserved_total_blanks_the_output(self):
+        mzs, intensities = _flat()
+        # An axis disjoint from the spectrum keeps nothing.
+        axis = np.linspace(900.0, 1000.0, 100)
+        resampled = np.full(100, 5.0)
+
+        out = rescale_to_preserved_tic(resampled, axis, mzs, intensities)
+
+        assert not out.any()
+
+    def test_all_zero_interpolation_is_left_alone(self):
+        mzs, intensities = _flat()
+        axis = np.linspace(400.0, 600.0, 100)
+        resampled = np.zeros(100)
+
+        out = rescale_to_preserved_tic(resampled, axis, mzs, intensities)
+
+        assert np.isfinite(out).all()
+        assert not out.any()
+
+
+class TestBothCallersAgree:
+    """The converter and the strategy must return the same totals.
+
+    This is the regression that matters: the two implementations diverging
+    is the original bug, in a more general form.
+    """
+
+    @pytest.mark.parametrize(
+        "lo,hi",
+        [(400.0, 600.0), (450.0, 550.0), (500.2, 500.8), (300.0, 700.0)],
+    )
+    @pytest.mark.parametrize("bins", [101, 5_000])
+    def test_converter_and_strategy_match(self, lo, hi, bins):
+        from types import SimpleNamespace
+
+        from thyra.converters.spatialdata.base_spatialdata_converter import (
+            BaseSpatialDataConverter,
+        )
+        from thyra.resampling.strategies.base import Spectrum
+        from thyra.resampling.strategies.tic_preserving import TICPreservingStrategy
+
+        mzs, intensities = _flat()
+        axis = np.linspace(lo, hi, bins)
+
+        from_converter = BaseSpatialDataConverter._tic_preserving_resample(
+            SimpleNamespace(_common_mass_axis=axis), mzs, intensities
+        )
+        from_strategy = TICPreservingStrategy().resample(
+            Spectrum(mz=mzs, intensity=intensities, coordinates=(0, 0, 0)), axis
+        )
+
+        assert from_converter.sum() == pytest.approx(
+            float(np.sum(from_strategy.intensity)), rel=1e-9
+        )
+        # Not just the totals -- the distributions too.
+        np.testing.assert_allclose(
+            from_converter, from_strategy.intensity, rtol=1e-9, atol=1e-12
+        )

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1091,11 +1091,40 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
     def _tic_preserving_resample(
         self, mzs: NDArray[np.float64], intensities: NDArray[np.float64]
     ) -> NDArray[np.float64]:
-        """Resample using TIC-preserving linear interpolation - optimized."""
+        """Resample onto the common axis, preserving total ion current.
+
+        Linear interpolation onto the target axis, followed by rescaling so
+        the resampled spectrum carries the same total ion current as the
+        input -- the behaviour ``ResamplingMethod.TIC_PRESERVING`` and
+        docs/resampling.md both describe.
+
+        The rescaling is not cosmetic. Interpolation samples the spectrum at
+        every target point, so the raw interpolated sum scales with the
+        density of the target axis rather than staying fixed. Onto the
+        default 190,000-bin axis, 4,000 source points came back with 47x the
+        input TIC, and a 150-peak centroid spectrum with over 1000x.
+
+        The TIC preserved is that of the input peaks lying inside the target
+        axis range. ``np.interp`` drops anything outside it (``left=0``,
+        ``right=0``), so normalising against the whole input TIC would
+        redistribute the dropped intensity over the bins that remain --
+        inventing signal inside a range the caller deliberately cropped with
+        ``--resample-min-mz`` / ``--resample-max-mz``. When the axis spans
+        the spectrum, which is the default, the two are the same number.
+
+        Args:
+            mzs: Original m/z values from the spectrum.
+            intensities: Corresponding intensity values.
+
+        Returns:
+            Intensities on the common mass axis, of the axis's length.
+        """
         if self._common_mass_axis is None:
             raise RuntimeError("Common mass axis is not initialized")
+
+        axis = self._common_mass_axis
         if mzs.size == 0:
-            return np.zeros(len(self._common_mass_axis))
+            return np.zeros(len(axis))
 
         # OPTIMIZED: Check if already sorted to avoid unnecessary sorting
         if np.all(mzs[:-1] <= mzs[1:]):
@@ -1108,17 +1137,40 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             mzs_sorted = mzs[sort_indices]
             intensities_sorted = intensities[sort_indices]
 
+        # The intensity the output is required to carry. Peaks outside the
+        # axis are dropped by the interpolation and must not reappear.
+        in_range = (mzs_sorted >= axis[0]) & (mzs_sorted <= axis[-1])
+        target_tic = float(intensities_sorted[in_range].sum())
+        if target_tic <= 0.0:
+            return np.zeros(len(axis))
+
+        if mzs_sorted.size == 1:
+            # np.interp cannot interpolate a lone point onto a grid that
+            # does not contain it -- it would return all zeros and lose the
+            # peak. Place it in its nearest bin, as the nearest_neighbor
+            # path and TICPreservingStrategy both do.
+            resampled = np.zeros(len(axis))
+            resampled[int(np.argmin(np.abs(axis - mzs_sorted[0])))] = target_tic
+            return resampled
+
         # Interpolate onto the common mass axis (np.interp is highly optimized)
-        if self._common_mass_axis is None:
-            raise RuntimeError("Common mass axis is not initialized")
         resampled = np.interp(
-            self._common_mass_axis,
+            axis,
             mzs_sorted,
             intensities_sorted,
             left=0,
             right=0,
         )
 
+        # Rescale to the required TIC. This is the step that makes the
+        # method live up to its name.
+        resampled_tic = float(resampled.sum())
+        if resampled_tic <= 0.0:
+            # Every peak landed strictly between two axis points. There is
+            # nothing to rescale and nothing to recover.
+            return resampled
+
+        resampled *= target_tic / resampled_tic
         return resampled
 
     def _process_resampled_spectrum(

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -17,6 +17,7 @@ from ...core.base_converter import BaseMSIConverter, PixelSizeSource
 from ...core.base_reader import BaseMSIReader
 from ...metadata.types import ComprehensiveMetadata, EssentialMetadata
 from ...resampling import ResamplingDecisionTree, ResamplingMethod
+from ...resampling.tic import preserved_tic, rescale_to_preserved_tic
 from ...resampling.types import ResamplingConfig
 from ...utils.zarr_atomic_write import install_windows_atomic_write_retry
 from ._chunking import image_chunks
@@ -1104,13 +1105,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         default 190,000-bin axis, 4,000 source points came back with 47x the
         input TIC, and a 150-peak centroid spectrum with over 1000x.
 
-        The TIC preserved is that of the input peaks lying inside the target
-        axis range. ``np.interp`` drops anything outside it (``left=0``,
-        ``right=0``), so normalising against the whole input TIC would
-        redistribute the dropped intensity over the bins that remain --
-        inventing signal inside a range the caller deliberately cropped with
-        ``--resample-min-mz`` / ``--resample-max-mz``. When the axis spans
-        the spectrum, which is the default, the two are the same number.
+        The TIC preserved is the share of the spectrum lying inside the
+        target axis range -- see ``thyra.resampling.tic``, which holds the
+        rule and the reasoning, and which ``TICPreservingStrategy`` uses too.
+        When the axis spans the spectrum, which is the default, that share
+        is the whole input TIC.
 
         Args:
             mzs: Original m/z values from the spectrum.
@@ -1137,20 +1136,17 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             mzs_sorted = mzs[sort_indices]
             intensities_sorted = intensities[sort_indices]
 
-        # The intensity the output is required to carry. Peaks outside the
-        # axis are dropped by the interpolation and must not reappear.
-        in_range = (mzs_sorted >= axis[0]) & (mzs_sorted <= axis[-1])
-        target_tic = float(intensities_sorted[in_range].sum())
-        if target_tic <= 0.0:
-            return np.zeros(len(axis))
-
         if mzs_sorted.size == 1:
             # np.interp cannot interpolate a lone point onto a grid that
             # does not contain it -- it would return all zeros and lose the
             # peak. Place it in its nearest bin, as the nearest_neighbor
             # path and TICPreservingStrategy both do.
             resampled = np.zeros(len(axis))
-            resampled[int(np.argmin(np.abs(axis - mzs_sorted[0])))] = target_tic
+            target_tic = preserved_tic(
+                mzs_sorted, intensities_sorted, float(axis[0]), float(axis[-1])
+            )
+            if target_tic > 0.0:
+                resampled[int(np.argmin(np.abs(axis - mzs_sorted[0])))] = target_tic
             return resampled
 
         # Interpolate onto the common mass axis (np.interp is highly optimized)
@@ -1164,14 +1160,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
         # Rescale to the required TIC. This is the step that makes the
         # method live up to its name.
-        resampled_tic = float(resampled.sum())
-        if resampled_tic <= 0.0:
-            # Every peak landed strictly between two axis points. There is
-            # nothing to rescale and nothing to recover.
-            return resampled
-
-        resampled *= target_tic / resampled_tic
-        return resampled
+        return rescale_to_preserved_tic(resampled, axis, mzs_sorted, intensities_sorted)
 
     def _process_resampled_spectrum(
         self,

--- a/thyra/resampling/strategies/tic_preserving.py
+++ b/thyra/resampling/strategies/tic_preserving.py
@@ -3,14 +3,22 @@
 This strategy uses linear interpolation while preserving the Total Ion
 Current (TIC) of the original spectrum, making it ideal for profile data
 from most MS instruments.
+
+The rule for *which* total is preserved lives in ``thyra.resampling.tic``
+and is shared with the converters' per-pixel path, so the two
+implementations of ``tic_preserving`` cannot drift apart again. In short:
+the preserved total is the share of the spectrum lying inside the target
+axis range, so resampling onto an axis that crops the spectrum drops the
+cropped intensity rather than redistributing it over the bins that remain.
+When the axis spans the spectrum, the whole TIC is preserved exactly.
 """
 
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
-from scipy import interpolate
 
+from ..tic import preserved_tic, rescale_to_preserved_tic
 from .base import ResamplingStrategy, Spectrum
 
 
@@ -22,8 +30,12 @@ class TICPreservingStrategy(ResamplingStrategy):
     ) -> Spectrum:
         """Resample spectrum using TIC-preserving linear interpolation.
 
-        Uses scipy's linear interpolation and then scales the result
-        to preserve the original Total Ion Current (TIC).
+        Linearly interpolates onto ``target_axis`` and then scales the
+        result so it carries the Total Ion Current the axis is entitled to
+        -- the whole input TIC when the axis spans the spectrum, and the
+        share lying inside the axis otherwise. See ``thyra.resampling.tic``
+        for why the share is measured by integration rather than by counting
+        the source points that fall in range.
 
         Parameters
         ----------
@@ -47,11 +59,20 @@ class TICPreservingStrategy(ResamplingStrategy):
             )
 
         if len(spectrum.mz) == 1:
-            # Handle single point spectrum with nearest neighbor
-            distances = np.abs(target_axis - spectrum.mz[0])
-            closest_idx = np.argmin(distances)
+            # A lone point cannot be interpolated onto a grid that does not
+            # contain it, so place it in its nearest bin -- unless it falls
+            # outside the axis, in which case it is cropped away like any
+            # other out-of-range peak and preserved_tic returns 0.
             resampled_intensity = np.zeros_like(target_axis)
-            resampled_intensity[closest_idx] = spectrum.intensity[0]
+            kept = preserved_tic(
+                np.asarray(spectrum.mz, dtype=np.float64),
+                np.asarray(spectrum.intensity, dtype=np.float64),
+                float(target_axis[0]),
+                float(target_axis[-1]),
+            )
+            if kept > 0.0:
+                closest_idx = np.argmin(np.abs(target_axis - spectrum.mz[0]))
+                resampled_intensity[closest_idx] = kept
 
             return Spectrum(
                 mz=target_axis.copy(),
@@ -60,10 +81,7 @@ class TICPreservingStrategy(ResamplingStrategy):
                 metadata=spectrum.metadata,
             )
 
-        # Calculate original TIC
-        original_tic = np.sum(spectrum.intensity)
-
-        if original_tic == 0:
+        if np.sum(spectrum.intensity) == 0:
             # Handle zero intensity spectrum
             return Spectrum(
                 mz=target_axis.copy(),
@@ -72,34 +90,33 @@ class TICPreservingStrategy(ResamplingStrategy):
                 metadata=spectrum.metadata,
             )
 
-        # Perform linear interpolation
-        # Use bounds_error=False and fill_value=0 for extrapolation
-        interp_func = interpolate.interp1d(
-            spectrum.mz,
-            spectrum.intensity,
-            kind="linear",
-            bounds_error=False,
-            fill_value=0.0,
-            assume_sorted=False,  # Don't assume sorted for safety
-        )
+        # np.interp and preserved_tic both require ascending m/z.
+        order = np.argsort(spectrum.mz)
+        mzs_sorted = np.asarray(spectrum.mz, dtype=np.float64)[order]
+        intensities_sorted = np.asarray(spectrum.intensity, dtype=np.float64)[order]
 
-        # Interpolate to target axis
-        interpolated_intensity = interp_func(target_axis)
+        # Interpolate to target axis, dropping anything outside the source
+        # range. Equivalent to the previous interp1d(bounds_error=False,
+        # fill_value=0.0) for linear interpolation, without the scipy call.
+        interpolated_intensity = np.interp(
+            target_axis,
+            mzs_sorted,
+            intensities_sorted,
+            left=0.0,
+            right=0.0,
+        )
 
         # Ensure no negative values (can happen with extrapolation)
         interpolated_intensity = np.maximum(interpolated_intensity, 0.0)
 
-        # Calculate new TIC and preserve original TIC
-        new_tic = np.sum(interpolated_intensity)
-
-        if new_tic > 0:
-            # Scale to preserve TIC
-            scaling_factor = original_tic / new_tic
-            interpolated_intensity *= scaling_factor
-        else:
-            # If interpolation resulted in zero TIC, handle gracefully
-            # This shouldn't happen with proper data, but be defensive
-            interpolated_intensity = np.zeros_like(target_axis)
+        # Scale onto the TIC the target axis is entitled to carry. Shared
+        # with the converters' hot path so the two cannot drift apart again.
+        rescale_to_preserved_tic(
+            interpolated_intensity,
+            np.asarray(target_axis, dtype=np.float64),
+            mzs_sorted,
+            intensities_sorted,
+        )
 
         return Spectrum(
             mz=target_axis.copy(),

--- a/thyra/resampling/tic.py
+++ b/thyra/resampling/tic.py
@@ -1,0 +1,146 @@
+"""Total ion current preservation, shared by both resampling paths.
+
+Thyra interpolates spectra onto a common mass axis in two places: the
+converters' hot per-pixel loop
+(``BaseSpatialDataConverter._tic_preserving_resample``) and the public
+``TICPreservingStrategy``. Both are supposed to honour the same contract --
+``ResamplingMethod.TIC_PRESERVING`` promises that "the total ion count is
+preserved after rebinning" -- and they drifted apart, with the converter
+losing its rescaling step entirely. Keeping the rule in one module is what
+stops that happening again.
+
+Why rescaling is needed at all
+------------------------------
+
+Linear interpolation *samples* the spectrum at every target point, so the
+sum of the interpolated values scales with how densely the target axis is
+laid out. Interpolating 4,000 source points onto a 190,000-bin axis returns
+roughly 47x the input TIC, and a 150-peak centroid spectrum over 1000x. The
+sum only comes out right when the target axis happens to match the source
+point density. Rescaling to a TIC computed from the *source* removes that
+dependence on axis width.
+
+Why cropping has to reduce the preserved TIC
+--------------------------------------------
+
+Interpolation drops everything outside the axis range. Rescaling to the full
+input TIC would push that dropped intensity back into the bins that survive,
+so a window cropped with ``--resample-min-mz`` / ``--resample-max-mz`` would
+claim every ion from the parts that were cut away. The preserved total is
+therefore the share of the spectrum that lies inside the axis range.
+
+Why that share is measured by integral, not by counting samples
+---------------------------------------------------------------
+
+The obvious implementation -- sum the source intensities whose m/z falls
+inside the axis range -- is wrong whenever the target axis is narrower than
+the spacing between source points. A 0.6 Da window over a spectrum sampled
+every 1 Da can contain no source points at all, and the sum-based rule then
+reports zero and blanks a spectrum that interpolation would have represented
+perfectly well. Integrating handles that continuously: a narrow window keeps
+a proportionally small share rather than falling off a cliff.
+
+The common case, where the axis spans the whole spectrum, is short-circuited
+so it returns the input TIC exactly rather than to within rounding.
+"""
+
+from typing import Any, TypeVar
+
+import numpy as np
+import numpy.typing as npt
+
+# ``rescale_to_preserved_tic`` returns the very array it was handed, so the
+# element type it was called with is the element type it gives back.
+_FloatT = TypeVar("_FloatT", bound=np.floating[Any])
+
+
+def preserved_tic(
+    mzs: npt.NDArray[np.floating[Any]],
+    intensities: npt.NDArray[np.floating[Any]],
+    axis_min: float,
+    axis_max: float,
+) -> float:
+    """Return the share of a spectrum's TIC that survives a target axis range.
+
+    Args:
+        mzs: Source m/z values, ascending. Callers sort before calling;
+            the result is meaningless on unsorted input.
+        intensities: Source intensities, parallel to ``mzs``.
+        axis_min: Lowest m/z on the target axis.
+        axis_max: Highest m/z on the target axis.
+
+    Returns:
+        The total ion current the resampled spectrum should carry. Equal to
+        ``intensities.sum()`` when the axis spans the spectrum, and ``0.0``
+        when the two ranges do not overlap.
+    """
+    if mzs.size == 0:
+        return 0.0
+
+    total_tic = float(np.sum(intensities))
+    if total_tic <= 0.0:
+        return 0.0
+
+    # The axis covers the whole spectrum: nothing is dropped. Short-circuit
+    # so the overwhelmingly common case is exact and cheap.
+    if axis_min <= mzs[0] and axis_max >= mzs[-1]:
+        return total_tic
+
+    lo = max(axis_min, float(mzs[0]))
+    hi = min(axis_max, float(mzs[-1]))
+    if hi <= lo:
+        # Disjoint, or touching at a single point of zero width.
+        return 0.0
+
+    total_integral = float(np.trapezoid(intensities, mzs))
+    if total_integral <= 0.0:
+        # Degenerate sampling -- repeated m/z values, or a spectrum whose
+        # points carry intensity but enclose no area. Integration says
+        # nothing useful here, so fall back to the samples inside the range.
+        inside = (mzs >= lo) & (mzs <= hi)
+        return float(np.sum(intensities[inside]))
+
+    # Integrate the source over the overlap, using interpolated values at the
+    # two cut points so a window narrower than the source spacing still gets
+    # a sensible share rather than zero.
+    interior = mzs[(mzs > lo) & (mzs < hi)]
+    kept_mz = np.concatenate(([lo], interior, [hi]))
+    kept_integral = float(np.trapezoid(np.interp(kept_mz, mzs, intensities), kept_mz))
+
+    fraction = min(max(kept_integral / total_integral, 0.0), 1.0)
+    return total_tic * fraction
+
+
+def rescale_to_preserved_tic(
+    resampled: npt.NDArray[_FloatT],
+    axis: npt.NDArray[np.floating[Any]],
+    mzs: npt.NDArray[np.floating[Any]],
+    intensities: npt.NDArray[np.floating[Any]],
+) -> npt.NDArray[_FloatT]:
+    """Scale an interpolated spectrum onto the TIC it is meant to carry.
+
+    Modifies ``resampled`` in place and returns it.
+
+    Args:
+        resampled: Interpolated intensities on ``axis``, as returned by
+            ``np.interp`` with out-of-range values set to zero.
+        axis: The target mass axis, ascending.
+        mzs: Source m/z values, ascending.
+        intensities: Source intensities, parallel to ``mzs``.
+
+    Returns:
+        ``resampled``, scaled so that its sum is the preserved TIC.
+    """
+    target = preserved_tic(mzs, intensities, float(axis[0]), float(axis[-1]))
+    if target <= 0.0:
+        resampled.fill(0.0)
+        return resampled
+
+    current = float(np.sum(resampled))
+    if current <= 0.0:
+        # Every source peak landed strictly between two axis points. There is
+        # nothing to scale and nothing to recover.
+        return resampled
+
+    resampled *= target / current
+    return resampled


### PR DESCRIPTION
Fixes the correctness bug found while measuring [handout C](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/pull/111), and removes the duplication that let it happen.

## The bug

`_tic_preserving_resample` was a bare `np.interp` with no rescaling step, so the one property the method is named for did not hold. Interpolation samples the spectrum at every target point, so the output TIC scaled with the width of the target axis instead of staying fixed.

Output TIC / input TIC, measured on a 250-1200 Da range:

| Bins | 4,000-point profile | 150-peak centroid |
|---|---|---|
| 1,000 | 0.246 | 6.69 |
| 4,000 | 1.000 | 26.8 |
| 10,000 | 2.500 | 66.9 |
| 50,000 | 12.50 | 334.7 |
| **190,000 (auto default)** | **47.50** | **1271.85** |

It read as correct only at 4,000 bins, where the target axis happens to match this data's source density. `nearest_neighbor`, which is *not* named for the property, preserved TIC exactly throughout.

This matters because `tic_preserving` is auto-selected for Rapiflex, Bruker MALDI-TOF profile, and unknown-vendor high-density profile data -- and the reason to choose it is quantitation.

## Why it is unambiguously a bug

The inline implementation contradicted three other statements of the same contract: the `ResamplingMethod.TIC_PRESERVING` docstring, `TICPreservingStrategy` (which already rescaled), and `docs/resampling.md` ("followed by rescaling so the spectrum's total ion current matches the original").

## The fix, in two commits

**1. Add the rescaling step.** Both converters inherit the method, so one change covers the in-memory and streaming paths. End-to-end conversion now reports a TIC ratio of exactly `1.000000` at 4,000 and at 190,000 bins.

**2. Share one rule between both implementations.** Having `TICPreservingStrategy` and the converter each implement "preserve the TIC" separately is *how the drift happened*. The rule now lives in `thyra/resampling/tic.py`, documented in one place, and both call it.

Aligning the strategy exposed a flaw in the crop handling from commit 1, which I have corrected rather than propagated:

- **Commit 1 preserved the sum of source samples inside the axis range.** That reports zero whenever the target axis is narrower than the source spacing -- a 0.6 Da window over a spectrum sampled every 1 Da contains no source point at all, so the spectrum was blanked even though interpolation represents it perfectly well.
- **The shared rule measures the kept share by area**, which degrades continuously: a narrow window keeps a proportionally small amount. The uncropped case is short-circuited, so it returns the input TIC *exactly* rather than to within rounding.

Also drops the strategy's `scipy.interpolate.interp1d` for `np.interp`. For linear interpolation with `fill_value=0` they are equivalent, and it removes a scipy call from a path that no longer needs one.

## Semantics, stated plainly

The preserved total is the share of the spectrum lying inside the target axis range. Crop with `--resample-min-mz` / `--resample-max-mz` and the cropped intensity is dropped, not redistributed over the bins you kept -- a cropped window should not claim ions from the parts cut away. With the default axis, which spans the dataset's own mass range, nothing is dropped and the whole TIC is preserved.

## Two existing tests changed

`test_basic_interpolation` and `test_centroid_vs_profile_behavior` asserted that an axis narrower than the spectrum preserves the *whole* TIC -- the redistribution this PR rejects. Both cropped the source incidentally rather than deliberately (they were written to check resampling onto a different grid), so their axes now span the spectrum and they test what they were named for. Cropping is covered explicitly by new tests instead. Flagging this because changing an existing assertion deserves a reviewer's eye.

## Impact

Intensity values on the `tic_preserving` path change. The `var` axis is untouched, so stored column indices and cached selections stay valid. Quantitation from affected stores was wrong by the factors above and should be reconverted.

Flagging for a version-bump decision: the commits are typed `fix` and `refactor`, which semantic-release will take as a patch, but output values do change.

## Cost

Rescaling adds roughly 20-30% over a bare `np.interp` -- inherent, since preserving TIC requires a sum and a scale over the interpolated array. Against the per-pixel loop, where resampling is about 15% of the cost and writing to the sparse matrix dominates, that is roughly 3%.

## Tests

The method had **no direct test coverage**, which is how this survived. Now:

- 28 tests on the converter path, pinning TIC preservation across bin counts. **18 fail against the original implementation.** The parametrisation over bin counts is the point -- a test at 4,000 bins alone would have passed against the broken code.
- 32 tests on the shared rule directly, covering cropping, sub-spacing windows, monotonicity, and degenerate input.
- A cross-implementation test running both callers over the same spectra, asserting they agree **elementwise**, not merely in total.

`pytest`: 705 passed, 11 skipped, 1 xfailed. `black`, `isort`, `flake8`, `mypy`, `bandit`, `pydocstyle` clean via pre-commit. `mkdocs build --strict` clean.

## Not addressed here

This fixes correctness, not the densification. `tic_preserving` still stores ~190,000 non-zeros per pixel, because `np.interp` output is genuinely dense. That is the conservative-rebinning proposal in the findings report, which needs scientific sign-off and is a larger change.
