### PR TITLE
fix(metadata): read the declared spectrum representation, don't infer it

### DIFF
--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -69,6 +69,14 @@ axis), the **axis type** (how bin widths scale with m/z), and the **bin count**.
 - average peaks per spectrum; above **5000** the data is recorded as high-density profile
 - format flags for Rapiflex and timsTOF
 
+Spectrum type is whatever the file **declares** -- `MS:1000127` or
+`MS:1000128` -- read from the file description first and then from the rest of
+the document. Only when a file declares neither does Thyra fall back to
+guessing centroid from processed storage mode, and it says so in a warning
+when it does. Processed and centroid are independent: processed means each
+spectrum carries its own m/z array, which says nothing about whether its peaks
+are centroided.
+
 Peak density is reported but does **not** select a method or an axis type. It
 describes how finely the spectra were sampled, not what acquired them, and a
 dense profile spectrum can come from a MALDI-TOF, a TOF-SIMS, or an Orbitrap

--- a/tests/unit/metadata/extractors/test_imzml_extractor.py
+++ b/tests/unit/metadata/extractors/test_imzml_extractor.py
@@ -1,10 +1,16 @@
 # tests/unit/metadata/extractors/test_imzml_extractor.py
+import logging
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import numpy as np
 import pytest
+from pyimzml.ImzMLParser import ImzMLParser
+from pyimzml.ImzMLWriter import ImzMLWriter
 
 from thyra.metadata.extractors.imzml_extractor import ImzMLMetadataExtractor
+from thyra.resampling.decision_tree import ResamplingDecisionTree
+from thyra.resampling.types import ResamplingMethod
 
 
 class TestImzMLMetadataExtractor:
@@ -298,3 +304,125 @@ class TestImzMLMetadataExtractor:
         assert essential.dimensions == (1, 1, 1)
         assert essential.n_spectra == 1
         assert essential.coordinate_bounds == (1, 1, 1, 1)
+
+
+def _write_imzml(directory, name, spec_type, mode="processed"):
+    """Write a two-pixel imzML declaring the given spectrum representation."""
+    path = directory / f"{name}.imzML"
+    mzs = np.linspace(100.0, 1000.0, 50)
+    intensities = np.zeros_like(mzs)
+    intensities[10] = 100.0
+    with ImzMLWriter(str(path), mode=mode, spec_type=spec_type) as writer:
+        writer.addSpectrum(mzs, intensities, (1, 1, 1))
+        writer.addSpectrum(mzs, intensities, (2, 1, 1))
+    return path
+
+
+class TestSpectrumTypeDetection:
+    """Spectrum representation comes from what the file declares.
+
+    Processed and centroid are orthogonal: ``IMS:1000031`` says each spectrum
+    carries its own m/z array, not that its peaks are centroided. The
+    detection used to assume otherwise and check storage mode *first*, so a
+    processed file declaring ``MS:1000128 profile spectrum`` was reported as
+    centroid.
+    """
+
+    def _extractor(self, params):
+        """An extractor whose parser declares exactly ``params``.
+
+        The path does not exist, so the XML accession scan can contribute
+        nothing and these tests isolate the fileDescription path.
+        """
+        parser = Mock()
+        parser.metadata.file_description.param_by_name = params
+        return ImzMLMetadataExtractor(parser, Path("/does/not/exist.imzML"))
+
+    def test_declared_profile_beats_processed_storage_mode(self):
+        """The regression: a processed file that says profile is profile."""
+        extractor = self._extractor({"profile spectrum": True, "processed": True})
+        assert extractor._detect_centroid_spectrum() == "profile spectrum"
+
+    def test_declared_centroid_is_reported(self):
+        extractor = self._extractor({"centroid spectrum": True, "processed": True})
+        assert extractor._detect_centroid_spectrum() == "centroid spectrum"
+
+    def test_declared_profile_in_continuous_mode(self):
+        extractor = self._extractor({"profile spectrum": True, "continuous": True})
+        assert extractor._detect_centroid_spectrum() == "profile spectrum"
+
+    def test_undeclared_processed_falls_back_to_the_guess(self):
+        """With nothing declared, the storage-mode guess is all there is.
+
+        It has to say so. ``caplog`` is unusable here because
+        ``setup_logging`` disables propagation on the ``thyra`` logger and
+        other tests in the session leave that state behind, so the handler is
+        attached to the module logger directly.
+        """
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+
+        module_logger = logging.getLogger("thyra.metadata.extractors.imzml_extractor")
+        handler = _Capture(level=logging.WARNING)
+        previous_level = module_logger.level
+        module_logger.addHandler(handler)
+        module_logger.setLevel(logging.WARNING)
+        try:
+            extractor = self._extractor({"processed": True})
+            assert extractor._detect_centroid_spectrum() == "centroid spectrum"
+        finally:
+            module_logger.removeHandler(handler)
+            module_logger.setLevel(previous_level)
+
+        assert any("Assuming centroid" in message for message in records)
+
+    def test_undeclared_continuous_is_unknown(self):
+        """The guess is only defensible for processed mode; otherwise say nothing."""
+        extractor = self._extractor({"continuous": True})
+        assert extractor._detect_centroid_spectrum() is None
+
+    def test_non_dict_params_declare_nothing(self):
+        """A Mock's attribute is not a declaration -- it used to read as one."""
+        extractor = self._extractor(Mock())
+        assert extractor._detect_centroid_spectrum() is None
+
+    @pytest.mark.parametrize(
+        "spec_type,expected",
+        [("profile", "profile spectrum"), ("centroid", "centroid spectrum")],
+    )
+    def test_real_processed_file_round_trip(self, tmp_path, spec_type, expected):
+        """End to end on a real file: what was written is what is read back."""
+        path = _write_imzml(tmp_path, spec_type, spec_type)
+        parser = ImzMLParser(str(path), parse_lib="ElementTree")
+        try:
+            extractor = ImzMLMetadataExtractor(parser, path)
+            assert extractor._detect_centroid_spectrum() == expected
+            assert extractor.get_essential().spectrum_type == expected
+        finally:
+            parser.m.close()
+
+    def test_profile_file_routes_to_nearest_neighbor_not_tic_preserving(self, tmp_path):
+        """A correctly-detected profile file must not reach the interpolating path.
+
+        Reporting profile honestly is only safe because unknown-provenance
+        profile data no longer reaches ``tic_preserving``.
+        """
+        path = _write_imzml(tmp_path, "profile", "profile")
+        parser = ImzMLParser(str(path), parse_lib="ElementTree")
+        try:
+            extractor = ImzMLMetadataExtractor(parser, path)
+            essential = extractor.get_essential()
+            metadata = {
+                "essential_metadata": {
+                    "spectrum_type": essential.spectrum_type,
+                    "total_peaks": essential.total_peaks,
+                    "n_spectra": essential.n_spectra,
+                }
+            }
+            tree = ResamplingDecisionTree()
+            assert tree.select_strategy(metadata) == ResamplingMethod.NEAREST_NEIGHBOR
+        finally:
+            parser.m.close()

--- a/thyra/metadata/extractors/imzml_extractor.py
+++ b/thyra/metadata/extractors/imzml_extractor.py
@@ -9,7 +9,7 @@ from numpy.typing import NDArray
 from pyimzml.ImzMLParser import ImzMLParser
 
 from ...core.base_extractor import MetadataExtractor
-from ...resampling.constants import ImzMLAccessions, SpectrumType
+from ...resampling.constants import BinaryDataType, ImzMLAccessions, SpectrumType
 from ..types import ComprehensiveMetadata, EssentialMetadata
 
 logger = logging.getLogger(__name__)
@@ -131,7 +131,7 @@ class ImzMLMetadataExtractor(MetadataExtractor):
             if param_by_name is None or not isinstance(param_by_name, dict):
                 return False
 
-            return "continuous" in param_by_name
+            return BinaryDataType.CONTINUOUS in param_by_name
         except Exception:
             return False
 
@@ -522,19 +522,27 @@ class ImzMLMetadataExtractor(MetadataExtractor):
             return None
 
     def _detect_centroid_spectrum(self) -> Optional[str]:
-        """Detect spectrum type by looking for MS:1000127 (centroid) or MS:1000128 (profile)."""
+        """Detect spectrum type by looking for MS:1000127 (centroid) or MS:1000128 (profile).
+
+        What the file *declares* wins, wherever it is written. Only when the
+        file declares nothing does Thyra guess -- see
+        :meth:`_guess_spectrum_type_from_storage_mode` for what that guess is
+        worth.
+        """
         try:
-            # Method 1: Check parser metadata first (no XML parsing needed)
-            result = self._check_parser_metadata_for_centroid()
+            # 1. The declaration, from metadata the parser already holds.
+            result = self._check_parser_metadata_for_spectrum_type()
             if result:
                 return result
 
-            # Method 2: Stream-parse XML for spectrum type markers (memory efficient)
+            # 2. The same declaration, wherever else in the document it sits.
+            #    Streams the XML, so it is tried only if step 1 came up empty.
             result = self._check_xml_for_spectrum_type()
             if result:
                 return result
 
-            return None
+            # 3. Nothing declared. Only now is a guess appropriate.
+            return self._guess_spectrum_type_from_storage_mode()
         except Exception as e:
             logger.debug(f"Could not detect spectrum type: {e}")
             return None
@@ -607,8 +615,13 @@ class ImzMLMetadataExtractor(MetadataExtractor):
             logger.warning("defusedxml not available, using xml.etree.ElementTree")
             return ET
 
-    def _check_parser_metadata_for_centroid(self) -> Optional[str]:
-        """Check parser metadata for processed flag indicating centroid data."""
+    def _file_description_params(self) -> Optional[Dict[str, Any]]:
+        """Return the fileDescription cvParams the parser already parsed.
+
+        ``param_by_name`` maps a term's CV *name* to its parsed value, and a
+        valueless cvParam -- which is what a flag like ``profile spectrum``
+        is -- parses to ``True``.
+        """
         if not (hasattr(self.parser, "metadata") and self.parser.metadata):
             return None
 
@@ -616,13 +629,70 @@ class ImzMLMetadataExtractor(MetadataExtractor):
             return None
 
         file_desc = self.parser.metadata.file_description
-        if not hasattr(file_desc, "param_by_name"):
+        params = getattr(file_desc, "param_by_name", None)
+        if not isinstance(params, dict):
             return None
 
-        params = file_desc.param_by_name
-        # If it's processed data, it's likely centroided
-        if params.get("processed", False):
-            logger.info("Assuming centroid spectrum for processed ImzML data")
+        return params
+
+    def _check_parser_metadata_for_spectrum_type(self) -> Optional[str]:
+        """Read the declared spectrum representation out of the fileDescription.
+
+        Cheap: the parser has already read this, so no XML pass is needed.
+        ``SpectrumType.CENTROID`` and ``SpectrumType.PROFILE`` are the CV
+        names of ``MS:1000127`` and ``MS:1000128``, which is what
+        ``param_by_name`` is keyed on.
+        """
+        params = self._file_description_params()
+        if params is None:
+            return None
+
+        if params.get(SpectrumType.CENTROID, False):
+            logger.info(
+                f"Detected centroid spectrum from declared "
+                f"{ImzMLAccessions.CENTROID_SPECTRUM} in fileDescription"
+            )
+            return SpectrumType.CENTROID
+
+        if params.get(SpectrumType.PROFILE, False):
+            logger.info(
+                f"Detected profile spectrum from declared "
+                f"{ImzMLAccessions.PROFILE_SPECTRUM} in fileDescription"
+            )
+            return SpectrumType.PROFILE
+
+        return None
+
+    def _guess_spectrum_type_from_storage_mode(self) -> Optional[str]:
+        """Last-resort guess: assume a processed-mode file is centroided.
+
+        Processed and centroid are orthogonal. ``IMS:1000031`` says each
+        spectrum carries its own m/z array; it says nothing about whether
+        the peaks in it are centroided or profile. Plenty of instruments
+        export profile spectra in processed mode -- ``bellini.imzML`` is
+        processed *and* declares ``MS:1000128 profile spectrum``.
+
+        This used to run before the declared accession was ever read, so
+        every processed file was reported as centroid whatever it said about
+        itself. It now runs only when the file declares neither
+        ``MS:1000127`` nor ``MS:1000128`` anywhere, where a guess is all
+        there is. Peak lists are the common case for processed exports, so
+        centroid is the better guess -- but it is still a guess, hence the
+        warning.
+        """
+        params = self._file_description_params()
+        if params is None:
+            return None
+
+        if params.get(BinaryDataType.PROCESSED, False):
+            logger.warning(
+                "This imzML declares neither %s (centroid) nor %s (profile). "
+                "Assuming centroid, because it is stored in processed mode -- "
+                "but the two are independent, so check the result if the "
+                "spectra are actually profile.",
+                ImzMLAccessions.CENTROID_SPECTRUM,
+                ImzMLAccessions.PROFILE_SPECTRUM,
+            )
             return SpectrumType.CENTROID
 
         return None


### PR DESCRIPTION
Handout item 3. **Stacked on #126** — base it there, or merge that first.

## Does this change stored values?

**Yes, for processed-mode imzML that declares `MS:1000128 profile spectrum`.**
Of the five local datasets, exactly one: `bellini`. Its method is unchanged;
its axis type changes from `reflector_tof` to `constant`.

**No, for anything that declares `MS:1000127`.** `pea` and
`20240826_xenium_0041899` are reported as centroid before and after, with
identical routing, bin counts and bin widths.

## The bug

`_detect_centroid_spectrum` tried `_check_parser_metadata_for_centroid` first:

```python
params = file_desc.param_by_name
# If it's processed data, it's likely centroided
if params.get("processed", False):
    logger.info("Assuming centroid spectrum for processed ImzML data")
    return SpectrumType.CENTROID
```

The real `MS:1000127`/`MS:1000128` accession scan only ran if that returned
nothing — which it never did for a processed file, because pyimzml parses a
valueless `IMS:1000031` cvParam to `True`.

Processed and centroid are orthogonal. Processed means each spectrum carries
its own m/z array. It says nothing about whether the peaks in it are
centroided or profile.

`bellini.imzML` is processed **and** declares profile, in both places it could:

```
fileDescription param_by_name: {'profile spectrum': True, 'processed': True, ...}
MS:1000128 in the spectrum list: yes
```

and Thyra called it centroid.

## What changed

`_detect_centroid_spectrum` now reads the declaration first, wherever it is
written, and guesses only when there is nothing to read:

1. `_check_parser_metadata_for_spectrum_type` — the fileDescription the parser
   already holds. Cheap, no XML pass. `SpectrumType.CENTROID` and
   `SpectrumType.PROFILE` are the CV *names* of the two accessions, which is
   what `param_by_name` is keyed on, so this is a real read of the
   declaration, not a heuristic.
2. `_check_xml_for_spectrum_type` — the streaming accession scan, unchanged,
   for files that declare it elsewhere in the document.
3. `_guess_spectrum_type_from_storage_mode` — the old heuristic, renamed,
   demoted to last, and now emitting a **warning** rather than an info line,
   because it is a guess.

Two supporting changes in the same file:

- The fileDescription params lookup is factored into
  `_file_description_params` and now rejects a non-dict. A bare `Mock`'s
  attribute used to read as a declaration — which is exactly why the
  extractor's own tests never caught this.
- `_is_continuous_mode` uses `BinaryDataType.CONTINUOUS` instead of a bare
  `"continuous"`.

## Before/after

| `bellini.imzML` | before | after |
|---|---|---|
| declared in the file | `profile spectrum` | `profile spectrum` |
| reported as | `centroid spectrum` | **`profile spectrum`** |
| method | `nearest_neighbor` | `nearest_neighbor` |
| axis type | `reflector_tof` | **`constant`** |
| bins | 2,373,513 | 708,847 |
| bin width | 0.0001–17.7212 mDa | 5.0000 mDa flat |
| snap error, spectrum 0 | median 0.1241 mDa, max 3.4566 mDa | median 1.2770 mDa, max 2.4992 mDa |
| colliding points | 6 of 2,401 | 785 of 2,401 |

`pea.imzML` (460,495 bins, `reflector_tof`) and
`20240826_xenium_0041899.imzML` (313,713 bins, `reflector_tof`) are unchanged
in every column.

### On bellini's collision count

785 of 2,401 is 33%, which is the figure already recorded for this dataset —
46% of its source gaps are finer than one 5 mDa bin. It is a property of the
generic default axis, not of this change. Neither `constant` nor
`reflector_tof` matches bellini's actual grid law: its axis is uniform in
*flight time*, so bin width grows as `sqrt(m)`, which is `linear_tof`. No
auto-detector returns `linear_tof`, so data of that shape needs
`--mass-axis-type linear_tof` to get a matching axis.

That is worth knowing but it is a separate question from what the file
declares, and fixing it would need its own evidence. Flagged, not fixed.

## Why this had to land after #126

Reporting `bellini` as profile is only safe because unknown-provenance profile
data no longer reaches `tic_preserving`. On `main` today, this commit alone
would open the interpolating path for every processed-profile file — the exact
outcome #126 exists to prevent. There is a test pinning it:
`test_profile_file_routes_to_nearest_neighbor_not_tic_preserving`.

## Tests

New `TestSpectrumTypeDetection` in
`tests/unit/metadata/extractors/test_imzml_extractor.py`:

- **the regression** — a processed file declaring profile is reported as
  profile;
- declared centroid, and declared profile in continuous mode;
- undeclared + processed falls back to the guess **and warns**;
- undeclared + continuous returns `None` rather than guessing;
- a non-dict `param_by_name` declares nothing;
- round trip through real files written by `ImzMLWriter(spec_type=...)`, both
  representations, asserting `get_essential().spectrum_type`;
- a real profile file routes to `nearest_neighbor`.

The extractor had **no** test asserting `spectrum_type` at all before this.

Full suite: **1025 passed, 11 skipped**. Both `read_lazy` contract tests pass.
`black`, `isort`, `flake8`, `mypy`, `bandit`, `pydocstyle` clean.

## Verification beyond the suite

`pea.imzML` converted end to end with resampling on (419 s) and
`anndata.experimental.read_lazy` opens the result: shape (12737, 460495),
60,149,625 non-zeros, stored `spectrum_type` `'centroid spectrum'`, 460,495
bins as predicted.

`bellini.imzML` **cannot** be converted end to end, on this branch or on
`main`. `ImzMLReader._initialize_parser` hardcodes `parse_lib="lxml"` and
pyimzml's lxml path raises `XMLSyntaxError: xmlSAX2Characters, line 212575` on
it. This is pre-existing (reproduced at `2a3b161`) and unrelated: the file is
well-formed — plain `lxml.etree.iterparse` walks all 311,358 elements, and
`parse_lib="ElementTree"` parses it fine. Filed separately. bellini's numbers
above therefore come from the extractor and decision tree directly, not from a
conversion.

## Not in this PR

The handout also suggests *considering* an explicit representation override,
mirroring SCiLS's `--rep_type PROFILE|CENTROID`. That adds user-facing API
surface on a library with an external consumer, so it is left as the owner's
call. If wanted, the natural shape is a `spectrum_type` key in
`reader_options`, consumed in `_detect_centroid_spectrum` ahead of step 1.
