### PR TITLE
fix(streaming): route on the real bin count, not a guessed one

### DIFF
--- a/tests/unit/converters/test_routing_estimate.py
+++ b/tests/unit/converters/test_routing_estimate.py
@@ -1,0 +1,182 @@
+# tests/unit/converters/test_routing_estimate.py
+"""Tests that CSR-vs-CSC routing is decided on the real bin count.
+
+``_estimate_output_size_gb`` scores a dataset as
+``n_pixels * n_mz_bins * 4`` and ``_should_use_pcs`` compares that against
+``PCS_SIZE_THRESHOLD_GB``. The resampling branch already resolved the real
+bin count (issue #87), but the raw-axis branch still guessed it from
+``(max_mass - min_mass) / 0.01`` -- a 10 mDa spacing the data need not have.
+
+That guess is wrong in both directions. A continuous file carrying 4,000
+points over 250-1200 m/z was scored as though it had 95,000, inflating it
+24x; a processed file whose spectra share no m/z values was scored far too
+low, which routed the very largest datasets to the method that holds the
+most in memory.
+
+``convert()`` runs ``_initialize_conversion()`` before it asks which method
+to use, so the axis is already built when the gate is evaluated and there is
+nothing to estimate. These tests pin that the built axis is preferred, and
+that the old heuristics still apply when it is not available -- which is the
+case when the estimator is called directly, as the older tests in
+``test_streaming_converter.py`` do.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata.streaming_converter import (
+    StreamingSpatialDataConverter,
+)
+
+THRESHOLD = StreamingSpatialDataConverter.PCS_SIZE_THRESHOLD_GB
+
+
+class _Meta:
+    def __init__(self, dimensions, mass_range):
+        self.dimensions = dimensions
+        self.mass_range = mass_range
+        self.n_spectra = dimensions[0] * dimensions[1] * dimensions[2]
+        self.pixel_size = (20.0, 20.0)
+        self.estimated_memory_gb = 1.0
+        self.coordinate_bounds = (0, dimensions[0], 0, dimensions[1])
+        self.is_3d = dimensions[2] > 1
+        self.has_mass_axis = True
+        self.source_path = "mock"
+
+
+class _Reader:
+    def __init__(self, dimensions, mass_range):
+        self._meta = _Meta(dimensions, mass_range)
+
+    def get_essential_metadata(self):
+        return self._meta
+
+
+def _converter(
+    dimensions: Tuple[int, int, int],
+    mass_range: Tuple[float, float] = (250.0, 1200.0),
+    axis: Optional[np.ndarray] = None,
+    resampling_config=None,
+):
+    """Build a converter, optionally with the mass axis already resolved."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        conv = StreamingSpatialDataConverter(
+            reader=_Reader(dimensions, mass_range),
+            output_path=Path(tmpdir) / "out.zarr",
+            use_csc="auto",
+            resampling_config=resampling_config,
+        )
+    conv._common_mass_axis = axis
+    return conv
+
+
+class TestPrefersTheBuiltAxis:
+    """When the axis exists, its length is what counts."""
+
+    def test_uses_real_axis_length(self):
+        n_pixels = 10_000
+        axis = np.linspace(250.0, 1200.0, 4_000)
+        conv = _converter((100, 100, 1), axis=axis)
+
+        expected = n_pixels * 4_000 * 4 / (1024**3)
+        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
+
+    def test_real_axis_beats_the_raw_heuristic(self):
+        """The heuristic would say 95,000 bins; the axis says 4,000."""
+        axis = np.linspace(250.0, 1200.0, 4_000)
+        conv = _converter((100, 100, 1), axis=axis)
+        with_axis = conv._estimate_output_size_gb()
+
+        conv._common_mass_axis = None
+        without_axis = conv._estimate_output_size_gb()
+
+        # (1200 - 250) / 0.01 = 95,000, i.e. 23.75x the real count.
+        assert without_axis == pytest.approx(with_axis * 95_000 / 4_000, rel=1e-6)
+
+    def test_real_axis_beats_the_resampling_plan_too(self):
+        """A built axis is authoritative even when resampling is configured."""
+        axis = np.linspace(250.0, 1200.0, 1_000)
+        conv = _converter(
+            (100, 100, 1),
+            axis=axis,
+            resampling_config={"method": "nearest_neighbor", "target_bins": 500_000},
+        )
+        expected = 10_000 * 1_000 * 4 / (1024**3)
+        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
+
+
+class TestFallbacksStillApply:
+    """Without a built axis, the previous behaviour is unchanged."""
+
+    def test_raw_heuristic_when_no_axis_and_no_resampling(self):
+        conv = _converter((100, 100, 1), mass_range=(250.0, 1200.0), axis=None)
+        expected = 10_000 * 95_000 * 4 / (1024**3)
+        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
+
+    def test_resampling_plan_when_no_axis(self):
+        conv = _converter(
+            (50, 50, 1),
+            mass_range=(100.0, 1000.0),
+            axis=None,
+            resampling_config={"method": "nearest_neighbor", "target_bins": 5_000},
+        )
+        expected = 2_500 * 5_000 * 4 / (1024**3)
+        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
+
+
+class TestRoutingDecision:
+    """The estimate exists to pick a method, so pin the decision itself."""
+
+    def test_narrow_real_axis_routes_to_coo(self):
+        """Was PCS on an estimate inflated 24x by the 10 mDa assumption."""
+        axis = np.linspace(250.0, 1200.0, 4_000)
+        conv = _converter((1000, 600, 1), axis=axis)
+
+        assert conv._estimate_output_size_gb() < THRESHOLD
+        assert conv._should_use_pcs() is False
+
+        # Same dataset under the old rule would have been sent to PCS.
+        conv._common_mass_axis = None
+        assert conv._estimate_output_size_gb() > THRESHOLD
+
+    def test_wide_real_axis_routes_to_pcs(self):
+        """Was COO despite being genuinely large."""
+        axis = np.linspace(250.0, 1200.0, 200_000)
+        conv = _converter((250, 200, 1), axis=axis)
+
+        assert conv._estimate_output_size_gb() > THRESHOLD
+        assert conv._should_use_pcs() is True
+
+        # The old rule scored this below the threshold.
+        conv._common_mass_axis = None
+        assert conv._estimate_output_size_gb() < THRESHOLD
+
+    def test_explicit_use_csc_still_wins(self):
+        """The estimate is only consulted in auto mode."""
+        axis = np.linspace(250.0, 1200.0, 10)
+        conv = _converter((10, 10, 1), axis=axis)
+
+        conv._use_csc = True
+        assert conv._should_use_pcs() is True
+        conv._use_csc = False
+        assert conv._should_use_pcs() is False
+
+
+class TestDegenerate:
+    """Empty and tiny axes must not raise."""
+
+    def test_empty_axis_is_zero_sized(self):
+        conv = _converter((10, 10, 1), axis=np.array([]))
+        assert conv._estimate_output_size_gb() == 0.0
+        assert conv._should_use_pcs() is False
+
+    def test_single_bin_axis(self):
+        conv = _converter((10, 10, 1), axis=np.array([500.0]))
+        expected = 100 * 1 * 4 / (1024**3)
+        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -123,10 +123,21 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         n_x, n_y, n_z = metadata.dimensions
         n_pixels = n_x * n_y * n_z
 
-        # Estimate number of m/z bins after resampling using the same
-        # resolution path the axis builder will use, so the gate against
-        # PCS_SIZE_THRESHOLD_GB sees the real bin count.
-        if self._resampling_config:
+        # Prefer the axis that was actually built. ``convert()`` runs
+        # ``_initialize_conversion()`` -- and so ``_setup_mass_axis()`` --
+        # before it asks which method to use, so by the time this gate is
+        # evaluated the real bin count is known and there is nothing to
+        # estimate. That matters most on the raw-axis path, where the
+        # fallback below assumes a 10 mDa spacing that the data need not
+        # have: a continuous file carrying 4,000 points over 250-1200 m/z
+        # was scored as though it had 95,000, and a processed file whose
+        # spectra share no m/z values was scored far too low, which routed
+        # the largest datasets to the method that holds the most in memory.
+        if self._common_mass_axis is not None:
+            n_mz_bins = len(self._common_mass_axis)
+        elif self._resampling_config:
+            # Same resolution path the axis builder will use, so the gate
+            # against PCS_SIZE_THRESHOLD_GB sees the real bin count.
             _, _, _, n_mz_bins = self._resolve_resampling_plan()
         else:
             min_mass, max_mass = metadata.mass_range


### PR DESCRIPTION
The routing bug flagged as out of scope in [PR #122](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/pull/122).

## The problem

`_estimate_output_size_gb` scores a dataset as `n_pixels * n_mz_bins * 4`, and `_should_use_pcs` compares that against `PCS_SIZE_THRESHOLD_GB` to choose between the CSR and CSC write paths.

The resampling branch already resolves the real bin count (fixed under issue #87), but the **raw-axis branch still derived it from `(max_mass - min_mass) / 0.01`** — a hardcoded 10 mDa spacing the data need not have.

There is no reason to estimate it at all. `convert()` calls `_initialize_conversion()` — and therefore `_setup_mass_axis()` — *before* it asks which method to use, so the axis is already built when the gate is evaluated. I verified that ordering directly rather than assuming it.

## Unlike the other fixes, this one changes behaviour

The guess was wrong in both directions, so correcting it moves some datasets across the threshold. Measured against the 30 GB default:

| Dataset | Old estimate | Real | Routing |
|---|---|---|---|
| Continuous, 200k points, 50,000 px | 17.7 GB | 37.3 GB | **COO → PCS** |
| Continuous, 4k points, 600,000 px | 212.3 GB | 8.9 GB | **PCS → COO** |
| Processed, shared grid, 200k bins | 67.1 GB | 149.0 GB | PCS (unchanged) |
| Processed, all-distinct 50M bins | 67.1 GB | 37,253 GB | PCS (unchanged) |

The first was a genuinely large dataset being sent to the method that holds the most in memory. The second was inflated 24x by assuming a spacing the file did not have.

The worst case was processed-mode files whose spectra share no m/z values: those score far too low under the old rule, so the largest datasets that exist were being routed *away* from the memory-efficient path.

## Something to be aware of

Because the old estimate ran high on narrow continuous axes, it sent some datasets to PCS that will now use COO. That is the accurate decision given the threshold — but if 30 GB turns out to be miscalibrated for the COO path, this is where it will surface. The fix for that is to calibrate the threshold, not to restore an estimate that was wrong. Flagging it because it is the one way this change could bite.

## Compatibility

Output is unaffected: this picks which of two write paths runs, and both produce equivalent stores. The existing tests in `test_streaming_converter.py` call the estimator directly without initializing, so they take the fallback path and are unchanged.

## Tests

10 new tests covering: the built axis being preferred over both heuristics; both fallbacks still applying when it is absent; the routing decision itself flipping in each direction; explicit `use_csc` still overriding; and empty/single-bin axes. 7 of the 10 fail against the previous code — I verified by reverting the change — and the 3 that pass are exactly the fallback tests, which should be unaffected.

`pytest`: 651 passed, 11 skipped. `black`, `isort`, `flake8`, `mypy`, `bandit`, `pydocstyle` clean via pre-commit.
