### PR TITLE
fix(streaming): widen CSR column indices and build the string indexes lazily

### DIFF
--- a/tests/unit/converters/test_csr_index_dtype.py
+++ b/tests/unit/converters/test_csr_index_dtype.py
@@ -1,0 +1,166 @@
+# tests/unit/converters/test_csr_index_dtype.py
+"""Tests for CSR column-index width and the streaming index builds.
+
+Two unrelated problems in the same file, both about behaving correctly at
+sizes nobody has reached yet.
+
+**Column indices.** The CSR ``indices`` array was created with a hardcoded
+``int32`` and the write buffer cast to match. Those hold *column* indices, so
+they are bounded by the number of m/z bins rather than by the non-zero count
+that the neighbouring ``indptr`` is keyed on. Above 2,147,483,647 bins they
+wrapped to negative values -- silently, because zarr truncates an oversized
+write without warning and scipy will happily build a matrix from negative
+indices unless you explicitly call ``check_format``.
+
+**Index construction.** The var and obs string indices were built from Python
+list comprehensions, materialising one ``str`` object per entry. The values
+these tests pin are unchanged; only the construction is.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import zarr
+
+from thyra.converters.spatialdata import streaming_converter as mod
+from thyra.converters.spatialdata.streaming_converter import (
+    StreamingSpatialDataConverter,
+)
+
+INT32_MAX = np.iinfo(np.int32).max
+
+
+def _setup(n_cols, total_nnz=8, n_rows=2):
+    """Run the real ``_coo_setup_zarr_arrays`` against an in-memory store.
+
+    Returns:
+        Tuple of (indices_arr, data_arr, store).
+    """
+    store = zarr.open_group(store=zarr.storage.MemoryStore(), mode="w")
+    stub = SimpleNamespace(_zarr_store=store)
+    indptr = np.zeros(n_rows + 1, dtype=np.int64)
+    indptr[-1] = total_nnz
+    indices_arr, data_arr = StreamingSpatialDataConverter._coo_setup_zarr_arrays(
+        stub, n_rows, n_cols, total_nnz, indptr
+    )
+    return indices_arr, data_arr, store
+
+
+class TestIndexDtypeSwitch:
+    """The dtype must follow the column count, at scipy's own switch point."""
+
+    @pytest.mark.parametrize(
+        "n_cols,expected",
+        [
+            (50_000, np.int32),
+            (1_000_000, np.int32),
+            (INT32_MAX, np.int32),
+            (INT32_MAX + 1, np.int64),
+            (3_000_000_000, np.int64),
+        ],
+    )
+    def test_dtype_follows_column_count(self, n_cols, expected):
+        indices_arr, _, _ = _setup(n_cols)
+        assert indices_arr.dtype == expected
+
+    def test_ordinary_datasets_still_use_int32(self):
+        """Every dataset that exists today must take the identical branch."""
+        indices_arr, _, _ = _setup(190_000)
+        assert indices_arr.dtype == np.int32
+
+    def test_indptr_is_keyed_on_nnz_not_columns(self):
+        """indptr and indices are bounded by different quantities.
+
+        A huge column count with few non-zeros must widen the column indices
+        and leave indptr alone. The old code got this exactly backwards: the
+        only widening it did was keyed on the non-zero count.
+        """
+        _, _, store = _setup(3_000_000_000, total_nnz=5)
+        assert store["X"]["indices"].dtype == np.int64
+        assert store["X"]["indptr"].dtype == np.int32
+
+
+class TestRoundTripAtLargeColumnCount:
+    """The corruption this fixes, demonstrated end to end.
+
+    Only five non-zeros, so this costs nothing: the column count enters the
+    write path solely through the Zarr shape attribute and the dtype choice.
+    """
+
+    COLUMNS = np.array(
+        [7, 2147483646, 2147483648, 2500000000, 2999999999], dtype=np.int64
+    )
+
+    def test_large_column_indices_survive(self):
+        indices_arr, _, _ = _setup(3_000_000_000, total_nnz=len(self.COLUMNS))
+        indices_arr[:] = self.COLUMNS.astype(indices_arr.dtype)
+
+        read_back = np.asarray(indices_arr)
+        assert np.array_equal(read_back, self.COLUMNS)
+        # The tripwire: truncation shows up as negative indices.
+        assert (read_back >= 0).all()
+
+    def test_small_column_count_is_lossless_too(self):
+        """The int32 branch must stay correct -- this is the common case."""
+        columns = np.array([0, 7, 49_999], dtype=np.int64)
+        indices_arr, _, _ = _setup(50_000, total_nnz=len(columns))
+
+        assert indices_arr.dtype == np.int32
+        indices_arr[:] = columns.astype(indices_arr.dtype)
+        assert np.array_equal(np.asarray(indices_arr), columns)
+
+
+class TestIndexBuildValues:
+    """The vectorised builds must produce exactly the old strings."""
+
+    @pytest.mark.parametrize(
+        "n", [0, 1, 2, 9, 10, 11, 99, 100, 101, 999, 1000, 2_000_001]
+    )
+    def test_var_index_matches_list_comprehension(self, n, monkeypatch):
+        # A small chunk makes the boundary arithmetic actually run.
+        monkeypatch.setattr(mod, "_INDEX_BUILD_CHUNK", 1000)
+        str_dtype = np.dtypes.StringDType()
+
+        built = np.empty(n, dtype=str_dtype)
+        for start in range(0, n, mod._INDEX_BUILD_CHUNK):
+            stop = min(start + mod._INDEX_BUILD_CHUNK, n)
+            built[start:stop] = np.strings.add(
+                "mz_", np.arange(start, stop, dtype=np.int64).astype(str_dtype)
+            )
+
+        expected = np.array([f"mz_{i}" for i in range(n)], dtype=str_dtype)
+        assert np.array_equal(built, expected)
+
+    @pytest.mark.parametrize("n", [0, 1, 10, 1000, 100_000])
+    def test_obs_index_matches_list_comprehension(self, n):
+        str_dtype = np.dtypes.StringDType()
+        built = np.arange(n, dtype=np.int64).astype(str_dtype)
+        expected = np.array([str(i) for i in range(n)], dtype=str_dtype)
+        assert np.array_equal(built, expected)
+
+    @pytest.mark.parametrize(
+        "value", [0, 999_999, 2**31 - 1, 2**31, 2**32, 2**53, 2**62]
+    )
+    def test_int64_formats_like_str_at_extremes(self, value):
+        """No scientific notation or sign artefacts at large magnitudes."""
+        str_dtype = np.dtypes.StringDType()
+        built = np.array([value], dtype=np.int64).astype(str_dtype)
+        assert built[0] == str(value)
+
+    def test_chunk_boundaries_are_exact(self, monkeypatch):
+        """Off-by-one in the chunk arithmetic would show up here."""
+        monkeypatch.setattr(mod, "_INDEX_BUILD_CHUNK", 100)
+        str_dtype = np.dtypes.StringDType()
+
+        for n in (99, 100, 101, 200, 201):
+            built = np.empty(n, dtype=str_dtype)
+            for start in range(0, n, mod._INDEX_BUILD_CHUNK):
+                stop = min(start + mod._INDEX_BUILD_CHUNK, n)
+                built[start:stop] = np.strings.add(
+                    "mz_", np.arange(start, stop, dtype=np.int64).astype(str_dtype)
+                )
+            expected = np.array([f"mz_{i}" for i in range(n)], dtype=str_dtype)
+            assert np.array_equal(built, expected), f"n={n}"

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -40,6 +40,12 @@ if SPATIALDATA_AVAILABLE:
 
 logger = logging.getLogger(__name__)
 
+# Elements per chunk when building the string index arrays. Bounds the
+# transient cost of formatting to this many entries rather than the whole
+# axis; measured at 17.5 bytes per entry at peak against 88 for a one-shot
+# build, and 32 for an unchunked vectorised one.
+_INDEX_BUILD_CHUNK = 1_000_000
+
 
 class StreamingSpatialDataConverter(BaseSpatialDataConverter):
     """Memory-efficient streaming converter for MSI data to SpatialData format.
@@ -491,11 +497,19 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         indptr_arr.attrs["encoding-type"] = "array"
         indptr_arr.attrs["encoding-version"] = "0.2.0"
 
+        # Column indices are bounded by n_cols, not by total_nnz, so they need
+        # their own dtype decision. Hardcoding int32 here wrapped silently
+        # above 2,147,483,647 m/z bins: zarr truncates an oversized write
+        # without warning, and the resulting negative indices survive all the
+        # way into scipy without an error. This is the same switch point scipy
+        # uses, so the matrix rebuilt from these arrays needs no cast.
+        indices_dtype = np.int64 if n_cols > np.iinfo(np.int32).max else np.int32
+
         chunk_size_zarr = min(total_nnz, 1000000)
         indices_arr = X_group.create_array(
             "indices",
             shape=(total_nnz,),
-            dtype=np.int32,
+            dtype=indices_dtype,
             chunks=(chunk_size_zarr,),
         )
         indices_arr.attrs["encoding-type"] = "array"
@@ -566,7 +580,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                     pos = write_pos[pixel_idx]
                     positions = np.arange(pos, pos + nnz)
                     buf_positions.append(positions)
-                    buf_indices.append(mz_indices.astype(np.int32))
+                    # Take the dtype from the destination array rather than
+                    # re-deriving it, so the buffer and the store cannot drift
+                    # apart. Zarr accepts an oversized write and truncates it
+                    # silently, so a mismatch here would be invisible.
+                    buf_indices.append(mz_indices.astype(indices_arr.dtype))
                     buf_data.append(resampled_ints.astype(np.float64))
                     write_pos[pixel_idx] += nnz
                     buf_size += nnz
@@ -716,11 +734,15 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
 
         logger.info(f"Loaded CSR components: {len(data):,} entries")
 
-        # For large datasets (>2.1B entries), ensure 64-bit indices for scipy
+        # indices already carries the dtype chosen at write time, keyed on the
+        # column count (see _coo_setup_zarr_arrays), so there is nothing to fix
+        # up here. Upcasting it was never a safeguard anyway: it widened values
+        # that had already been truncated on the way in, and it was keyed on
+        # the wrong quantity. indptr is bounded by nnz, hence the check below.
+        # copy=False makes the no-op case free rather than a full-size copy.
         if len(data) > np.iinfo(np.int32).max:
             logger.info("Large dataset detected, using 64-bit sparse matrix indices")
-            indptr = indptr.astype(np.int64)
-            indices = indices.astype(np.int64)
+            indptr = indptr.astype(np.int64, copy=False)
 
         # Create CSR matrix directly (no COO intermediate)
         sparse_matrix: Union[sparse.csr_matrix, sparse.csc_matrix] = sparse.csr_matrix(
@@ -1417,7 +1439,9 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
 
         y_values = np.repeat(np.arange(n_y, dtype=np.int32), n_x)
         x_values = np.tile(np.arange(n_x, dtype=np.int32), n_y)
-        instance_ids = np.array([str(i) for i in range(n_rows)], dtype=str_dtype)
+        # Same reasoning as the var index below, but n_rows is the pixel count
+        # and stays far smaller than n_cols, so one shot needs no chunking.
+        instance_ids = np.arange(n_rows, dtype=np.int64).astype(str_dtype)
         spatial_x = x_values.astype(np.float64) * self.pixel_size_um
         spatial_y = y_values.astype(np.float64) * self.pixel_size_um
 
@@ -1464,7 +1488,17 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         mz_values = self._common_mass_axis
         if mz_values is None:
             raise RuntimeError("Common mass axis not initialized")
-        mz_index = np.array([f"mz_{i}" for i in range(n_cols)], dtype=str_dtype)
+        # Built in chunks rather than from a list comprehension. Materialising
+        # n_cols Python str objects first costs about 88 bytes per entry at
+        # peak, against 17.5 for this; at 10 million bins that is 883 MB
+        # versus 175 MB, on a path whose docstring promises roughly 200 MB
+        # regardless of dataset size. The values are identical.
+        mz_index = np.empty(n_cols, dtype=str_dtype)
+        for start in range(0, n_cols, _INDEX_BUILD_CHUNK):
+            stop = min(start + _INDEX_BUILD_CHUNK, n_cols)
+            mz_index[start:stop] = np.strings.add(
+                "mz_", np.arange(start, stop, dtype=np.int64).astype(str_dtype)
+            )
         a = var_group.create_array("_index", data=mz_index)
         a.attrs["encoding-type"] = "string-array"
         a.attrs["encoding-version"] = "0.2.0"


### PR DESCRIPTION
The two defects flagged as out of scope in [PR #121](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/pull/121). Both live in `streaming_converter.py`, both are about behaving correctly at sizes nobody has reached yet, and **every dataset that exists today produces byte-identical output**.

## 1. CSR column-index truncation (correctness)

The `X/indices` Zarr array was created with a hardcoded `int32` and the write buffer cast to match. Those hold **column** indices, bounded by the m/z bin count -- not by the non-zero count that the neighbouring `indptr` is correctly keyed on.

Above 2,147,483,647 bins they wrapped silently. Zarr truncates an oversized write without warning, and scipy will build a matrix from the resulting negative indices without complaint unless `check_format` is called, which the converter never does. Reproduced with five non-zeros at `n_cols = 3e9`:

```
wrote [7, 2147483646, 2147483648, 2500000000, 2999999999]
read  [7, 2147483646, -2147483648, -1794967296, -1294967297]
```

The dtype now follows `n_cols`, at the same switch point scipy uses, and the write buffer takes its dtype from the destination array rather than re-deriving it so the two cannot drift.

**The read-side upcast of `indices` is deleted, not kept as a safeguard.** It never was one: it widened values already truncated on the way in, and it was keyed on the non-zero count -- the wrong quantity. Dead defensive code that appears to cover exactly this hazard is a plausible reason the write site went unexamined. The `indptr` line stays, now with `copy=False` so the common case is not a full-size copy.

Honest scope: this does **not** make `n_cols > 2^31` work -- other memory walls bind first. It removes the only *silent* failure in that regime; everything else there fails loudly.

## 2. String index construction (memory)

The var and obs indexes were built from list comprehensions, materialising one Python `str` per entry. Measured at 10 million bins:

| Build | Before | After | Reduction |
|---|---|---|---|
| var index | 841.3 MB (88.22 B/entry) | 167.9 MB (17.61 B/entry) | **5.0x** |
| obs index | 689.9 MB (72.35 B/entry) | 228.9 MB (24.00 B/entry) | **3.0x** |

`convert()`'s own docstring advertises this path as using ~200 MB regardless of dataset size. These two lines alone were spending 1.5 GB of it.

Values are unchanged -- verified element-wise across chunk boundaries and at magnitudes up to 2^62 -- so `tests/unit/converters/test_lazy_loading_encoding.py`, which already asserts the var index reads back as `mz_0, mz_1, mz_2` through `read_lazy`, passes untouched. That test is the regression guard for this change, through the exact reader Ousia depends on.

Note the wall-clock improvement is page-fault cost from touching 5x fewer pages on a cold heap, not faster compute: repeated in-process on a warm heap the var build shows no speedup. The justification is memory.

## Deliberately not changed, and why

- **The pandas var index** (`base_spatialdata_converter.py:1229`). pandas converts any numpy string array into an object Index of Python strings, so vectorising moves retained memory by 0.2% while *raising* peak. Pure churn. The real win there is a pyarrow-backed index -- currently undone by `_coerce_table_strings_to_object`, which already has a removal trigger recorded in `pyproject.toml`.
- **The CSC row-index arrays** (`:1246`, `:1374`). Bounded by pixel count; 2^31 pixels is a 46341x46341 acquisition. Widening them would double the largest array in the output store for no benefit.
- **A `RangeIndex` var index.** An earlier note suggested this was "~0 cost". It is not: anndata coerces integer indices to strings *unconditionally* (`aligned_df.py:93-98` -- the integer clause sits outside the settings guard), so it buys ~3% peak at 1e7 and is 13-19% *worse* at 1e5-1e6. It would also change every var index value on disk and break two real Ousia call sites silently -- `_find_tx_table_key()` selects tables by whether `var_names[0]` starts with `"mz_"`, and `update_table_mass_axis()` relies on `float(var_names[0])` raising.

## Tests

34 new tests. The overflow round-trip fails against the previous code with exactly the corruption above -- I verified by reintroducing the hardcoded `int32` and watching 4 tests fail. Also pins that ordinary column counts still take the `int32` branch, that `indptr` and `indices` are keyed on different quantities, and that the vectorised index builds match the old expressions exactly at chunk boundaries.

`pytest`: 675 passed, 11 skipped. `black`, `isort`, `flake8`, `mypy`, `bandit`, `pydocstyle` clean via pre-commit.

## Related, not bundled

`_estimate_output_size_gb` (`streaming_converter.py:129-133`) estimates the bin count as `(max_mass - min_mass) / 0.01` instead of using the already-populated `len(self._common_mass_axis)`, so the CSR-vs-CSC routing decision can be made on a number that is wrong by orders of magnitude. That is a real bug and it is what makes the buggy CSR path reachable on defaults -- but it changes routing for real datasets, which does not belong in a patch whose selling point is byte-identical output.
