### PR TITLE
feat(readers): default the raw mass axis cap to SCiLS's 10 million bins

### DIFF
--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -244,6 +244,46 @@ INFO - Building resampled mass axis: 250.00 - 1200.00 m/z, 190000 bins
 stored sparsely, so the store stays small -- roughly 29 MB here. Pass
 `--resample-bins` or `--no-resample` if you would rather not upsample.
 
+### The 10 million bin cap
+
+`--no-resample` on a processed-mode imzML does not build a physics axis at all.
+It builds the **raw** axis: every distinct m/z value in the whole dataset, one
+column each. When the peak lists genuinely share m/z values that is small. When
+they do not -- which is the normal case for centroided peak picking, where two
+pixels almost never report a peak at the same double -- it grows to roughly one
+column per peak in the entire dataset, and there is no natural stopping point.
+
+Thyra gives up once that axis passes **10 million** unique m/z values, and says
+what to do instead:
+
+```
+ValueError: Common mass axis exceeded 10,000,000 unique m/z values after
+12,400 of 918,855 spectra (10,004,112 so far). The peak lists in this dataset
+do not share m/z values, so a raw axis grows to roughly one column per peak,
+which is not usable downstream. Convert with resampling instead (it is the
+default; --no-resample disables it), or raise max_mass_axis_length.
+```
+
+10 million is SCiLS Lab's own limit on the same quantity: "Data sets in SCiLS
+Lab are limited to a maximum of 10 million bins on the common mass axis" (2026b
+User Guide, p.76).
+
+The cap is Python-API only, through `reader_options`, and applies to the imzML
+reader:
+
+```python
+from thyra import convert_msi
+
+convert_msi(
+    "data.imzML",
+    "out.zarr",
+    reader_options={"max_mass_axis_length": 50_000_000},  # or None for no cap
+)
+```
+
+It has no effect when resampling is on, which is the default: a resampled axis
+has the bin count you asked for.
+
 ---
 
 ## Overriding the automatic choice

--- a/tests/unit/readers/test_mass_axis_streaming.py
+++ b/tests/unit/readers/test_mass_axis_streaming.py
@@ -24,6 +24,7 @@ all-NaN batch, one on an empty accumulator.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -250,9 +251,42 @@ class TestMaxMassAxisLength:
         runs = [[float(i)] for i in range(50)]
         assert _build(runs, max_len=10_000).size == 50
 
-    def test_absent_limit_is_unlimited(self, batch):
+    def test_explicit_none_is_unlimited(self, batch):
         runs = [[float(i)] for i in range(50)]
         assert _build(runs, max_len=None).size == 50
+
+
+class TestDefaultMaxMassAxisLength:
+    """The reader's default cap, and how a caller overrides it.
+
+    SCiLS Lab limits its own common mass axis to 10 million bins (2026b User
+    Guide, p.76). Thyra adopts that number: it is the tool the resampling was
+    designed against, and previously the cap defaulted to None only because
+    no defensible figure was available.
+    """
+
+    def _reader(self, **options):
+        """Construct a reader without touching the filesystem.
+
+        ``ImzMLReader.__init__`` is lazy -- it stores paths and defers the
+        parser -- so it is safe to build one for a path that does not exist.
+        """
+        return ImzMLReader(Path("does-not-exist.imzML"), **options)
+
+    def test_default_is_ten_million(self):
+        assert mod.DEFAULT_MAX_MASS_AXIS_LENGTH == 10_000_000
+        assert self._reader().max_mass_axis_length == 10_000_000
+
+    def test_caller_can_lower_it(self):
+        assert self._reader(max_mass_axis_length=5_000).max_mass_axis_length == 5_000
+
+    def test_caller_can_raise_it(self):
+        reader = self._reader(max_mass_axis_length=50_000_000)
+        assert reader.max_mass_axis_length == 50_000_000
+
+    def test_explicit_none_restores_unlimited(self):
+        """Absent means "use the default"; None means "no cap at all"."""
+        assert self._reader(max_mass_axis_length=None).max_mass_axis_length is None
 
 
 class TestPerSpectrumErrors:

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -283,10 +283,13 @@ def convert_msi(
               use active/recalibrated calibration (default True).
             - max_mass_axis_length: int - For processed-mode imzML
               converted with --no-resample, give up once the raw
-              mass axis exceeds this many unique m/z values.
-              Default: None (unlimited). Useful when the peak
-              lists share no m/z values, where the raw axis grows
-              to roughly one column per peak in the whole dataset.
+              mass axis exceeds this many unique m/z values. This
+              matters when the peak lists share no m/z values,
+              where the raw axis grows to roughly one column per
+              peak in the whole dataset. Default: 10,000,000,
+              which is the limit SCiLS Lab places on the same
+              quantity (2026b User Guide, p.76). Pass None for
+              no limit.
         sparse_format: Sparse matrix format ('csc' or 'csr')
         include_optical: Include optical images (default: True)
         apply_optical_alignment: If True (default) and the MSI source

--- a/thyra/readers/imzml/imzml_reader.py
+++ b/thyra/readers/imzml/imzml_reader.py
@@ -27,6 +27,16 @@ _MASS_AXIS_BATCH_VALUES = 1 << 20
 # Bounds that function's temporaries to O(block) rather than O(batch).
 _MASS_AXIS_PROBE_BLOCK = 1 << 20
 
+# Default cap on the number of unique m/z values the processed-mode raw mass
+# axis may reach, in ELEMENTS. Taken from SCiLS Lab, which applies the same
+# limit to the same quantity: "Data sets in SCiLS Lab are limited to a maximum
+# of 10 million bins on the common mass axis" (SCiLS Lab 2026b User Guide,
+# p.76). The cap previously defaulted to None because no defensible number was
+# available; this is one, from the tool Thyra's resampling was designed
+# against. Override with ``reader_options={"max_mass_axis_length": N}``, or
+# pass None for the old unlimited behaviour.
+DEFAULT_MAX_MASS_AXIS_LENGTH = 10_000_000
+
 
 def _dedupe_sorted(a: NDArray[Any]) -> NDArray[Any]:
     """Deduplicate an ALREADY-SORTED array, as ``np.unique`` would.
@@ -337,14 +347,20 @@ class ImzMLReader(BaseMSIReader):
             cache_coordinates: Whether to cache coordinates upfront
             **kwargs: Additional arguments. ``max_mass_axis_length`` caps the
                 number of unique m/z values the processed-mode raw axis may
-                reach before the build gives up; None (the default) is
-                unlimited. See ``_extract_continuous_mass_axis``.
+                reach before the build gives up. Defaults to
+                ``DEFAULT_MAX_MASS_AXIS_LENGTH`` (10 million, SCiLS Lab's own
+                limit); pass ``None`` explicitly for unlimited. See
+                ``_extract_continuous_mass_axis``.
         """
         super().__init__(data_path, **kwargs)
         self.filepath: Optional[Union[str, Path]] = data_path
         self.batch_size: int = batch_size
         self.cache_coordinates: bool = cache_coordinates
-        self.max_mass_axis_length: Optional[int] = kwargs.get("max_mass_axis_length")
+        # Absent means "use the default"; an explicit None means "unlimited",
+        # so this cannot be a bare ``.get(...)`` with a None fallback.
+        self.max_mass_axis_length: Optional[int] = kwargs.get(
+            "max_mass_axis_length", DEFAULT_MAX_MASS_AXIS_LENGTH
+        )
         self.parser: Optional[ImzMLParser] = None
         self.ibd_file: Optional[Any] = None
         self.imzml_path: Optional[Path] = None


### PR DESCRIPTION
Handout item 4. Independent of the others — based on `main`.

## Does this change stored values?

**No.** Not for any local dataset, and not for any dataset small enough to
have converted before. This is a guard rail: it turns a conversion that would
have ground on until it exhausted memory into an error that says what to do.

## What changed

`max_mass_axis_length` existed but defaulted to `None`, because when it was
added no defensible number was available. There is one, from the tool Thyra's
resampling was designed against:

> Data sets in SCiLS Lab are limited to a maximum of 10 million bins on the
> common mass axis.
>
> — SCiLS Lab 2026b User Guide, p.76

So `DEFAULT_MAX_MASS_AXIS_LENGTH = 10_000_000`, cited at the definition.

The cap only applies to the processed-mode **raw** axis, which is what
`--no-resample` builds: every distinct m/z value in the dataset, one column
each. When the peak lists share m/z values that is small. When they do not —
the normal case for centroided peak picking, where two pixels almost never
report a peak at the same double — it grows to roughly one column per peak in
the whole dataset, with no natural stopping point. Resampled conversions, the
default, are unaffected: their bin count is whatever was asked for.

One subtlety in the plumbing. Absent now means "use the default" while an
explicit `None` still means unlimited, so this cannot be a bare `.get(...)`
relying on the `None` fallback:

```python
self.max_mass_axis_length: Optional[int] = kwargs.get(
    "max_mass_axis_length", DEFAULT_MAX_MASS_AXIS_LENGTH
)
```

## Measured: nothing local comes close

Raw axis sizes, built with the cap off:

| dataset | spectra | peaks | unique m/z | over 10M? |
|---|---|---|---|---|
| `bellini.imzML` | 16,384 | ~36M | **1,122,721** | no |
| `pea.imzML` | 12,737 | ~60M | **331,701** | no |
| `20240826_xenium_0041899.imzML` | 918,855 | ~1.17B | **313,714** | no |

Xenium is the interesting one: 1.17 billion peaks collapse to 313,714 unique
m/z values, so its peak lists share m/z heavily and the raw axis is tiny. The
build was re-run with the cap in place and completed in 22.8 s without the cap
ever applying.

## Who this affects

Anyone converting a processed-mode imzML with `--no-resample` whose peak lists
genuinely share nothing, above 10 million distinct values, and who had the
memory to finish. They now get:

```
ValueError: Common mass axis exceeded 10,000,000 unique m/z values after
12,400 of 918,855 spectra (10,004,112 so far). The peak lists in this dataset
do not share m/z values, so a raw axis grows to roughly one column per peak,
which is not usable downstream. Convert with resampling instead (it is the
default; --no-resample disables it), or raise max_mass_axis_length.
```

and can say `reader_options={"max_mass_axis_length": 50_000_000}` — or `None`
for the old unlimited behaviour. The error message and the raise path are
unchanged and already tested.

## Docs

`max_mass_axis_length` had **no** prose documentation anywhere in `docs/` — it
reached the site only through the auto-rendered `convert_msi` docstring. This
adds a "The 10 million bin cap" section under `docs/resampling.md`'s bin-count
chapter, explaining what the raw axis is, why it can run away, the citation,
and how to override it.

## Tests

New `TestDefaultMaxMassAxisLength` in
`tests/unit/readers/test_mass_axis_streaming.py`: the default is 10 million
and reaches the reader; a caller can lower it; a caller can raise it; an
explicit `None` restores unlimited. The existing
`test_absent_limit_is_unlimited` is renamed `test_explicit_none_is_unlimited`,
which is what it actually pinned — absent no longer means unlimited.

Full suite: **1009 passed, 11 skipped**. `black`, `isort`, `flake8`, `mypy`,
`bandit`, `pydocstyle` clean.

## Note

There is still no CLI flag for this — it is reachable only through
`reader_options`, and the docs say so. Adding one is a separate decision.
