### PR TITLE
perf(imzml): stream the processed-mode raw mass axis build

### DIFF
--- a/tests/unit/readers/test_mass_axis_streaming.py
+++ b/tests/unit/readers/test_mass_axis_streaming.py
@@ -1,0 +1,358 @@
+# tests/unit/readers/test_mass_axis_streaming.py
+"""Tests for the streaming processed-mode common mass axis build.
+
+``_extract_continuous_mass_axis`` used to collect every spectrum's m/z array
+into a list, concatenate it, and hand the result to ``np.unique`` -- three
+live copies of the whole m/z payload. It now streams: values go into a
+scratch buffer that is sorted, deduplicated and merged into a running axis
+whenever it fills.
+
+The contract is that the result stays **bit-identical** to what
+``np.unique(np.concatenate(all_mzs))`` returned, so nearly everything here
+compares against that reference rather than against hand-written expectations.
+``np.testing.assert_allclose``, which the older reader test uses, is not
+sufficient: it cannot see a dtype change, a NaN difference, or a signed-zero
+difference.
+
+The most important thing in this file is that the whole matrix runs against a
+monkeypatched batch size. At the real batch of 2^20 values every test input
+fits in one batch, the merge path is never entered, and the tests are
+worthless as a guard on the part most likely to break. Both prototypes of this
+algorithm shipped with a crash that only a tiny batch size exposes: one on an
+all-NaN batch, one on an empty accumulator.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from thyra.readers.imzml import imzml_reader as mod
+from thyra.readers.imzml.imzml_reader import (
+    ImzMLReader,
+    _dedupe_sorted,
+    _filter_absent,
+    _merge_disjoint,
+)
+
+# Batch sizes small enough to force many folds, plus the real one.
+BATCH_SIZES = [1, 2, 3, 7, 1 << 20]
+
+
+class _StubParser:
+    """Minimal stand-in for ImzMLParser over a list of m/z runs.
+
+    Returns read-only arrays, as pyimzml does -- it hands back a
+    ``np.frombuffer`` view over a ``bytes`` object. Anything that tried to sort
+    a spectrum in place would raise here rather than silently corrupt the
+    caller's data.
+    """
+
+    def __init__(self, runs, raise_on=()):
+        self._runs = [np.asarray(r) for r in runs]
+        self._raise_on = set(raise_on)
+        self.coordinates = [(i + 1, 1, 1) for i in range(len(self._runs))]
+
+    def getspectrum(self, idx):
+        if idx in self._raise_on:
+            raise RuntimeError(f"boom at {idx}")
+        mzs = self._runs[idx]
+        view = np.frombuffer(mzs.tobytes(), dtype=mzs.dtype)
+        return view, np.ones(view.size, dtype=np.float32)
+
+
+def _reference(runs):
+    """What the previous implementation returned."""
+    non_empty = [np.asarray(r) for r in runs if np.asarray(r).size]
+    return np.unique(np.concatenate(non_empty))
+
+
+def _build(runs, max_len=None, raise_on=()):
+    reader = SimpleNamespace(max_mass_axis_length=max_len)
+    return ImzMLReader._extract_continuous_mass_axis(
+        reader, _StubParser(runs, raise_on=raise_on)
+    )
+
+
+def _assert_bit_identical(got, ref):
+    """Compare exactly, including dtype, NaN payloads and signed zeros."""
+    assert got.dtype == ref.dtype, f"dtype {got.dtype} != {ref.dtype}"
+    assert got.shape == ref.shape, f"shape {got.shape} != {ref.shape}"
+    raw = np.uint64 if got.dtype == np.float64 else np.uint32
+    assert np.array_equal(got.view(raw), ref.view(raw))
+
+
+@pytest.fixture(params=BATCH_SIZES)
+def batch(request, monkeypatch):
+    """Run each test at several batch sizes, including tiny ones."""
+    monkeypatch.setattr(mod, "_MASS_AXIS_BATCH_VALUES", request.param)
+    monkeypatch.setattr(mod, "_MASS_AXIS_PROBE_BLOCK", max(1, request.param))
+    return request.param
+
+
+class TestMatchesReference:
+    """Bit-identity against np.unique(np.concatenate(...))."""
+
+    @pytest.mark.parametrize(
+        "runs",
+        [
+            pytest.param([[1.0, 2.0, 3.0]], id="single-spectrum"),
+            pytest.param([[5.0]], id="single-peak"),
+            pytest.param([[1.0], [2.0], [3.0], [4.0]], id="one-peak-each"),
+            pytest.param([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]], id="all-identical"),
+            pytest.param([[1.0, 1.0, 1.0, 2.0, 2.0, 3.0]], id="dupes-within"),
+            pytest.param([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], id="dupes-across"),
+            pytest.param([[1.0, 2.0], [10.0, 11.0]], id="disjoint"),
+            pytest.param(
+                [list(np.arange(50.0, 100.0)), list(np.arange(0.0, 50.0))],
+                id="second-entirely-below-first",
+            ),
+            pytest.param(
+                [[float(20 - i)] for i in range(20)], id="strictly-descending"
+            ),
+            pytest.param([[3.0, 1.0, 2.0]], id="unsorted-within-spectrum"),
+        ],
+    )
+    def test_shapes(self, runs, batch):
+        _assert_bit_identical(_build(runs), _reference(runs))
+
+    def test_many_spectra_shared_grid(self, batch):
+        grid = np.arange(100.0, 200.0, 0.5)
+        rng = np.random.default_rng(0)
+        runs = [np.sort(rng.choice(grid, size=20, replace=False)) for _ in range(40)]
+        _assert_bit_identical(_build(runs), _reference(runs))
+
+    def test_many_spectra_all_distinct(self, batch):
+        rng = np.random.default_rng(1)
+        runs = [np.sort(rng.uniform(100.0, 200.0, 25)) for _ in range(40)]
+        _assert_bit_identical(_build(runs), _reference(runs))
+
+    def test_spectrum_larger_than_batch(self, batch):
+        # Forces the reallocation branch when one spectrum exceeds the buffer.
+        runs = [np.arange(0.0, 100.0), [500.0], np.arange(200.0, 400.0)]
+        _assert_bit_identical(_build(runs), _reference(runs))
+
+
+class TestEmptyAndDegenerate:
+    """Empty spectra are skipped; nothing at all is an error."""
+
+    @pytest.mark.parametrize(
+        "runs",
+        [
+            pytest.param([[], [1.0, 2.0], [3.0]], id="leading-empty"),
+            pytest.param([[1.0, 2.0], [3.0], []], id="trailing-empty"),
+            pytest.param([[1.0], [], [2.0], [], [3.0]], id="interleaved-empty"),
+        ],
+    )
+    def test_empty_spectra_are_skipped(self, runs, batch):
+        _assert_bit_identical(_build(runs), _reference(runs))
+
+    def test_all_spectra_empty_raises(self, batch):
+        with pytest.raises(ValueError, match="No spectra found"):
+            _build([[], [], []])
+
+    def test_zero_spectra_raises(self, batch):
+        with pytest.raises(ValueError, match="No spectra found"):
+            _build([])
+
+
+class TestFloatEdgeCases:
+    """NaN, infinities and values that must not be collapsed."""
+
+    @pytest.mark.parametrize(
+        "runs",
+        [
+            pytest.param([[1.0, np.nan]], id="one-nan"),
+            pytest.param([[np.nan]], id="only-nan"),
+            pytest.param([[np.nan], [np.nan], [np.nan]], id="all-nan-every-batch"),
+            pytest.param([[1.0, np.nan, np.nan, np.nan]], id="several-nan"),
+            pytest.param([[1.0, np.nan], [2.0], [np.nan, 3.0]], id="nan-interleaved"),
+        ],
+    )
+    def test_nan_matches_reference(self, runs, batch):
+        got = _build(runs)
+        _assert_bit_identical(got, _reference(runs))
+        # numpy collapses NaNs and sorts them last.
+        assert np.count_nonzero(np.isnan(got)) == 1
+        assert np.isnan(got[-1])
+
+    def test_all_nan_batch_does_not_crash(self, batch):
+        """Regression: an all-NaN batch broke an early version of the dedupe.
+
+        Without the ``first_nan > 0`` guard this raises
+        "operands could not be broadcast together".
+        """
+        runs = [[np.nan, np.nan], [np.nan], [1.0]]
+        _assert_bit_identical(_build(runs), _reference(runs))
+
+    def test_infinities(self, batch):
+        runs = [[-np.inf, 1.0], [np.inf], [0.0, np.inf]]
+        _assert_bit_identical(_build(runs), _reference(runs))
+
+    def test_one_ulp_apart_is_not_collapsed(self, batch):
+        a = 700.0
+        b = np.nextafter(a, np.inf)
+        got = _build([[a], [b]])
+        assert got.size == 2
+        _assert_bit_identical(got, _reference([[a], [b]]))
+
+    def test_subnormals(self, batch):
+        tiny = np.finfo(np.float64).tiny
+        runs = [[tiny, tiny / 2.0], [0.0]]
+        _assert_bit_identical(_build(runs), _reference(runs))
+
+
+class TestDtype:
+    """The axis dtype follows the file's mzPrecision."""
+
+    def test_float32_stays_float32(self, batch):
+        runs = [np.array([3.0, 1.0], dtype=np.float32), np.array([2.0], np.float32)]
+        got = _build(runs)
+        assert got.dtype == np.float32
+        _assert_bit_identical(got, _reference(runs))
+
+    def test_float64_stays_float64(self, batch):
+        runs = [np.array([3.0, 1.0], dtype=np.float64)]
+        assert _build(runs).dtype == np.float64
+
+
+class TestMaxMassAxisLength:
+    """The guard that stops a raw axis growing without bound."""
+
+    def test_raises_when_exceeded(self, batch):
+        runs = [[float(i)] for i in range(100)]
+        with pytest.raises(ValueError, match="exceeded"):
+            _build(runs, max_len=10)
+
+    def test_message_names_the_limit_and_the_count(self, batch):
+        runs = [[float(i)] for i in range(100)]
+        with pytest.raises(ValueError) as exc:
+            _build(runs, max_len=10)
+        text = str(exc.value)
+        assert "10" in text
+        assert "spectra" in text
+        # It must say what to do about it.
+        assert "resampling" in text
+
+    def test_not_swallowed_by_the_per_spectrum_handler(self, batch):
+        """Regression: the guard must escape the read's try/except.
+
+        The previous code wrapped the whole loop body, so a ValueError raised
+        during the merge would have been logged as a warning and ignored.
+        """
+        runs = [[float(i)] for i in range(100)]
+        with pytest.raises(ValueError):
+            _build(runs, max_len=5)
+
+    def test_generous_limit_does_not_raise(self, batch):
+        runs = [[float(i)] for i in range(50)]
+        assert _build(runs, max_len=10_000).size == 50
+
+    def test_absent_limit_is_unlimited(self, batch):
+        runs = [[float(i)] for i in range(50)]
+        assert _build(runs, max_len=None).size == 50
+
+
+class TestPerSpectrumErrors:
+    """A failing spectrum is warned about, not fatal."""
+
+    def test_failing_spectra_are_skipped(self, batch, caplog):
+        runs = [[1.0], [2.0], [3.0], [4.0]]
+        got = _build(runs, raise_on=(1, 2))
+        assert np.array_equal(got, np.array([1.0, 4.0]))
+
+    def test_all_spectra_failing_raises(self, batch):
+        with pytest.raises(ValueError, match="No spectra found"):
+            _build([[1.0], [2.0]], raise_on=(0, 1))
+
+
+class TestFuzz:
+    """Randomised comparison against the reference.
+
+    This is what found the crashes in both prototypes of this algorithm.
+    """
+
+    @pytest.mark.parametrize("seed", range(60))
+    def test_random_runs_match_reference(self, seed, monkeypatch):
+        rng = np.random.default_rng(seed)
+        monkeypatch.setattr(mod, "_MASS_AXIS_BATCH_VALUES", int(rng.integers(1, 16)))
+        monkeypatch.setattr(mod, "_MASS_AXIS_PROBE_BLOCK", int(rng.integers(1, 16)))
+
+        n_runs = int(rng.integers(0, 12))
+        pool = rng.uniform(0.0, 50.0, 25)
+        runs = []
+        for _ in range(n_runs):
+            size = int(rng.integers(0, 10))
+            vals = rng.choice(pool, size=size, replace=True).astype(np.float64)
+            if size and rng.random() < 0.15:
+                vals[rng.integers(0, size)] = np.nan
+            if size and rng.random() < 0.08:
+                vals[rng.integers(0, size)] = np.inf
+            runs.append(np.sort(vals))
+
+        if not any(r.size for r in runs):
+            with pytest.raises(ValueError):
+                _build(runs)
+            return
+
+        _assert_bit_identical(_build(runs), _reference(runs))
+
+
+class TestHelpers:
+    """The pure helpers, targeted directly."""
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [],
+            [1.0],
+            [1.0, 1.0],
+            [1.0, 2.0, 2.0, 3.0],
+            [np.nan],
+            [np.nan, np.nan],
+            [1.0, np.nan, np.nan],
+        ],
+    )
+    def test_dedupe_sorted_matches_np_unique(self, values):
+        a = np.array(values, dtype=np.float64)
+        got = _dedupe_sorted(a)
+        ref = np.unique(a)
+        assert np.array_equal(got, ref, equal_nan=True)
+
+    def test_dedupe_sorted_does_not_mutate_input(self):
+        a = np.array([1.0, 1.0, 2.0])
+        before = a.copy()
+        _dedupe_sorted(a)
+        assert np.array_equal(a, before)
+
+    def test_filter_absent_empty_accumulator(self):
+        """Regression: an empty accumulator used to raise IndexError."""
+        s = np.array([1.0, 2.0])
+        assert np.array_equal(_filter_absent(np.array([]), s), s)
+
+    def test_filter_absent_removes_present_values(self):
+        acc = np.array([1.0, 3.0, 5.0])
+        s = np.array([2.0, 3.0, 6.0])
+        assert np.array_equal(_filter_absent(acc, s), np.array([2.0, 6.0]))
+
+    def test_filter_absent_all_present(self):
+        acc = np.array([1.0, 2.0, 3.0])
+        assert _filter_absent(acc, np.array([1.0, 3.0])).size == 0
+
+    def test_filter_absent_nan_already_present(self):
+        """A NaN in the accumulator must not be re-added every fold."""
+        acc = np.array([1.0, np.nan])
+        assert _filter_absent(acc, np.array([np.nan])).size == 0
+
+    def test_merge_disjoint_unions_and_sorts(self):
+        out = _merge_disjoint([np.array([1.0, 4.0])], [np.array([2.0, 3.0])])
+        assert np.array_equal(out, np.array([1.0, 2.0, 3.0, 4.0]))
+
+    def test_merge_disjoint_releases_its_inputs(self):
+        """The boxes are emptied so the caller's reference cannot pin memory."""
+        box_a, box_b = [np.array([1.0])], [np.array([2.0])]
+        _merge_disjoint(box_a, box_b)
+        assert box_a[0] is None
+        assert box_b[0] is None

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -281,6 +281,12 @@ def convert_msi(
               to include. Default: None (no filtering).
             - use_recalibrated_state: bool - For Bruker data,
               use active/recalibrated calibration (default True).
+            - max_mass_axis_length: int - For processed-mode imzML
+              converted with --no-resample, give up once the raw
+              mass axis exceeds this many unique m/z values.
+              Default: None (unlimited). Useful when the peak
+              lists share no m/z values, where the raw axis grows
+              to roughly one column per peak in the whole dataset.
         sparse_format: Sparse matrix format ('csc' or 'csr')
         include_optical: Include optical images (default: True)
         apply_optical_alignment: If True (default) and the MSI source

--- a/thyra/readers/imzml/imzml_reader.py
+++ b/thyra/readers/imzml/imzml_reader.py
@@ -15,6 +15,308 @@ from ...metadata.extractors.imzml_extractor import ImzMLMetadataExtractor
 
 logger = logging.getLogger(__name__)
 
+# Scratch buffer floor for the processed-mode mass axis build, in ELEMENTS.
+# 1Mi elements is 8 MiB at float64. Measured at a 512 MiB m/z payload on a
+# shared grid (peak extra RSS / wall clock): 2^14 -> 7.14 MiB / 3.04 s,
+# 2^17 -> 6.90 / 3.06, 2^20 -> 15.30 / 2.30, 2^22 -> 40.29 / 2.11,
+# 2^24 -> 148.38 / 2.06. A 1024x sweep of the knob moves wall clock 1.5x with
+# no cliff anywhere, so this is a knee rather than a fragile constant.
+_MASS_AXIS_BATCH_VALUES = 1 << 20
+
+# Block size for the searchsorted probe in ``_filter_absent``, in ELEMENTS.
+# Bounds that function's temporaries to O(block) rather than O(batch).
+_MASS_AXIS_PROBE_BLOCK = 1 << 20
+
+
+def _dedupe_sorted(a: NDArray[Any]) -> NDArray[Any]:
+    """Deduplicate an ALREADY-SORTED array, as ``np.unique`` would.
+
+    Reproduces numpy's ``_unique1d`` mask including its ``equal_nan=True``
+    behaviour, which collapses a trailing run of NaNs to its first element.
+    Unlike ``np.unique`` it does not make the extra full-size ``flatten()``
+    copy, which is one of the three payload-sized allocations the old
+    collect-everything-then-unique build paid for.
+
+    Args:
+        a: A sorted array.
+
+    Returns:
+        The distinct values of ``a``, in order.
+    """
+    n = a.size
+    if n == 0:
+        return a[:0].copy()
+
+    mask = np.empty(n, dtype=bool)
+    mask[0] = True
+
+    if a.dtype.kind == "f" and bool(np.isnan(a[-1])):
+        first_nan = int(np.searchsorted(a, a[-1], side="left"))
+        # The ``first_nan > 0`` guard is load-bearing: an all-NaN input makes
+        # the slices empty and ``np.not_equal`` raises on the shape mismatch.
+        if first_nan > 0:
+            np.not_equal(a[1:first_nan], a[: first_nan - 1], out=mask[1:first_nan])
+        mask[first_nan] = True
+        mask[first_nan + 1 :] = False
+    else:
+        np.not_equal(a[1:], a[:-1], out=mask[1:])
+
+    return a[mask]
+
+
+def _filter_absent(
+    acc: NDArray[Any],
+    s: NDArray[Any],
+    block: int = _MASS_AXIS_PROBE_BLOCK,
+) -> NDArray[Any]:
+    """Return the elements of ``s`` that are not already in ``acc``.
+
+    Both arrays must be sorted and free of duplicates. ``s`` is walked in
+    blocks so the search temporaries stay O(block) rather than O(len(s)).
+    Returns ``s`` itself, uncopied, when none of its values are present --
+    the all-distinct fast path, worth half a payload at peak.
+
+    Args:
+        acc: The running axis, sorted and unique.
+        s: A candidate batch, sorted and unique.
+        block: Probe block size in elements.
+
+    Returns:
+        The subset of ``s`` absent from ``acc``.
+    """
+    n = s.size
+    # ``acc.size == 0`` must be handled here: the ``np.minimum`` below would
+    # otherwise index ``acc[-1]`` on an empty array and raise IndexError.
+    if n == 0 or acc.size == 0:
+        return s
+
+    keep = np.empty(n, dtype=bool)
+    n_keep = 0
+    is_float = acc.dtype.kind == "f"
+    a_len = acc.size
+
+    for lo in range(0, n, block):
+        hi = min(lo + block, n)
+        sb = s[lo:hi]
+        pos = np.searchsorted(acc, sb, side="left")
+        out_of_range = pos >= a_len
+        np.minimum(pos, a_len - 1, out=pos)
+        va = acc[pos]
+        eq = va == sb
+        if is_float:
+            # searchsorted routes a NaN key onto acc's first NaN, but NaN does
+            # not compare equal to itself, so without this the same NaN would
+            # be re-inserted on every fold.
+            np.logical_or(eq, np.isnan(va) & np.isnan(sb), out=eq)
+        np.logical_and(eq, ~out_of_range, out=eq)
+        np.logical_not(eq, out=eq)
+        keep[lo:hi] = eq
+        n_keep += int(np.count_nonzero(eq))
+        del pos, out_of_range, va, eq, sb
+
+    if n_keep == n:
+        return s
+    if n_keep == 0:
+        return s[:0]
+    return s[keep]
+
+
+def _merge_disjoint(box_a: List[Any], box_b: List[Any]) -> NDArray[Any]:
+    """Merge two DISJOINT sorted arrays, releasing each once it is copied.
+
+    The inputs arrive boxed in one-element lists so this function can drop the
+    caller's reference as soon as each side has been copied. Passing them as
+    plain parameters would keep both alive for the whole call and add a full
+    copy of the larger side to the peak.
+
+    The result needs no second deduplication because ``_filter_absent`` has
+    already removed the overlap, which saves another full-size copy.
+
+    Args:
+        box_a: One-element list holding the first sorted array.
+        box_b: One-element list holding the second sorted array.
+
+    Returns:
+        The sorted union of the two inputs.
+    """
+    a, b = box_a[0], box_b[0]
+    out = np.empty(a.size + b.size, dtype=a.dtype)
+
+    n_a = a.size
+    out[:n_a] = a
+    box_a[0] = None
+    del a
+
+    out[n_a:] = b
+    box_b[0] = None
+    del b
+
+    # Exactly two ascending runs, which is the case quicksort handles best.
+    out.sort(kind="quicksort")
+    return out
+
+
+def _read_spectrum_mzs(parser: Any, idx: int) -> Optional[NDArray[Any]]:
+    """Read one spectrum's m/z values, or None if missing or unreadable.
+
+    Args:
+        parser: An initialized ImzML parser.
+        idx: Spectrum index.
+
+    Returns:
+        The m/z array, or None when the spectrum is empty or failed to read.
+    """
+    try:
+        spectrum_data = parser.getspectrum(idx)
+    except Exception as e:
+        logger.warning(f"Error getting spectrum {idx}: {e}")
+        return None
+
+    if spectrum_data is None or len(spectrum_data) < 1:
+        return None
+    mzs = spectrum_data[0]
+    return mzs if mzs.size else None
+
+
+class _MassAxisAccumulator:
+    """Builds a sorted, unique m/z axis without holding every spectrum.
+
+    Values are copied into a scratch buffer; when that buffer fills, it is
+    sorted, deduplicated, and merged into the running axis. The buffer's
+    capacity tracks the axis length, so the number of merges is logarithmic in
+    the input rather than linear -- a fixed batch size would re-copy the
+    accumulator once per batch, which is the quadratic behaviour that makes a
+    naive ``np.union1d`` fold far slower than the code it replaces.
+
+    Peak memory therefore depends on the number of *unique* m/z values rather
+    than on the size of the file.
+    """
+
+    def __init__(self, total_spectra: int, max_length: Optional[int] = None) -> None:
+        """Initialize the accumulator.
+
+        Args:
+            total_spectra: Spectrum count, used only in the error message.
+            max_length: Cap on unique m/z values, or None for unlimited.
+        """
+        self._total_spectra = total_spectra
+        self._max_length = max_length
+        self._acc: Optional[NDArray[Any]] = None
+        self._buf: Optional[NDArray[Any]] = None
+        self._cap = 0
+        self._cap_target = _MASS_AXIS_BATCH_VALUES
+        self._n = 0
+        self.saw_any = False
+
+    def add(self, mzs: NDArray[Any], index: int) -> None:
+        """Buffer one spectrum's m/z values, folding first if the buffer is full.
+
+        Args:
+            mzs: The spectrum's m/z values. Not modified.
+            index: Spectrum index, used only in the error message.
+        """
+        m = mzs.size
+        if not m:
+            return
+        self.saw_any = True
+
+        if self._buf is None:
+            self._allocate(m, mzs.dtype)
+        elif self._n + m > self._cap:
+            self._fold(index)
+            if self._buf is None:
+                self._allocate(m, mzs.dtype)
+            elif m > self._cap:
+                self._buf = None
+                self._allocate(m, mzs.dtype, exact=True)
+
+        assert self._buf is not None
+        self._buf[self._n : self._n + m] = mzs
+        self._n += m
+
+    def finish(self, index: int) -> NDArray[Any]:
+        """Fold whatever is buffered and return the axis.
+
+        Args:
+            index: Last spectrum index, used only in the error message.
+
+        Returns:
+            Sorted, unique m/z values.
+
+        Raises:
+            ValueError: If no spectrum yielded any m/z values.
+        """
+        self._fold(index)
+        self._buf = None
+
+        if not self.saw_any or self._acc is None:
+            raise ValueError("No spectra found to build common mass axis")
+        if self._acc.size == 0:
+            raise ValueError("Failed to extract any m/z values")
+        return self._acc
+
+    def _allocate(self, m: int, dtype: Any, exact: bool = False) -> None:
+        """Allocate the scratch buffer, at least large enough for one spectrum."""
+        self._cap = m if exact else max(self._cap_target, m)
+        self._buf = np.empty(self._cap, dtype=dtype)
+
+    def _fold(self, index: int) -> None:
+        """Sort, deduplicate and merge the buffered batch into the axis."""
+        if self._n == 0 or self._buf is None:
+            return
+
+        view = self._buf[: self._n]
+        view.sort(kind="quicksort")
+        run = _dedupe_sorted(view)
+        self._n = 0
+
+        if self._cap > _MASS_AXIS_BATCH_VALUES:
+            # The scratch has grown to axis size, so release it before the
+            # merge allocates. Gating on the batch floor keeps this from firing
+            # on every one of the thousands of folds a shared-grid dataset
+            # performs, where re-faulting the buffer each time costs more than
+            # the memory it frees.
+            view = None
+            self._buf = None
+            self._cap = 0
+
+        if self._acc is None:
+            self._acc = run
+        else:
+            new = _filter_absent(self._acc, run)
+            run = None  # drop the batch before the merge allocates
+            if new.size:
+                box_a, box_b = [self._acc], [new]
+                self._acc = None
+                new = None
+                self._acc = _merge_disjoint(box_a, box_b)
+
+        self._check_limit(index)
+
+        # Record the next capacity but do NOT allocate it here. On the final
+        # fold the stream is already exhausted, so allocating would commit a
+        # whole axis-sized buffer that is never written.
+        self._cap_target = max(_MASS_AXIS_BATCH_VALUES, self._acc.size)
+        if self._cap and self._cap != self._cap_target:
+            self._buf = None
+            self._cap = 0
+
+    def _check_limit(self, index: int) -> None:
+        """Stop if the axis has outgrown ``max_length``."""
+        if self._max_length is None or self._acc is None:
+            return
+        if self._acc.size <= self._max_length:
+            return
+        raise ValueError(
+            f"Common mass axis exceeded {self._max_length:,} unique m/z values "
+            f"after {index + 1:,} of {self._total_spectra:,} spectra "
+            f"({self._acc.size:,} so far). The peak lists in this dataset do "
+            "not share m/z values, so a raw axis grows to roughly one column "
+            "per peak, which is not usable downstream. Convert with resampling "
+            "instead (it is the default; --no-resample disables it), or raise "
+            "max_mass_axis_length."
+        )
+
 
 @register_reader("imzml")
 class ImzMLReader(BaseMSIReader):
@@ -33,12 +335,16 @@ class ImzMLReader(BaseMSIReader):
             data_path: Path to the imzML file
             batch_size: Default batch size for spectrum iteration
             cache_coordinates: Whether to cache coordinates upfront
-            **kwargs: Additional arguments
+            **kwargs: Additional arguments. ``max_mass_axis_length`` caps the
+                number of unique m/z values the processed-mode raw axis may
+                reach before the build gives up; None (the default) is
+                unlimited. See ``_extract_continuous_mass_axis``.
         """
         super().__init__(data_path, **kwargs)
         self.filepath: Optional[Union[str, Path]] = data_path
         self.batch_size: int = batch_size
         self.cache_coordinates: bool = cache_coordinates
+        self.max_mass_axis_length: Optional[int] = kwargs.get("max_mass_axis_length")
         self.parser: Optional[ImzMLParser] = None
         self.ibd_file: Optional[Any] = None
         self.imzml_path: Optional[Path] = None
@@ -207,25 +513,46 @@ class ImzMLReader(BaseMSIReader):
         return self._common_mass_axis
 
     def _extract_continuous_mass_axis(self, parser: ImzMLParser) -> NDArray[np.float64]:
-        """Extract continuous mass axis from processed data."""
-        # For processed data, collect unique m/z values across spectra
+        """Build the common mass axis for processed-mode data.
+
+        Returns exactly what ``np.unique(np.concatenate(all_mzs))`` returned:
+        sorted, deduplicated, with the dtype following the file's mzPrecision.
+
+        This streams the file rather than collecting it. The previous
+        implementation held every spectrum's m/z array in a list, concatenated
+        that into one array, and handed the result to ``np.unique`` -- three
+        live copies of the whole m/z payload P, plus the output. Measured peak
+        was 3.40-3.51x P on data whose spectra share m/z values and 4.32-4.39x
+        P when every value is distinct, which put a hard ceiling around a
+        40 GB input on a 128 GB machine.
+
+        Here each spectrum is copied into a scratch buffer, and when that
+        buffer fills it is sorted, deduplicated, and merged into the running
+        axis. Peak memory becomes a function of the number of *unique* values
+        rather than the payload: measured 15.2-15.5 MiB, flat, for payloads
+        from 32 MiB to 16 GiB of shared-grid data, and 2.00x P in the
+        all-distinct case, which is the structural floor for an out-of-place
+        merge.
+
+        Args:
+            parser: An initialized ImzML parser.
+
+        Returns:
+            Sorted, unique m/z values across all spectra.
+
+        Raises:
+            ValueError: If no spectrum yielded any m/z values, or if
+                ``max_mass_axis_length`` is set and the axis outgrows it.
+        """
         logger.info(
             "Building common mass axis from all unique m/z values " "(processed mode)"
         )
 
         total_spectra = len(parser.coordinates)
-        all_mzs = self._collect_processed_mzs(parser, total_spectra)
-
-        if not all_mzs:
-            raise ValueError("No spectra found to build common mass axis")
-
-        return self._finalize_mass_axis(all_mzs)
-
-    def _collect_processed_mzs(
-        self, parser: ImzMLParser, total_spectra: int
-    ) -> List[NDArray[np.float64]]:
-        """Collect m/z values from all processed spectra."""
-        all_mzs: List[NDArray[np.float64]] = []
+        accumulator = _MassAxisAccumulator(
+            total_spectra, getattr(self, "max_mass_axis_length", None)
+        )
+        idx = -1
 
         with tqdm(
             total=total_spectra,
@@ -233,38 +560,18 @@ class ImzMLReader(BaseMSIReader):
             unit="spectrum",
         ) as pbar:
             for idx in range(total_spectra):
-                try:
-                    spectrum_data = parser.getspectrum(idx)
-                    if spectrum_data is None or len(spectrum_data) < 1:
-                        continue
-
-                    mzs = spectrum_data[0]
-                    if mzs.size > 0:
-                        all_mzs.append(mzs)
-                except Exception as e:
-                    logger.warning(f"Error getting spectrum {idx}: {e}")
+                mzs = _read_spectrum_mzs(parser, idx)
+                if mzs is not None:
+                    # Deliberately outside the read's try/except: a
+                    # max_mass_axis_length failure must not be swallowed and
+                    # logged as a per-spectrum warning.
+                    accumulator.add(mzs, idx)
+                mzs = None
                 pbar.update(1)
 
-        return all_mzs
-
-    def _finalize_mass_axis(
-        self, all_mzs: List[NDArray[np.float64]]
-    ) -> NDArray[np.float64]:
-        """Finalize the mass axis from collected m/z values."""
-        try:
-            combined_mzs = np.concatenate(all_mzs)
-            unique_mzs = np.unique(combined_mzs)
-
-            if unique_mzs.size == 0:
-                raise ValueError("Failed to extract any m/z values")
-
-            logger.info(
-                f"Created common mass axis with {len(unique_mzs)} unique " f"m/z values"
-            )
-            return unique_mzs
-        except Exception as e:
-            # Re-raise with more context
-            raise ValueError(f"Error creating common mass axis: {e}") from e
+        axis = accumulator.finish(idx)
+        logger.info(f"Created common mass axis with {axis.size} unique m/z values")
+        return axis
 
     def _get_spectrum_coordinates(
         self, parser: ImzMLParser, idx: int


### PR DESCRIPTION
Fixes the memory ceiling identified as the most serious remaining finding in [handout C](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/pull/111) -- a blocker for the stated 100+ GB use case.

## The problem

`_extract_continuous_mass_axis` collected every spectrum's m/z array into a list, concatenated it, and handed the result to `np.unique`. That keeps three copies of the whole m/z payload live at once, plus the output.

Measured peak extra RSS: **3.40-3.51x the payload** where spectra share m/z values, **4.32-4.39x** where every value is distinct. On a 128 GB machine that hard-OOMs somewhere around a 40 GB input. The streaming converter did not escape it either, since `StreamingSpatialDataConverter` inherits `_initialize_conversion` and calls `_setup_mass_axis` unconditionally.

## The fix

Every spectrum's m/z array already arrives ascending -- the old code threw that away by concatenating and re-sorting. Values now go into a scratch buffer that is sorted, deduplicated and merged into a running axis whenever it fills. The buffer's capacity **tracks the axis length**, so the number of merges is logarithmic rather than linear. That growth rule is not optional: a fixed batch size re-copies the accumulator once per batch, which is the quadratic behaviour that makes a naive `np.union1d` fold *slower* than the code it replaces.

Peak memory becomes a function of the number of **unique** values rather than of the file:

| Regime | Payload | Before | After | Reduction |
|---|---|---|---|---|
| Shared grid | 128 MiB | 455.7 MiB (3.56x) | 28.3 MiB (0.22x) | **16x** |
| Shared grid | 512 MiB | 1,811.7 MiB (3.54x) | 62.4 MiB (0.12x) | **29x** |
| All-distinct | 128 MiB | 568.5 MiB (4.44x) | 269.0 MiB (2.10x) | 2.1x |
| All-distinct | 512 MiB | 2,259.4 MiB (4.41x) | 1,072.7 MiB (2.10x) | 2.1x |

2.0x payload is the structural floor for an out-of-place merge, so there is no further constant-factor work worth doing in the all-distinct case. On a harness that excludes spectrum generation from the measured region, the shared-grid peak is **flat at ~15 MiB from 32 MiB to 16 GiB of payload**, and 10% *faster* than the current code at 4 GiB and above.

Which regime you are in is bimodal and worth knowing: m/z values recur only when the exported float64s are bit-identical, so grid-snapped exports share heavily (U/P ~ 1e-4) while anything interpolated or per-pixel recalibrated is fully distinct (U/P = 1.0) even on a shared instrument grid.

## Three details that look like polish and are not

Each was found by measurement, not reasoning:

- **The next scratch capacity is recorded, not allocated.** Allocating at the end of a fold commits an axis-sized buffer that the final fold never writes. This is invisible in Windows RSS but shows up as `tracemalloc` reading 3.0x payload against RSS's 2.0x, and it would bite on a cgroup limit or strict-overcommit Linux.
- **The scratch is released before the merge allocates, but only once it has outgrown the batch floor.** Doing it unconditionally re-faults the buffer on every one of thousands of folds in the sharing regime.
- **The per-spectrum `try/except` wraps only the read.** The old shape wrapped the whole loop body, which would swallow a `max_mass_axis_length` failure and log it as a warning.

## Opt-in guard

Adds a `max_mass_axis_length` reader option, **default None (unlimited)**. Where peak lists share no m/z values the raw axis grows to roughly one column per peak in the dataset -- a store with a mean of 1.0 nonzeros per column, unusable downstream whether or not it fits in RAM.

**No default limit is imposed here.** That is a policy decision with user-visible impact -- it would turn slow-but-working conversions into failures -- so it is left to you. If you want one, ~50,000,000 entries is defensible: it is comfortably above any real instrument grid and roughly where the `var` index alone costs 5-6 GB.

## Correctness

Output is **bit-identical** to `np.unique(np.concatenate(all_mzs))` -- same values, order, dtype and NaN handling. 254 new tests compare against that reference *bitwise*, not with `assert_allclose`, which cannot see a dtype or NaN difference.

The whole matrix runs at monkeypatched batch sizes of 1, 2, 3 and 7 as well as the real 2^20. This matters: at the real batch size every test input fits in one batch and the merge path is never exercised at all. Both earlier drafts of this algorithm carried a crash that only a tiny batch exposes -- one on an all-NaN batch, one on an empty accumulator -- and both have explicit regression tests. I verified the tests catch them by reintroducing each bug and confirming the suite fails.

`pytest`: 897 passed, 11 skipped. `black`, `isort`, `flake8`, `mypy`, `bandit`, `pydocstyle` clean via pre-commit. `mkdocs build --strict` clean.

## Not addressed here

Two independent defects surfaced while measuring and are deliberately **not** folded in:

- `base_spatialdata_converter.py:1229` and `streaming_converter.py:1470` each build a full-length list of `f"mz_{i}"` strings for the var index, measured at 89-112 bytes per entry. A `RangeIndex` is roughly free. This binds ~5.6x earlier than the axis build now does.
- `streaming_converter.py:498` and `:569` truncate CSR column indices to `int32`, which silently corrupts above 2,147,483,647 columns.
