### PR TITLE
docs: correct the anndata pandas-3 fix status

### DIFF
--- a/handouts/pandas-3-string-dtypes.md
+++ b/handouts/pandas-3-string-dtypes.md
@@ -53,25 +53,45 @@ registry has a writer for `pandas.core.arrays.string_.StringArray` but not
 for the `*NumpySemantics` subclasses pandas 3 actually produces, and the
 registry matches exact types rather than subclasses.
 
-### Upstream will not fix this in a version we can use
+### Upstream has already fixed this, in a release the ceiling excludes
+
+**Corrected 2026-07-30.** This section previously said anndata #2221 was open
+and milestoned 0.14.0, and concluded that upstream would not fix this in a
+usable timeframe. That was wrong. The fix below was written on that mistaken
+basis, which does not make it wrong — it was and is needed on the pinned
+anndata — but it does change it from a permanent fixture into removable work.
 
 Checked directly:
 
 - **anndata #2377** is our exact error. Closed as a duplicate of #2221.
-- **anndata #2221** ("Pandas 3.0 compatibility") is **open**, milestoned
-  **0.14.0**. The plan is to warn in 0.13 and flip defaults in 0.14.
+- **anndata #2221** ("Pandas 3.0 compatibility") was **closed as completed**
+  on 2025-12-11 by anndata #2133, and shipped in **anndata 0.13.0**
+  (2026-07-07). Its milestone label still reads 0.14.0, which is what caused
+  the original misreading — the label was never updated to match the release
+  the fix actually landed in.
 - **spatialdata-io #364** is the same failure hitting spatialdata's own
-  Xenium writer, so this is an ecosystem gap, not a Thyra bug.
+  Xenium writer, so this is an ecosystem gap, not a Thyra bug. Note the right
+  advice for that issue is now "upgrade to anndata >= 0.13", not the coercion
+  below.
 
-The repo owner is a spatialdata contributor with an open PR there (#1055,
-see [handout E](upstream-lazy-table-pr.md)). The same coercion arguably
-belongs in spatialdata's own table write path, which would make Thyra's
-copy redundant. That is a good thing to raise on #364, but it is not a
-reason to delay this handout: Thyra cannot wait on an upstream release
-cycle for a bug that breaks conversions today.
+Verified by direct test on 2026-07-30, writing an obs table with a string
+index, a string column, and a string-backed categorical:
 
-`pyproject.toml` pins `anndata = ">=0.11.0, <0.13"`, so even 0.13's warnings
-are out of range and 0.14 is far out.
+| pandas | pyarrow | anndata | `write_zarr` |
+|---|---|---|---|
+| 2.3.2 + `infer_string` | yes | 0.12.2 | `IORegistryError` on `ArrowStringArrayNumpySemantics` |
+| 3.0.5 | yes | 0.12.2 | `IORegistryError` on `pandas.arrays.ArrowStringArray` |
+| 3.0.5 | no | 0.12.2 | `RuntimeError` on `allow_write_nullable_strings` |
+| 2.3.2 + `infer_string` | yes | **0.13.2** | **PASS** |
+| 3.0.5 | yes | **0.13.2** | **PASS** |
+
+The concrete failing class varies with pandas version and whether pyarrow is
+installed, which is why a fix keyed to any one class name would be wrong.
+
+`pyproject.toml` pins `anndata = ">=0.11.0, <0.13"`, which excludes the fix.
+spatialdata 0.7.3 requires only `anndata>=0.9.1`, so raising that ceiling is
+**not** blocked by the spatialdata pin, and not blocked by
+[handout E](upstream-lazy-table-pr.md) either.
 
 **anndata's documented escape hatches do not work on our pinned version.**
 Verified against anndata 0.12.2 with `infer_string=True`:
@@ -125,12 +145,13 @@ Worth stating in the commit message, because it is the crux:
 
 ### Required: a removal trigger
 
-This *should* become dead code once anndata 0.14 ships pandas 3 support.
-Leave something that makes that obvious rather than letting it calcify:
+This is dead code the moment the `anndata` ceiling moves to `>= 0.13`, which
+already exists and is not blocked on anything. Leave something that makes that
+obvious rather than letting it calcify:
 
-- A module-level comment naming **anndata #2221** and the 0.14.0 milestone,
-  stating the coercion can be deleted when the `anndata` ceiling moves to
-  `>=0.14` with pandas-3 support.
+- A module-level comment naming **anndata #2221** and the 0.13.0 release that
+  fixed it, stating the coercion can be deleted when the `anndata` ceiling
+  moves to `>=0.13`.
 - Ideally a test that fails loudly when the installed anndata *can* write
   Arrow-backed strings, so the workaround announces its own obsolescence
   instead of silently pessimising. Something like: if

--- a/tests/unit/converters/test_pandas3_string_dtypes.py
+++ b/tests/unit/converters/test_pandas3_string_dtypes.py
@@ -252,10 +252,12 @@ def test_coercion_is_a_noop_on_object_dtypes():
 @pytest.mark.xfail(
     strict=False,
     reason=(
-        "The pinned anndata cannot serialize pandas' str dtype -- see anndata "
-        "#2221 ('Pandas 3.0 compatibility', milestone 0.14.0). An XPASS here "
-        "means the installed anndata can write Arrow-backed strings and "
-        "_coerce_table_strings_to_object can be deleted."
+        "The pinned anndata (< 0.13) cannot serialize pandas' str dtype. "
+        "anndata #2221 ('Pandas 3.0 compatibility') was fixed by anndata "
+        "#2133 and released in 0.13.0, so raising the ceiling is what makes "
+        "this XPASS. An XPASS here means the installed anndata can write "
+        "Arrow-backed strings and _coerce_table_strings_to_object can be "
+        "deleted."
     ),
 )
 def test_anndata_can_write_arrow_backed_strings(tmp_path):

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1830,8 +1830,9 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         return f"{self.dataset_id}_optical_{suffix}"
 
     # --- pandas 3 string dtypes: removal trigger ---------------------------
-    # anndata #2221 ("Pandas 3.0 compatibility") is open and milestoned
-    # 0.14.0: the plan is to warn in 0.13 and flip the defaults in 0.14.
+    # anndata #2221 ("Pandas 3.0 compatibility") was closed by anndata #2133
+    # and shipped in anndata 0.13.0 (2026-07-07), so this is already fixed
+    # upstream -- just not in a version this project's ceiling admits.
     # anndata #2377 is this exact IORegistryError, closed as a duplicate of
     # it, and spatialdata-io #364 is the same failure in spatialdata's own
     # Xenium writer, so this is an ecosystem gap and not a Thyra bug.
@@ -1840,8 +1841,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
     # `pd.set_option("mode.string_storage", "python")` both still raise.
     #
     # Delete `_coerce_table_strings_to_object` and its call in `_save_output`
-    # once the anndata ceiling in pyproject.toml moves to a release with
-    # pandas 3 support (>= 0.14). Until then this is the only thing keeping
+    # once the anndata ceiling in pyproject.toml moves to >= 0.13. Verified
+    # 2026-07-30: anndata 0.13.2 writes these tables cleanly on both pandas
+    # 2.3.2 with future.infer_string and pandas 3.0.5. spatialdata 0.7.3
+    # requires only anndata >= 0.9.1, so that bump is not blocked by the
+    # spatialdata pin. Until it happens this is the only thing keeping
     # non-PCS conversions writable, so it is not dead code yet:
     # tests/unit/converters/test_pandas3_string_dtypes.py
     # ::test_anndata_can_write_arrow_backed_strings XPASSes when it becomes so.


### PR DESCRIPTION
# Pull Request

## Description

Corrects the recorded status of anndata #2221 ("Pandas 3.0 compatibility") across
handout A, the removal-trigger comment on `_coerce_table_strings_to_object`, and the
xfail reason in the pandas-3 test module.

The issue was closed by anndata #2133 and shipped in anndata 0.13.0 on 2026-07-07. Its
milestone label still reads 0.14.0, which is why all three places recorded it as open
and further off than it is. The practical consequence is that the removal trigger for
the workaround moves from "anndata >= 0.14" to "anndata >= 0.13", which is a much nearer
bump.

No behaviour change: comments, documentation, and one xfail reason string.

## Type of Change
- [x] Documentation update

## Related Issues

Relates to #117 ("Delete `_coerce_table_strings_to_object` by raising the anndata ceiling
to >= 0.13"). This PR does not close it -- it only corrects the recorded facts that #117
acts on. The ceiling bump itself is still to do.

## Changes Made

- `thyra/converters/spatialdata/base_spatialdata_converter.py`: the removal-trigger
  comment now states that anndata #2221 was fixed upstream in 0.13.0 rather than being
  open and milestoned 0.14.0, and that the trigger is an anndata ceiling of >= 0.13.
  Records that spatialdata 0.7.3 requires only `anndata>=0.9.1`, so the spatialdata pin
  does not block that bump.
- `tests/unit/converters/test_pandas3_string_dtypes.py`: the xfail reason on
  `test_anndata_can_write_arrow_backed_strings` is updated to match, so an XPASS points
  at the right cause.
- `handouts/pandas-3-string-dtypes.md`: same correction, plus the verification result
  below.

Verified by direct test rather than from the issue tracker: anndata 0.13.2 writes a
table with a string index, a string column and a string-backed categorical on both
pandas 2.3.2 with `future.infer_string` and pandas 3.0.5, while anndata 0.12.2 fails on
both.

## Testing
- [x] All existing tests pass

No functional code changed. The converter diff contains no non-comment lines, and the
only test change is an xfail reason string, so the suite's behaviour is unaffected.

## Code Quality
- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Code is well-commented, particularly in hard-to-understand areas

## Documentation
- [x] Documentation has been updated (if applicable)

## Performance Impact
- [x] No performance impact

## Additional Notes

`_coerce_table_strings_to_object` stays in place for now. It is still the only thing
keeping non-PCS conversions writable under the current anndata ceiling, so it is not
dead code yet; `test_anndata_can_write_arrow_backed_strings` XPASSes once it becomes so,
which is the signal to delete it under #117.
