### PR TITLE
Make pre-commit run --all-files pass cleanly and idempotently

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,21 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Line-ending policy: LF in the repository and in every working tree.
+#
+# `text=auto` normalises text files to LF when they are staged; that half was
+# already here and the index is clean LF throughout. The load-bearing half is
+# the explicit `eol=lf`. Without it, checkout falls back to core.eol, which
+# defaults to "native" and therefore writes CRLF into Windows working trees.
+# That left the tree permanently at odds with the mixed-line-ending hook
+# (args: [--fix=lf]): the hook rewrote every text file to LF, git re-created
+# the CRLF on the next checkout, and `git status` reported all 179 tracked
+# text files as modified even though `git diff` showed no content change.
+#
+# Declaring the policy here rather than relying on each developer's
+# core.autocrlf means it travels with the repository and holds on a fresh
+# clone regardless of the machine's git configuration.
+* text=auto eol=lf
+
+# Vendored native libraries. `text=auto` already detects these as binary, so
+# this is belt and braces: it keeps the guarantee if a future library happens
+# to look like text to the heuristic.
+*.dll binary
+*.so binary

--- a/.github/scripts/complexity_monitor.py
+++ b/.github/scripts/complexity_monitor.py
@@ -170,7 +170,10 @@ def get_changed_files() -> List[Path]:
     Returns:
         List of Path objects for changed Python files that exist
     """
-    import subprocess
+    # nosec B404: CI tooling that shells out to git with a fixed argument
+    # list and no shell. B603 and B607, which cover the calls themselves,
+    # are already skipped repository-wide in pyproject.toml.
+    import subprocess  # nosec B404
 
     try:
         # Try comparing against origin/main first

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,7 @@ benchmarks/test_*.py
 # Claude Code files - should not be committed
 .claude/
 CLAUDE.md
-scripts/
+# Leading slash: anchor to the repository root. Unanchored, this also matched
+# .github/scripts/, the one tracked scripts directory, so git refused to add
+# changes to the complexity monitor without -f.
+/scripts/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,9 +68,13 @@ repos:
         exclude: ^tests/
 
   # Docstring formatting
+  # Settings live in pyproject.toml, the same arrangement flake8 uses with
+  # .flake8. Do not add setting args here: a YAML flow sequence splits on
+  # every comma, so `args: [--convention=google, --add-ignore=D100,D104,D105]`
+  # reached pydocstyle as `--add-ignore=D100` plus two stray positional
+  # arguments, and D104 was reported despite appearing to be ignored.
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.3.0
     hooks:
       - id: pydocstyle
-        args: [--convention=google, --add-ignore=D100,D104,D105]
         exclude: ^(tests/|docs/)

--- a/handouts/README.md
+++ b/handouts/README.md
@@ -85,11 +85,17 @@ Two things to know about working in a worktree here:
    This bit me while verifying handout A: two runs reported identical
    results because both imported `main`.
 
-2. **Line endings.** Every commit that touches a file will fail the
-   `mixed-line-ending` hook once, rewrite the file to LF, and need a second
-   `git add` + `git commit`. This is expected until handout D lands. Do not
-   run `pre-commit run --all-files` as a check: it rewrites ~137 unrelated
-   files.
+2. **Line endings.** Fixed by handout D. Commits no longer fail the
+   `mixed-line-ending` hook on the first attempt, and
+   `pre-commit run --all-files` is safe to run as a pre-push check: it passes
+   and leaves `git status` empty. Worktrees created before that landed still
+   hold CRLF files; `git add --renormalize .` settles them without producing
+   a diff.
+
+   One thing worktrees still hide: bandit silently skips everything under
+   `.github/`, because its default exclusions contain the bare string `.git`
+   and a worktree's `.git` is a file rather than a directory. Verify bandit
+   findings from an ordinary checkout.
 
 ## Shared conventions
 

--- a/handouts/toolchain-hygiene.md
+++ b/handouts/toolchain-hygiene.md
@@ -1,5 +1,50 @@
 # D. Line-ending churn and hook config drift
 
+> **RESOLVED** -- `pre-commit run --all-files` now passes and leaves
+> `git status` empty, verified three times running on a fresh clone made with
+> `core.autocrlf=true`.
+>
+> Four corrections to the brief below, found while investigating:
+>
+> * **The line-ending fix is one attribute, not a normalisation.** The index
+>   was already pure LF: `git ls-files --eol` reported `i/lf` for all 179
+>   tracked text files. Only the *checkout* side was converting, because
+>   `* text=auto` leaves that to `core.eol`, which defaults to `native`.
+>   Adding `eol=lf` fixed it with no content diff, so there was no blame
+>   pollution and nothing to put in `.git-blame-ignore-revs`. The count is 179
+>   rather than 137, and those paths were never really modified: `git diff`
+>   was empty throughout, and git only reported them because the CRLF round
+>   trip is unstable, so the stat cache could never settle.
+> * **pydocstyle was not a pyproject-versus-hook precedence problem.** The
+>   hook does read `pyproject.toml`, verified against both cached hook
+>   environments. The bug was quoting: `args: [--convention=google,
+>   --add-ignore=D100,D104,D105]` is a YAML flow sequence, so it splits on
+>   every comma and pydocstyle received `--add-ignore=D100` plus two stray
+>   positional arguments, `D104` and `D105`. Dropping the args entirely, as
+>   flake8 already does, removes both the duplication and the trap.
+> * **The bandit finding is real but invisible from a worktree.** B404
+>   reproduces on any ordinary checkout and never from `../Thyra-toolchain`.
+>   Bandit's default exclusions contain the bare string `.git`, and it only
+>   appends a path separator when that entry resolves to a directory
+>   (`bandit/core/manager.py`). In a linked worktree `.git` is a file, so the
+>   entry stays a bare substring and silently excludes everything under
+>   `.github/`. Anything verifying bandit from a worktree is verifying nothing.
+> * **The two mypy errors are the hook's flag set, not a bare run.** They are
+>   what `mypy --ignore-missing-imports --no-strict-optional thyra` reports;
+>   both are fixed at the root and that run is now clean. A bare
+>   `mypy thyra` reports 15 further errors, all of them strict-optional
+>   complaints that the project's own hook config switches off.
+>
+> Also fixed here: `.gitignore` carried an unanchored `scripts/`, which
+> matched `.github/scripts/` and made git refuse to stage its tracked
+> complexity monitor without `-f`.
+>
+> Two verification steps in this document cannot run in this environment, on
+> `main` as much as on this branch. The Poetry venv has neither mypy nor the
+> declared mkdocs plugins installed, so `poetry run mypy` and
+> `poetry run mkdocs` fall through to the Anaconda copies on PATH;
+> `mkdocs build --strict` aborts on a missing `mkdocs-jupyter`.
+
 **Branch:** `chore/toolchain-hygiene`
 **Worktree:** `../Thyra-toolchain`
 **Priority:** independent, touches no Python in `thyra/`. Do this one first

--- a/thyra/metadata/extractors/waters_extractor.py
+++ b/thyra/metadata/extractors/waters_extractor.py
@@ -7,7 +7,7 @@ files using the MassLynx native library and pre-built imaging grid.
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -15,6 +15,9 @@ from tqdm import tqdm
 
 from ...core.base_extractor import MetadataExtractor
 from ..types import ComprehensiveMetadata, EssentialMetadata
+
+if TYPE_CHECKING:
+    from ...readers.waters.masslynx_lib import MassLynxLib
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +32,7 @@ class WatersMetadataExtractor(MetadataExtractor):
 
     def __init__(
         self,
-        ml,  # MassLynxLib instance
+        ml: "MassLynxLib",
         handle,  # opaque file handle
         data_path: Path,
         imaging_grid,  # ImagingGrid instance

--- a/thyra/tools/make_example_data.py
+++ b/thyra/tools/make_example_data.py
@@ -56,7 +56,11 @@ def _ellipse_mask(
 ) -> np.ndarray:
     """Boolean mask of an axis-aligned ellipse on a (y, x) grid."""
     n_y, n_x = shape
-    yy, xx = np.mgrid[0:n_y, 0:n_x]
+    # np.mgrid is typed as Any, which propagates through the arithmetic below
+    # and makes the returned mask untyped. Broadcasting two typed 1-D ranges
+    # produces the same grid while keeping the return type checkable.
+    yy = np.arange(n_y, dtype=np.float64).reshape(n_y, 1)
+    xx = np.arange(n_x, dtype=np.float64).reshape(1, n_x)
     cy, cx = centre
     ry, rx = radii
     return ((yy - cy) / ry) ** 2 + ((xx - cx) / rx) ** 2 <= 1.0


### PR DESCRIPTION
Handout D. `pre-commit run --all-files` now passes and leaves `git status`
empty, so it can be trusted as a pre-push check.

**Acceptance test**, on a fresh clone made with `core.autocrlf=true` to
simulate a stock Windows git rather than this machine's configuration:

```
pre-commit run --all-files   ->  17 hooks Passed, exit 0
git status --short           ->  empty
pre-commit run --all-files   ->  17 hooks Passed, exit 0
git status --short           ->  empty
```

Previously the first run rewrote every tracked text file and three hooks
failed. No check was relaxed to get here.

## What was actually wrong

**Line endings.** Not a normalisation problem. The index was already pure
LF -- `git ls-files --eol` reported `i/lf` for all 179 tracked text files.
Only the checkout side was converting: `* text=auto` normalises on staging
but leaves checkout to `core.eol`, which defaults to `native`, so Windows
working trees got CRLF and the `mixed-line-ending` hook (`--fix=lf`) pulled
them back. Adding `eol=lf` pins checkout and makes the policy travel with
the repository instead of depending on each developer's `core.autocrlf`.

Consequences worth stating, because the brief expected otherwise: there is
no mass-normalisation diff, nothing to add to `.git-blame-ignore-revs`, and
no `git blame` pollution. The whole fix is one attribute. The 179 paths git
called modified were never really modified -- `git diff` was empty
throughout, and git reported them only because the CRLF round trip is
unstable, so the stat cache could never settle. `git add --renormalize .`
clears them and produces an empty diff.

**pydocstyle.** Not a pyproject-versus-hook precedence problem; the hook
does read `pyproject.toml`, verified against both cached hook environments.
The bug was quoting. `args: [--convention=google, --add-ignore=D100,D104,D105]`
is a YAML flow sequence, so it splits on every comma and pydocstyle received
`--add-ignore=D100` plus two stray positional arguments, `D104` and `D105`.
That is why D104 fired despite appearing to be ignored, and why
`poetry run pydocstyle thyra` disagreed with the hook. Dropping the args
entirely leaves `pyproject.toml` as the single source of truth, the same
arrangement flake8 and `.flake8` got in `e144f2d`, and removes the trap.

**bandit B404.** Real, and fixed with a narrow `# nosec B404` plus reason on
the import rather than excluding `.github/`, which would blind bandit to
every future CI script. The `subprocess` import runs git with a fixed
argument list and no shell; B603 and B607 are already skipped
repository-wide for exactly that reason.

Worth knowing for anyone verifying this: **the finding is invisible from a
linked git worktree.** Bandit's default exclusions contain the bare string
`.git`, and it only appends a path separator when that entry resolves to a
directory (`bandit/core/manager.py`). In a worktree `.git` is a file, so the
entry stays a bare substring and silently excludes everything under
`.github/`. `pre-commit run bandit --all-files` passed in `../Thyra-toolchain`
and failed on a clean clone, same binary, same file, same config. Every
result in this PR was therefore confirmed on an ordinary checkout.

**Two mypy errors.** Fixed at the root, not suppressed:

- `make_example_data.py`: `np.mgrid` is typed as `Any`, so the ellipse mask
  stayed `Any` through the arithmetic and out of the return. Broadcasting two
  typed 1-D ranges builds the same grid with a checkable type.
- `waters_extractor.py`: the `ml` constructor parameter was unannotated, so
  every call made through it returned `Any` -- including
  `MassLynxLib.read_spectrum`, which is itself annotated. Naming the type
  under `TYPE_CHECKING` restores it.

These are the errors reported under the hook's own flag set
(`--ignore-missing-imports --no-strict-optional`), which is what the brief
measured; that run is now clean across all 83 source files. A bare
`mypy thyra` reports 15 further errors, all strict-optional complaints that
the project's hook config deliberately switches off. Left alone.

## One thing beyond the brief

`.gitignore` carried an unanchored `scripts/`, meant for a local scratch
directory. Unanchored patterns match at any depth, so it also covered
`.github/scripts/` and its tracked complexity monitor: git refused to stage
the fix above without `-f`, and any new CI script added there would be
invisible to git. Anchored to `/scripts/`, which preserves the original
intent exactly.

## Verification

| Check | Result |
|---|---|
| `pre-commit run --all-files`, twice, fresh clone, `autocrlf=true` | passes, `git status` empty both times |
| `mypy --ignore-missing-imports --no-strict-optional thyra` | clean, 83 files |
| `pytest -q` | 643 passed, 11 skipped, 18 deselected, 1 xfailed |
| `mkdocs build --strict` | could not run, see below |

Two of the brief's verification steps cannot run in this environment, on
`main` as much as on this branch: the Poetry venv has neither mypy nor the
declared mkdocs plugins installed, so `poetry run mypy` and
`poetry run mkdocs` fall through to the Anaconda copies on PATH.
`mkdocs build --strict` aborts on a missing `mkdocs-jupyter` before reading
any content. Nothing here touches `mkdocs.yml` or any docs page outside
`handouts/`. Restoring those two is a `poetry install` away and is not part
of this branch.

The `poetry run mypy` fallback also explains the brief's error list: with
`python_version = "3.11"` it now dies on a 3.12 `type` statement in an
Anaconda-installed `imagecodecs` stub before reaching any project code. That
stub is absent from the Poetry venv, so it is an artefact of the fallback,
not a repository problem, and nothing here works around it.

## Branch cleanup

Already done. `fix/streaming-pcs-image-write` and
`feature/lazy-loading-support` are both gone from `origin`, removed by the
sweep recorded in `handouts/README.md`, which went further and deleted 56
stale local and 5 remote branches. `origin` now holds only `main`,
`gh-pages`, and the live lane branches. Nothing left to delete here.

`handouts/README.md` also carried advice not to run
`pre-commit run --all-files` because it rewrote ~137 unrelated files. That
is no longer true, so it is updated, along with a note that worktrees hide
bandit findings under `.github/`.
