### PR TITLE
fix(resampling): stop handing unknown modalities MALDI-TOF resampling

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -111,11 +111,14 @@ chooses an appropriate method and bin count.
     - **`nearest_neighbor`** -- Each target bin takes the nearest original m/z
       value. Correct for **centroid** data, where peaks are discrete masses.
     - **`tic_preserving`** -- Linear interpolation, rescaled so the total ion
-      current is unchanged. Correct for **profile** data, and whenever
-      quantitation must survive rebinning.
-    - **`auto`** -- Picks `tic_preserving` for profile MALDI-TOF data and
-      `nearest_neighbor` for everything else, including Orbitrap and FT-ICR
-      (which are normally centroided). See
+      current is unchanged. Correct for **profile** data on a target axis
+      whose bin widths scale the same way the source points are spaced --
+      pair it only with `constant` unless you know otherwise.
+    - **`auto`** -- Picks `tic_preserving` only for Bruker flexImaging /
+      Rapiflex data, whose source grid is uniform in m/z, and
+      `nearest_neighbor` for everything else -- including profile data from
+      an instrument Thyra cannot identify, because the interpolating method
+      is only exact when the two axis laws match. See
       [Resampling](resampling.md#which-detector-wins) for the full decision
       table.
 

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -66,8 +66,14 @@ axis), the **axis type** (how bin widths scale with m/z), and the **bin count**.
 - whether there is a shared mass axis (continuous) or not (processed)
 - spectrum type -- `centroid spectrum` (`MS:1000127`) or `profile spectrum` (`MS:1000128`)
 - instrument name, instrument type, and manufacturer
-- average peaks per spectrum; above **5000** the data is treated as high-density profile
+- average peaks per spectrum; above **5000** the data is recorded as high-density profile
 - format flags for Rapiflex and timsTOF
+
+Peak density is reported but does **not** select a method or an axis type. It
+describes how finely the spectra were sampled, not what acquired them, and a
+dense profile spectrum can come from a MALDI-TOF, a TOF-SIMS, or an Orbitrap
+run in profile mode. SCiLS Lab does not guess modality either -- its importer
+takes it as an argument (`--project TIMSTOF|TOF|FT`).
 
 The timsTOF flag is a case-insensitive substring match on the instrument name,
 because Bruker names the family many ways (`timsTOF fleX MALDI-2`,
@@ -85,9 +91,23 @@ default. This table is the actual observed behaviour of that chain:
 | timsTOF, profile high-density | timsTOF | `nearest_neighbor` | `reflector_tof` |
 | Rapiflex, profile | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
 | Bruker MALDI-TOF | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
-| unknown vendor, profile high-density | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
+| unknown vendor, profile (any density) | Unknown (default) | `nearest_neighbor` | `constant` |
 | unknown, centroid | ImzML Centroid | `nearest_neighbor` | `reflector_tof` |
 | no usable metadata | Unknown (default) | `nearest_neighbor` | `constant` |
+
+!!! info "`tic_preserving` is gated on the source and target axis laws matching"
+    A detector may only ask for `tic_preserving` if it knows the spacing law
+    of the grid the spectra *arrive* on, and that law is the one it is asking
+    the target axis to use. Only the Rapiflex route qualifies:
+    `RapiflexReader` lays every spectrum out with `np.linspace`, so the source
+    is uniform in m/z, and the axis it requests is `constant` -- the same law.
+
+    Anything else is refused and gets `nearest_neighbor` instead, with a log
+    line saying so. This is the rule SCiLS Lab applies: TIC-preserving
+    resampling "if all axis types are identical", otherwise interpolation
+    (2026b User Guide, p.80). It is also exactly when Thyra's
+    interpolate-then-rescale operator is exact -- see the `!!! danger` box
+    below for what it costs off the diagonal.
 
 !!! warning "The Orbitrap and FT-ICR detectors cannot currently fire"
     Both match on an `instrument_type` of `"Orbitrap"` or `"FT-ICR"`, but no
@@ -120,9 +140,11 @@ default. This table is the actual observed behaviour of that chain:
     `linear_tof`, 3.7x on `reflector_tof`, 7.0x on `orbitrap` and 13.4x on
     `fticr`.
 
-    Auto-selection never produces these pairings -- `tic_preserving` is only
-    ever chosen alongside `constant`, which is uniform and therefore exact.
-    You have to ask for the combination with two explicit flags.
+    Auto-selection cannot produce these pairings. `tic_preserving` is only
+    ever chosen alongside `constant`, and only on a source grid that is
+    itself uniform in m/z, which is what makes it exact; the detector chain
+    enforces that. You have to ask for the combination with two explicit
+    flags, and Thyra takes you at your word.
 
     If you want a non-uniform axis, use `nearest_neighbor`, which moves each
     peak into a single bin and is unaffected by bin width.

--- a/tests/unit/resampling/test_decision_tree.py
+++ b/tests/unit/resampling/test_decision_tree.py
@@ -11,6 +11,7 @@ from thyra.resampling.instrument_detectors import (
     CentroidImzMLDetector,
     DefaultDetector,
     FTICRDetector,
+    InstrumentDetector,
     InstrumentDetectorChain,
     OrbitrapDetector,
     RapiflexDetector,
@@ -94,8 +95,14 @@ class TestResamplingDecisionTree:
         method = self.tree.select_strategy(metadata)
         assert method == ResamplingMethod.NEAREST_NEIGHBOR
 
-    def test_profile_spectrum_with_high_density_uses_tic_preserving(self):
-        """Test that profile spectrum with high peak density uses TIC preserving."""
+    def test_profile_spectrum_with_high_density_uses_nearest_neighbor(self):
+        """High-density profile data of unknown provenance must not get MALDI-TOF logic.
+
+        Peak density is not a modality. This metadata says only "profile, and
+        densely sampled" -- it could be MALDI-TOF, TOF-SIMS, or a profile
+        Orbitrap acquisition. ``nearest_neighbor`` bins counts and assumes
+        nothing about the axis law, so it is the safe answer for all of them.
+        """
         metadata = {
             "essential_metadata": {
                 "spectrum_type": SpectrumType.PROFILE,
@@ -104,7 +111,36 @@ class TestResamplingDecisionTree:
             }
         }
         method = self.tree.select_strategy(metadata)
-        assert method == ResamplingMethod.TIC_PRESERVING
+        assert method == ResamplingMethod.NEAREST_NEIGHBOR
+
+        # And it must not pick up the MALDI-shaped axis either.
+        assert self.tree.select_axis_type(metadata) == AxisType.CONSTANT
+
+    def test_low_density_profile_uses_nearest_neighbor(self):
+        """The same holds below the density threshold -- there is no profile route."""
+        metadata = {
+            "essential_metadata": {
+                "spectrum_type": SpectrumType.PROFILE,
+                "total_peaks": 1000,
+                "n_spectra": 1000,  # 1 peak per spectrum
+            }
+        }
+        assert self.tree.select_strategy(metadata) == ResamplingMethod.NEAREST_NEIGHBOR
+
+    def test_named_non_bruker_profile_instrument_uses_nearest_neighbor(self):
+        """A named vendor that is not Bruker MALDI-TOF gets no TIC-preserving either."""
+        metadata = {
+            "essential_metadata": {
+                "spectrum_type": SpectrumType.PROFILE,
+                "total_peaks": 10000000,
+                "n_spectra": 1000,
+            },
+            "instrument_info": {
+                "instrument_type": "TOF-SIMS",
+                "manufacturer": "IONTOF",
+            },
+        }
+        assert self.tree.select_strategy(metadata) == ResamplingMethod.NEAREST_NEIGHBOR
 
     def test_rapiflex_format_detection(self):
         """Test Rapiflex format detection."""
@@ -173,6 +209,96 @@ class TestInstrumentDetectorChain:
         assert isinstance(detector, DefaultDetector)
 
 
+class _TICPreservingDetector(InstrumentDetector):
+    """Detector that asks for TIC_PRESERVING, for exercising the chain's gate.
+
+    ``source_law`` is what it claims about the grid its data arrives on;
+    ``axis`` is the target axis it asks for.
+    """
+
+    def __init__(self, source_law, axis=AxisType.CONSTANT):
+        self._source_law = source_law
+        self._axis = axis
+
+    @property
+    def name(self) -> str:
+        return "Test TIC-preserving"
+
+    def matches(self, characteristics: DataCharacteristics) -> bool:
+        return True
+
+    def get_resampling_method(self) -> ResamplingMethod:
+        return ResamplingMethod.TIC_PRESERVING
+
+    def get_axis_type(self) -> AxisType:
+        return self._axis
+
+    @property
+    def source_grid_law(self):
+        return self._source_law
+
+
+class TestTICPreservingGate:
+    """The SCiLS "identical axis types" gate on TIC-preserving resampling.
+
+    SCiLS Lab applies TIC-preserving resampling only when the axis types
+    being combined are identical, and interpolates otherwise (2026b User
+    Guide, p.80). That is also the condition under which Thyra's
+    interpolate-then-rescale operator is exact, so the chain enforces it.
+    """
+
+    def _method_for(self, detector):
+        chain = InstrumentDetectorChain([detector])
+        return chain.get_resampling_method(DataCharacteristics())
+
+    def test_matching_laws_keep_tic_preserving(self):
+        detector = _TICPreservingDetector(AxisType.CONSTANT, AxisType.CONSTANT)
+        assert self._method_for(detector) == ResamplingMethod.TIC_PRESERVING
+
+    @pytest.mark.parametrize(
+        "source_law",
+        [
+            AxisType.LINEAR_TOF,
+            AxisType.REFLECTOR_TOF,
+            AxisType.ORBITRAP,
+            AxisType.FTICR,
+        ],
+    )
+    def test_mismatched_laws_fall_back_to_nearest_neighbor(self, source_law):
+        """Off the diagonal the operator distorts peak ratios, so it is refused."""
+        detector = _TICPreservingDetector(source_law, AxisType.CONSTANT)
+        assert self._method_for(detector) == ResamplingMethod.NEAREST_NEIGHBOR
+
+    def test_unknown_source_law_falls_back_to_nearest_neighbor(self):
+        """Not knowing the acquisition is not a licence to assume it matches."""
+        detector = _TICPreservingDetector(None, AxisType.CONSTANT)
+        assert self._method_for(detector) == ResamplingMethod.NEAREST_NEIGHBOR
+
+    def test_gate_leaves_the_axis_type_alone(self):
+        """The gate changes the method only; the axis type is a separate answer."""
+        detector = _TICPreservingDetector(None, AxisType.CONSTANT)
+        chain = InstrumentDetectorChain([detector])
+        assert chain.get_axis_type(DataCharacteristics()) == AxisType.CONSTANT
+
+    def test_gate_does_not_touch_nearest_neighbor_detectors(self):
+        """A detector that never asks for TIC_PRESERVING is unaffected."""
+        chain = InstrumentDetectorChain([DefaultDetector()])
+        assert (
+            chain.get_resampling_method(DataCharacteristics())
+            == ResamplingMethod.NEAREST_NEIGHBOR
+        )
+
+    def test_every_shipped_detector_clears_the_gate(self):
+        """No detector in the default chain may ask for an unbacked TIC_PRESERVING."""
+        for detector in InstrumentDetectorChain().detectors:
+            if detector.get_resampling_method() is not ResamplingMethod.TIC_PRESERVING:
+                continue
+            assert detector.source_grid_law == detector.get_axis_type(), (
+                f"{detector.name} asks for TIC_PRESERVING but its source grid "
+                "law does not match the axis it requests"
+            )
+
+
 class TestInstrumentDetectors:
     """Test individual instrument detectors."""
 
@@ -208,16 +334,23 @@ class TestInstrumentDetectors:
         )
         assert detector.matches(chars)
 
-        # Should match high-density profile data
+        # Must NOT match on peak density alone -- that is not a modality.
         chars = DataCharacteristics(
             spectrum_type=SpectrumType.PROFILE,
             total_peaks=10000000,
             n_spectra=1000,
         )
-        assert detector.matches(chars)
+        assert chars.is_high_density_profile
+        assert not detector.matches(chars)
 
         assert detector.get_resampling_method() == ResamplingMethod.TIC_PRESERVING
         assert detector.get_axis_type() == AxisType.CONSTANT
+
+        # The source grid law it declares is what lets TIC_PRESERVING through
+        # the chain's gate: RapiflexReader lays spectra out with np.linspace,
+        # so source law == target law == CONSTANT.
+        assert detector.source_grid_law == AxisType.CONSTANT
+        assert detector.source_grid_law == detector.get_axis_type()
 
     def test_centroid_imzml_detector(self):
         """Test CentroidImzML detector matching."""

--- a/thyra/resampling/data_characteristics.py
+++ b/thyra/resampling/data_characteristics.py
@@ -66,6 +66,14 @@ class DataCharacteristics:
 
         Profile data typically has >5000 points per spectrum,
         indicating continuous signal rather than centroid peaks.
+
+        This says how densely the spectra are sampled. It says nothing about
+        which instrument produced them, so it **must not be used to pick a
+        resampling strategy or an axis type**: those encode assumptions about
+        the acquisition's physics. ``RapiflexDetector`` used to match on this
+        alone, which handed MALDI-TOF treatment to any dense profile data --
+        TOF-SIMS, Orbitrap, anything -- with no check that the data was
+        MALDI-TOF at all.
         """
         avg = self.avg_peaks_per_spectrum
         return (
@@ -76,7 +84,12 @@ class DataCharacteristics:
 
     @property
     def is_maldi_tof(self) -> bool:
-        """Check if this is MALDI-TOF data."""
+        """Check if this is MALDI-TOF data.
+
+        Carries the same caveat as :attr:`is_high_density_profile`, which its
+        last clause consults: density plus a vendor name is not a modality.
+        No detector calls this.
+        """
         return (
             self.is_rapiflex_format
             or self.instrument_type == "MALDI-TOF"

--- a/thyra/resampling/instrument_detectors.py
+++ b/thyra/resampling/instrument_detectors.py
@@ -52,6 +52,30 @@ class InstrumentDetector(ABC):
         """Get the recommended mass axis type for this instrument."""
         pass
 
+    @property
+    def source_grid_law(self) -> Optional[AxisType]:
+        """Spacing law of the *source* m/z grid, when it is known.
+
+        ``tic_preserving`` interpolates onto the target axis and then applies
+        one global scaling factor. That composite operator is exact only when
+        the source grid follows the same spacing law as the target axis; off
+        the diagonal it distorts the ratio between two peaks by exactly
+        ``(m_hi / m_lo) ** (p_target - p_source)``, with ``p`` = 0, 0.5, 1,
+        1.5, 2 for constant / linear_tof / reflector_tof / orbitrap / fticr.
+
+        SCiLS Lab gates its own TIC-preserving resampling on the same
+        condition -- "If all axis types are identical, a TIC preserving
+        resampling is applied, otherwise a linear interpolation is performed"
+        (SCiLS Lab 2026b User Guide, p.80).
+
+        ``None`` -- the default -- means Thyra does not know the source law.
+        That is the honest answer for every detector that matches on
+        something other than a vendor format whose grid Thyra itself lays
+        out, and :class:`InstrumentDetectorChain` refuses ``TIC_PRESERVING``
+        for such a detector.
+        """
+        return None
+
 
 class CentroidImzMLDetector(InstrumentDetector):
     """Detector for centroid ImzML data.
@@ -91,23 +115,33 @@ class RapiflexDetector(InstrumentDetector):
         return "Rapiflex MALDI-TOF"
 
     def matches(self, characteristics: DataCharacteristics) -> bool:
-        """Check if data matches Rapiflex, Bruker MALDI-TOF, or high-density profile."""
+        """Check if data came from Bruker flexImaging/Rapiflex.
+
+        Both branches below are written by one producer, the Rapiflex
+        metadata extractor, so a match here means the spectra arrive on the
+        uniform-in-m/z grid ``RapiflexReader`` builds.
+
+        Peak density is deliberately *not* consulted. It used to be: any
+        profile data averaging more than
+        ``Thresholds.PROFILE_PEAK_DENSITY`` points per spectrum was handed
+        MALDI-TOF treatment regardless of what instrument produced it. That
+        made the detector modality-blind -- a dense TOF-SIMS or Orbitrap
+        profile acquisition would have been resampled by MALDI-TOF logic
+        onto a MALDI-shaped axis, silently. SCiLS Lab does not guess
+        modality either; its importer takes ``--project TIMSTOF|TOF|FT`` as
+        an argument (2026b User Guide, p.81). Unknown-provenance profile
+        data now falls through to :class:`DefaultDetector`, which bins
+        counts rather than interpolating and so is safe for any modality.
+        """
         # Direct Rapiflex format detection
         if characteristics.is_rapiflex_format:
             return True
 
         # Bruker MALDI-TOF detection
-        if (
+        return (
             characteristics.instrument_type == "MALDI-TOF"
             and characteristics.manufacturer == "Bruker"
-        ):
-            return True
-
-        # Profile data with high peak density (likely MALDI-TOF)
-        if characteristics.is_high_density_profile:
-            return True
-
-        return False
+        )
 
     def get_resampling_method(self) -> ResamplingMethod:
         """Return TIC-preserving for profile MALDI-TOF data."""
@@ -115,6 +149,19 @@ class RapiflexDetector(InstrumentDetector):
 
     def get_axis_type(self) -> AxisType:
         """Return constant axis matching SCiLS Lab convention."""
+        return AxisType.CONSTANT
+
+    @property
+    def source_grid_law(self) -> Optional[AxisType]:
+        """Report the constant law of the flexImaging source grid.
+
+        ``RapiflexReader.get_common_mass_axis`` lays every spectrum out with
+        ``np.linspace(mass_start, mass_end, n_points)``, so the source
+        spacing is constant in m/z -- the same law as the ``constant`` target
+        axis :meth:`get_axis_type` asks for. Source law equal to target law
+        is what makes ``tic_preserving`` exact here, and it is the reason
+        this is the only route on which the chain permits it.
+        """
         return AxisType.CONSTANT
 
 
@@ -273,6 +320,9 @@ class InstrumentDetectorChain:
     ) -> ResamplingMethod:
         """Get resampling method for the detected instrument.
 
+        ``TIC_PRESERVING`` additionally has to clear the matching-axis-law
+        gate; see :meth:`_gate_tic_preserving`.
+
         Args:
             characteristics: Data characteristics to match
 
@@ -280,9 +330,50 @@ class InstrumentDetectorChain:
             Recommended resampling method for the instrument
         """
         detector = self.detect(characteristics)
-        method = detector.get_resampling_method()
+        method = self._gate_tic_preserving(detector)
         logger.info(f"Selected resampling method: {method.name}")
         return method
+
+    @staticmethod
+    def _gate_tic_preserving(detector: InstrumentDetector) -> ResamplingMethod:
+        """Allow ``TIC_PRESERVING`` only when source and target laws agree.
+
+        SCiLS Lab applies TIC-preserving resampling to profile data only
+        when all the mass axes being combined are of the same type, and
+        linear interpolation otherwise (2026b User Guide, p.80). That is
+        also precisely the condition under which Thyra's operator --
+        interpolate, then rescale by one global factor -- is exact. See
+        :attr:`InstrumentDetector.source_grid_law` for the error off the
+        diagonal.
+
+        A detector that has not declared its source grid law does not clear
+        the gate. Auto-selection therefore cannot reach the interpolating
+        path on data whose acquisition Thyra has not actually identified.
+
+        Args:
+            detector: The detector that matched.
+
+        Returns:
+            The detector's method, or ``NEAREST_NEIGHBOR`` in its place.
+        """
+        method = detector.get_resampling_method()
+        if method is not ResamplingMethod.TIC_PRESERVING:
+            return method
+
+        axis_type = detector.get_axis_type()
+        source_law = detector.source_grid_law
+        if source_law is axis_type:
+            return method
+
+        logger.info(
+            "%s asks for TIC_PRESERVING onto a %s axis, but the source grid "
+            "law is %s. TIC-preserving resampling is exact only when the two "
+            "match, so NEAREST_NEIGHBOR is used instead.",
+            detector.name,
+            axis_type.name,
+            "unknown" if source_law is None else source_law.name,
+        )
+        return ResamplingMethod.NEAREST_NEIGHBOR
 
     def get_axis_type(self, characteristics: DataCharacteristics) -> AxisType:
         """Get axis type for the detected instrument.


### PR DESCRIPTION
Closes the modality leak in auto-selection, and makes the condition that
licenses `tic_preserving` explicit. Handout items 1 and 2 — one decision, so
one PR.

## Does this change stored values?

**Yes, for one input shape:** profile data of unknown provenance averaging
more than 5,000 points per spectrum. Those datasets were getting
`tic_preserving` + `constant`; they now get `nearest_neighbor` + `constant`.

**No, for everything else.** All five local test datasets already route to
`nearest_neighbor` and still do. The Rapiflex path is untouched and still
measures exact (0.00000 ion-image error, TIC 1.000000). The centroid path is
untouched. Explicit `--resample-method tic_preserving` is still honoured.

## The bug

`RapiflexDetector.matches` had a third branch:

```python
# Profile data with high peak density (likely MALDI-TOF)
if characteristics.is_high_density_profile:
    return True
```

`is_high_density_profile` is "declares profile, and averages more than 5,000
points per spectrum". No vendor check, no instrument check. Anything dense and
profile was handed `tic_preserving` + `constant` — a strategy and an axis
derived from MALDI-TOF assumptions.

`bellini.imzML`, one of this project's own test files, is **TOF-SIMS** (IONTOF
SurfaceLab) — a different modality entirely, one SCiLS does not even ingest. It
escapes the leak today only because it averages 2,222 points per spectrum,
under the 5,000 threshold. A denser SIMS acquisition, or profile-mode Orbitrap
data, would have been resampled by MALDI-TOF logic onto a MALDI-shaped axis,
silently.

SCiLS does not guess modality. Its own command-line importer takes it as an
argument (2026b User Guide p.81): `--project TIMSTOF|TOF|FT`.

## What changed

**1. The branch is gone.** Unknown-provenance profile data falls through to
`DefaultDetector` → `nearest_neighbor`. That accumulates counts into bins,
which is correct under the extensive reading of intensity, and it is safe for
*any* modality because it makes no assumption about the axis law.

**2. The licence for `tic_preserving` is now declared, not implied.**
`InstrumentDetector` gained `source_grid_law` — the spacing law of the grid the
spectra *arrive* on, `None` when Thyra does not know. `InstrumentDetectorChain`
refuses `TIC_PRESERVING` unless that law equals the target axis law, and logs
why.

This is SCiLS's own rule (p.80):

> For centroid spectra SCiLS Lab always uses nearest neighbor resampling. […]
> In the case of profile data, the resampling method depends on whether
> multiple mass axis types are combined. If all axis types are identical, a TIC
> preserving resampling is applied, otherwise a linear interpolation is
> performed.

It is also exactly the condition under which Thyra's operator — interpolate,
then rescale by one global factor — is mathematically exact. Off the diagonal
it distorts the ratio of two peaks by `(m_hi/m_lo)^(p_target - p_source)`, with
`p` = 0, 0.5, 1, 1.5, 2 for constant / linear_tof / reflector_tof / orbitrap /
fticr. The `!!! danger` box in `docs/resampling.md` already measured that as
1.9x to 13.4x across 300–1100 m/z.

Only the Rapiflex route clears the gate: `RapiflexReader.get_common_mass_axis`
lays every spectrum out with `np.linspace(mass_start, mass_end, n_points)`, so
the source is uniform in m/z, and the axis it asks for is `constant` — the same
law. Nothing else in the chain asks for `TIC_PRESERVING`, so **the gate changes
no shipped routing today**. It is what stops the leak being reintroduced, and
it means auto-selection can no longer reach the interpolating path on data
Thyra has not actually identified.

It also dissolves an ordering trap for the next item in this series. Fixing
`_detect_centroid_spectrum` (handout item 3) will make processed-mode profile
files report `profile` correctly for the first time — including `bellini`. With
the gate in place, none of them can reach the interpolating path.

## Before/after numbers

Both operators run over 200 real pixels, onto the same 683,574-bin 5 mDa
`constant` axis the removed route would have built. This is what changes for
anyone whose data was hitting it.

### `bellini.imzML` — IONTOF TOF-SIMS, 2,222 pts/spectrum

Source point spacing: median 0.0072 Da, max 1269 Da.

| | before (`tic_preserving`) | after (`nearest_neighbor`) |
|---|---|---|
| per-pixel TIC out/in | 1.000000 | 1.000000 |
| output TIC in unmeasured m/z regions, 0.1 Da tol | 94.02% | 0.00% |
| … 0.5 Da tol | 80.60% | 0.00% |
| … 1.0 Da tol | 73.87% | 0.00% |
| non-zero bins (200 px) | 97,101,153 | 297,116 |

Whole-cube relative L1 between the two: **1.9931**. Across the eight most
intense bins, per-ion-image relative L1 runs 0.24–0.43 with Pearson r
0.53–0.78 — these are visibly different ion images, not a rounding difference.

### `pea.imzML` — 4,643 pts/spectrum, same shape

| | before | after |
|---|---|---|
| output TIC in unmeasured m/z regions, 0.5 Da tol | 3.56% (max 61.12%) | 0.00% |
| non-zero bins (200 px) | 34,867,220 | 928,444 |

Whole-cube relative L1 1.9340.

### Reading these

TIC is preserved either way — the rescale added in #112 does its job, and it is
not touched here. What changes is *where the total lands*. `np.interp` has no
gap tolerance, so it draws straight lines across the empty regions between
source points; on `bellini` most of the output total ends up at m/z values nothing was
ever measured at. Binning puts each measured count in exactly one bin and
leaves the rest empty.

## Routing, after the change

| input shape | method | axis |
|---|---|---|
| Rapiflex / flexImaging | `tic_preserving` | `constant` |
| Bruker MALDI-TOF | `tic_preserving` | `constant` |
| timsTOF | `nearest_neighbor` | `reflector_tof` |
| unknown vendor, centroid | `nearest_neighbor` | `reflector_tof` |
| unknown vendor, profile, 2,220 pts/spec | `nearest_neighbor` | `constant` |
| unknown vendor, profile, 10,000 pts/spec *(was the leak)* | `nearest_neighbor` | `constant` |
| no usable metadata | `nearest_neighbor` | `constant` |

## Tests

`tests/unit/resampling/test_decision_tree.py`:

- `test_profile_spectrum_with_high_density_uses_tic_preserving` →
  `…_uses_nearest_neighbor`, the assertion inverted. It was pinning the leak.
- `test_rapiflex_detector` now asserts the detector does **not** match on
  density alone, while `chars.is_high_density_profile` is still True — the
  property is fine, using it to pick a strategy was not.
- New: low-density profile, and a named non-Bruker profile vendor, both route
  to `nearest_neighbor`. This was a coverage hole — nothing asserted the
  negative at chain level.
- New `TestTICPreservingGate`: matching laws pass; each of the four mismatched
  laws falls back; an undeclared law falls back; the gate leaves the axis type
  alone; it does not touch `nearest_neighbor` detectors; and every detector in
  the shipped chain clears it.

`is_high_density_profile` and `is_maldi_tof` keep their tests. Both now carry a
docstring saying they describe sampling density, not modality, and must not
pick a strategy.

Full suite: **1016 passed, 11 skipped**. Both `read_lazy` contract tests pass.
`black`, `isort`, `flake8`, `mypy`, `bandit`, `pydocstyle` clean.

## Not in this PR

- Item 3 (`_detect_centroid_spectrum` reads storage mode before the declared
  accession) — must land after this, per the handout.
- Item 5 (a real, conservative intensity-splitting `tic_preserving`) — needs
  sign-off, since it changes stored values on the Rapiflex path.
- Item 6 (gap tolerance for `np.interp`) — with this gate in place nothing
  unknown reaches that code, so it is no longer urgent. Still worth having.
