### PR TITLE
fix(resampling): stop dropping negative bins, and correct the docs

### DIFF
--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -85,11 +85,21 @@ default. This table is the actual observed behaviour of that chain:
 | timsTOF, profile high-density | timsTOF | `nearest_neighbor` | `reflector_tof` |
 | Rapiflex, profile | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
 | Bruker MALDI-TOF | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
-| Orbitrap, centroid | Orbitrap | `nearest_neighbor` | `orbitrap` |
-| FT-ICR, centroid | FT-ICR | `nearest_neighbor` | `fticr` |
 | unknown vendor, profile high-density | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
 | unknown, centroid | ImzML Centroid | `nearest_neighbor` | `reflector_tof` |
 | no usable metadata | Unknown (default) | `nearest_neighbor` | `constant` |
+
+!!! warning "The Orbitrap and FT-ICR detectors cannot currently fire"
+    Both match on an `instrument_type` of `"Orbitrap"` or `"FT-ICR"`, but no
+    reader populates that key: the only place it is set is the Rapiflex reader,
+    which hardcodes `"MALDI-TOF"`. Neither the imzML nor the Bruker `.d`
+    metadata extractor emits it at all.
+
+    So Orbitrap and FT-ICR data does **not** get the `orbitrap` or `fticr`
+    axis automatically -- it falls through to the generic centroid or default
+    row above and gets `reflector_tof` or `constant`. Set
+    `--mass-axis-type orbitrap` or `--mass-axis-type fticr` explicitly if you
+    want the matching physics.
 
 !!! note "`tic_preserving` is selected for profile MALDI-TOF, not for high resolution"
     It is easy to assume the high-resolution analysers get the more elaborate
@@ -99,6 +109,23 @@ default. This table is the actual observed behaviour of that chain:
     `nearest_neighbor`, which is the correct choice for discrete peaks. If you
     have *profile* Orbitrap or FT-ICR data, set
     `--resample-method tic_preserving` yourself.
+
+!!! danger "Do not combine `tic_preserving` with a non-uniform axis type"
+    `tic_preserving` interpolates onto the target axis and then applies a
+    single scaling factor to the whole spectrum. A single factor cannot
+    account for bin widths that vary across the mass range, so pairing it with
+    `linear_tof`, `reflector_tof`, `orbitrap` or `fticr` suppresses high-m/z
+    ions relative to low-m/z ones. Measured across 300-1100 m/z, two ions of
+    equal abundance come back with their ratio distorted by 1.9x on
+    `linear_tof`, 3.7x on `reflector_tof`, 7.0x on `orbitrap` and 13.4x on
+    `fticr`.
+
+    Auto-selection never produces these pairings -- `tic_preserving` is only
+    ever chosen alongside `constant`, which is uniform and therefore exact.
+    You have to ask for the combination with two explicit flags.
+
+    If you want a non-uniform axis, use `nearest_neighbor`, which moves each
+    peak into a single bin and is unaffected by bin width.
 
 The chosen detector, method, and axis type are all logged:
 
@@ -227,9 +254,10 @@ automatic.
 === "CLI"
 
     ```bash
-    # Method and axis type
+    # Method and axis type. nearest_neighbor is the pairing to use with a
+    # non-uniform axis -- see the warning under "Selection" above.
     thyra input.imzML output.zarr \
-        --resample-method tic_preserving \
+        --resample-method nearest_neighbor \
         --mass-axis-type orbitrap
 
     # Fixed bin count

--- a/tests/unit/converters/test_nearest_neighbor_negatives.py
+++ b/tests/unit/converters/test_nearest_neighbor_negatives.py
@@ -1,0 +1,73 @@
+# tests/unit/converters/test_nearest_neighbor_negatives.py
+"""``nearest_neighbor`` must not silently discard negative bins.
+
+``_nearest_neighbor_resample`` accumulates each source peak into its nearest
+target bin and then keeps the bins that hold something. That filter used to
+be ``accumulated > 0``, which drops a bin whose accumulated value came out
+negative -- and dropping it raises the stored total ion current above the
+input's, which is the opposite of what the method guarantees.
+
+Baseline-subtracted spectra can carry negative intensities. Every export
+examined so far filters them upstream, so this has no observed trigger in
+practice, but the invariant is cheap to hold and the failure would be silent.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    BaseSpatialDataConverter,
+)
+
+
+def _resample(axis, mzs, intensities):
+    stub = SimpleNamespace(_common_mass_axis=axis)
+    return BaseSpatialDataConverter._nearest_neighbor_resample(
+        stub, np.asarray(mzs, float), np.asarray(intensities, float)
+    )
+
+
+class TestNegativeIntensities:
+    """Negative bins are measurements, not absences."""
+
+    def test_total_is_preserved_with_negatives(self):
+        axis = np.linspace(250.0, 1200.0, 5_000)
+        mzs = [300.0, 300.02, 500.0, 700.0]
+        intensities = [-5.0, 3.0, 10.0, -2.0]
+
+        _, values = _resample(axis, mzs, intensities)
+
+        # Dropping the negative bins gave 13.0 against an input total of 6.0.
+        assert values.sum() == pytest.approx(sum(intensities))
+
+    def test_a_wholly_negative_bin_survives(self):
+        axis = np.linspace(250.0, 1200.0, 5_000)
+        indices, values = _resample(axis, [700.0], [-4.0])
+
+        assert indices.size == 1
+        assert values[0] == pytest.approx(-4.0)
+
+    def test_bins_cancelling_to_zero_are_dropped(self):
+        """Exactly zero still means nothing to store."""
+        axis = np.linspace(250.0, 1200.0, 5_000)
+        # Both land in the same bin and cancel.
+        indices, values = _resample(axis, [700.0, 700.0001], [5.0, -5.0])
+
+        assert indices.size == 0
+        assert values.size == 0
+
+    def test_all_positive_is_unchanged(self):
+        """The ordinary case must be untouched by the fix."""
+        axis = np.linspace(250.0, 1200.0, 5_000)
+        mzs = [300.0, 500.0, 700.0]
+        intensities = [1.0, 2.0, 3.0]
+
+        indices, values = _resample(axis, mzs, intensities)
+
+        assert indices.size == 3
+        assert values.sum() == pytest.approx(6.0)
+        assert (values > 0).all()

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1082,8 +1082,13 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # bincount without minlength is fastest
         accumulated = np.bincount(indices_clipped, weights=intensities)
 
-        # Extract non-zero bins for sparse representation
-        nonzero_mask = accumulated > 0
+        # Extract non-zero bins for sparse representation. The test is
+        # ``!= 0`` rather than ``> 0`` because a bin whose accumulated value is
+        # negative is still a measurement: dropping it silently raises the
+        # stored TIC above the input's. Baseline-subtracted data can carry
+        # negative intensities, though every export seen so far filters them
+        # out upstream.
+        nonzero_mask = accumulated != 0
         nonzero_indices = np.where(nonzero_mask)[0].astype(np.int_)
         nonzero_values = accumulated[nonzero_mask]
 

--- a/thyra/resampling/strategies/nearest_neighbor.py
+++ b/thyra/resampling/strategies/nearest_neighbor.py
@@ -2,6 +2,23 @@
 
 This strategy is optimal for centroid data (e.g., from timsTOF
 instruments) where each peak represents a discrete mass value.
+
+Not to be confused with the converters' ``_nearest_neighbor_resample``
+(``thyra/converters/spatialdata/base_spatialdata_converter.py``), which is
+what ``ResamplingMethod.NEAREST_NEIGHBOR`` actually selects during a
+conversion. The two share a name and do opposite things with intensity:
+
+- This class INTERPOLATES. Each target point takes the intensity of the
+  nearest source point, so one source peak is replicated across every
+  target point closer to it than to any other. Summed intensity therefore
+  scales with how densely the target axis is laid out, and is not
+  preserved. That is the defining behaviour of nearest-neighbour
+  interpolation, not a defect -- but it means this class is the wrong tool
+  if you care about total ion current.
+- The converter's version BINS. Each source peak is accumulated into
+  exactly one target bin, so summed intensity is preserved exactly.
+
+If you want the conversion pipeline's behaviour, use the converter.
 """
 
 from typing import Any
@@ -23,6 +40,10 @@ class NearestNeighborStrategy(ResamplingStrategy):
         For each target m/z value, finds the nearest original m/z value
         and assigns its intensity. This preserves the discrete nature
         of centroid data.
+
+        Does NOT preserve total ion current -- a source peak is repeated
+        at every target point nearest to it, so the sum grows with the
+        target axis density. See the module docstring.
 
         Parameters
         ----------

--- a/thyra/resampling/types.py
+++ b/thyra/resampling/types.py
@@ -70,7 +70,13 @@ class MassAxis:
         return np.diff(self.mz_values)
 
     def resolution_at(self, mz: float) -> float:
-        """Calculate resolution at given m/z."""
+        """Return ``mz`` divided by the local bin width.
+
+        This is a property of the AXIS, not of the data on it. A finely
+        spaced axis reports a large number here whether or not the spectra
+        stored on it resolve anything at that scale, so it must not be
+        reported to users as the acquisition's resolving power.
+        """
         idx = int(np.searchsorted(self.mz_values, mz))
         if idx > 0 and idx < len(self.mz_values):
             delta_mz = float(self.mz_values[idx] - self.mz_values[idx - 1])
@@ -91,8 +97,11 @@ class ResamplingConfig:
         axis_type: Mass axis spacing model.  ``None`` auto-detects from
             the instrument metadata.
         target_bins: Number of bins in the resampled axis.  ``None``
-            lets the resampler choose a bin count that preserves the
-            native resolution.
+            derives the count from ``mass_width_da`` at ``reference_mz``
+            across the mass range.  Note that this is a fixed target
+            width, not a measurement: the source spectra's own point
+            spacing is never consulted, so the resulting axis can be
+            finer or coarser than the data it will hold.
         mass_width_da: Bin width in Daltons at ``reference_mz``.
             Alternative to ``target_bins`` -- specify one or the other.
         reference_mz: Reference m/z for ``mass_width_da``.  Default


### PR DESCRIPTION
Loose ends from the scientific check of Thyra's resampling. **No change to how anything is resampled** -- the investigation's main conclusion was that the default paths are correct.

For context, measured on the real imzML in `test_data`: the Rapiflex `tic_preserving` route gives **0.00000** error on a normalised ion image, and the centroid route on `pea.imzML` loses **0 points** with TIC ratio **1.000000** and 2.5 ppm snap error. Nothing here changes either.

## One behaviour fix

`_nearest_neighbor_resample` kept bins where the accumulated value was `> 0`, silently discarding any bin that accumulated to a **negative** value. Dropping it raises the stored TIC above the input's, which is the opposite of what the method guarantees:

```
input  mz=[300.0, 300.02, 500.0, 700.0]  intensity=[-5, 3, 10, -2]   TIC = 6.0
output 2 bins summing to                                             TIC = 13.0
```

Now `!= 0`. Baseline-subtracted spectra can carry negative intensities, though every export examined filters them upstream — I found **zero** negatives in 3.5M real values across `pea` and `bellini`. So this is a real defect with no observed trigger, and the fix is one character.

## Three documentation corrections

**The Orbitrap and FT-ICR detectors cannot fire.** Both match on an `instrument_type` of `"Orbitrap"`/`"FT-ICR"`, and the only place that key is ever set is `rapiflex_reader.py:139`, which hardcodes `"MALDI-TOF"`. Neither the imzML nor the Bruker `.d` extractor emits it. `docs/resampling.md` tabulated both as live routes; that data actually falls through to the generic centroid or default row and gets `reflector_tof` or `constant`.

**The worked CLI example demonstrated a distorting pairing.** It showed `--resample-method tic_preserving --mass-axis-type orbitrap`. `tic_preserving` interpolates then applies one global scaling factor, and a single factor cannot account for bin widths that vary across the mass range. Measured across 300-1100 m/z, two equally abundant ions come back with their ratio distorted by:

| Axis type | Distortion |
|---|---|
| `constant` | 1.0x (exact) |
| `linear_tof` | 1.9x |
| `reflector_tof` | 3.7x |
| `orbitrap` | 7.0x |
| `fticr` | 13.4x |

Auto-selection never produces these pairings — `tic_preserving` is only ever chosen alongside the uniform `constant` axis — so it takes two deliberate flags to reach. The example now uses `nearest_neighbor`, which moves each peak into a single bin and is unaffected by bin width.

**Two docstrings claimed things that are not true.** `ResamplingConfig.target_bins` said `None` "preserves the native resolution"; it derives the count from a fixed target width and never consults the source at all. `MassAxis.resolution_at` called m/z over bin width "resolution"; that is a property of the axis, not the data, and on a fine axis it reports a resolving power the spectra do not have.

## Deliberately not changed

`NearestNeighborStrategy` (the public strategy class) shares a name with the converters' `_nearest_neighbor_resample` and behaves oppositely — it interpolates, replicating one source peak across every nearer target point, so its summed intensity scales with axis density (measured 6.39x on real data at an 8.3x upsample), while the converter's version bins and preserves the sum exactly.

An earlier pass called this a public-API bug. On reading it, it isn't: that is precisely what nearest-neighbour *interpolation* means, it is what the docstring describes, and three existing tests explicitly pin the replication. Changing it would be a behaviour change to public API based on inference about intent. The actual defect is that the name collision was undocumented, so both docstrings now spell out the difference.

## Tests

4 new tests. The two negative-intensity ones fail against the previous code — verified by reverting — and the two controls (all-positive, and bins cancelling to exactly zero) correctly stay green either way.

`pytest`: 1005 passed, 11 skipped. `mkdocs build --strict` clean. All pre-commit hooks clean.

## Still open, and genuinely not mine to settle

Two questions for a mass spectrometrist, unchanged by this PR:

1. **Is a stored profile intensity a per-sample ion count or a per-Da density?** This decides whether `tic_preserving`'s operator is right at all.
2. **Do your users' profile files have >5,000 points/spectrum with gappy m/z?** `_tic_preserving_resample` interpolates across empty regions with no gap tolerance — on `bellini` I measured 91.7% of output TIC landing in unmeasured m/z regions versus 49.8% for `nearest_neighbor`. But neither real file you have triggers it: `bellini` has 2,236 points/spectrum and `pea` 4,495, both below the 5,000 threshold that selects `tic_preserving`.
