### PR TITLE
feat(resampling): give tic_preserving a gap tolerance, as Cardinal and matter have

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -105,6 +105,7 @@ chooses an appropriate method and bin count.
 | `--resample-max-mz FLOAT` | auto | Maximum m/z value |
 | `--resample-width-at-mz FLOAT` | auto | Mass width in Da at reference m/z for physics-based binning |
 | `--resample-reference-mz FLOAT` | `1000.0` | Reference m/z for width specification |
+| `--resample-gap-tolerance FLOAT` | none | `tic_preserving` only: discard target bins farther than this many Da from any measured m/z, instead of interpolating across the gap |
 
 !!! info "Choosing a resampling method"
     - **`nearest_neighbor`** -- Each target bin takes the nearest original m/z

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -175,6 +175,40 @@ proportionate amount instead of collapsing to zero.
 With the default axis, which spans the dataset's own mass range, nothing is
 dropped and the total is preserved exactly.
 
+#### Gaps in the source m/z values
+
+Interpolation has no notion of a gap. Between the last source point before an
+empty stretch and the first one after it, `np.interp` draws a straight line,
+and every target bin in between gets an intensity that was never measured. On
+sparse or thresholded m/z arrays that is most of the axis: forcing
+`tic_preserving` onto `bellini.imzML` -- 2,222 points per spectrum, median
+source spacing 0.0072 Da, largest gap 1,269 Da -- puts **80.6%** of the output
+total ion current more than 0.5 Da from any measured point.
+
+`--resample-gap-tolerance` sets how far a target bin may sit from the nearest
+source m/z before its interpolated value is discarded instead of trusted. It is
+the same parameter Cardinal calls `tolerance` and matter calls `tol`.
+
+```bash
+thyra convert data.imzML out.zarr \
+  --resample-method tic_preserving \
+  --resample-gap-tolerance 0.1
+```
+
+Masking happens **before** the TIC rescale, so the intensity returns to the
+bins that do have measurements behind them rather than being deleted; the
+per-pixel total is still preserved.
+
+Sizing it: on a source grid of uniform step `s`, no target bin is ever more
+than `s/2` from a source point, so **any tolerance above half the widest gap in
+your source m/z values changes nothing**. Continuous profile data is dense and
+evenly sampled, which is why the default is *no* limit -- there is nothing to
+refuse. Set it when your m/z arrays are sparse or peak-picked and you are
+asking for `tic_preserving` anyway.
+
+`nearest_neighbor` needs no such parameter: it only ever fills a bin some peak
+was snapped into.
+
 ---
 
 ## Axis types

--- a/tests/unit/resampling/test_gaps.py
+++ b/tests/unit/resampling/test_gaps.py
@@ -1,0 +1,162 @@
+"""Tests for the interpolation gap tolerance.
+
+``np.interp`` draws a straight line across any gap in the source m/z values,
+so every target bin between two distant source points comes back with a
+fabricated intensity. ``gap_tolerance_da`` is the parameter Cardinal
+(``tolerance``) and matter (``approx1(..., tol=)``) both expose to stop that.
+
+The property that matters most here is the one that makes it safe to switch
+on: on a source grid of uniform step ``s``, no target point is farther than
+``s / 2`` from a source point, so any tolerance of at least ``s / 2`` is a
+no-op. That is the flexImaging/Rapiflex case, which is the only route
+auto-selection sends to ``tic_preserving``.
+"""
+
+import numpy as np
+import pytest
+
+from thyra.resampling.gaps import zero_across_gaps
+from thyra.resampling.strategies.base import Spectrum
+from thyra.resampling.strategies.tic_preserving import TICPreservingStrategy
+
+
+class TestZeroAcrossGaps:
+    """The masking primitive on its own."""
+
+    def test_none_is_a_no_op(self):
+        values = np.ones(5)
+        axis = np.linspace(0.0, 4.0, 5)
+        mzs = np.array([0.0])
+        assert np.array_equal(zero_across_gaps(values, axis, mzs, None), np.ones(5))
+
+    @pytest.mark.parametrize("tolerance", [0.0, -1.0])
+    def test_non_positive_tolerance_is_a_no_op(self, tolerance):
+        """Zero would otherwise mask everything not exactly on a source point."""
+        values = np.ones(5)
+        axis = np.linspace(0.0, 4.0, 5)
+        mzs = np.array([0.0])
+        assert np.array_equal(
+            zero_across_gaps(values, axis, mzs, tolerance), np.ones(5)
+        )
+
+    def test_empty_source_is_a_no_op(self):
+        values = np.ones(3)
+        axis = np.linspace(0.0, 2.0, 3)
+        assert np.array_equal(
+            zero_across_gaps(values, axis, np.array([]), 0.1), np.ones(3)
+        )
+
+    def test_bins_beyond_the_tolerance_are_zeroed(self):
+        axis = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        mzs = np.array([0.0, 4.0])
+        values = np.ones(5)
+        zero_across_gaps(values, axis, mzs, 1.0)
+        # 0.0 and 4.0 are on source points; 1.0 and 3.0 are exactly one Da
+        # away, which is within tolerance; 2.0 is two Da from either.
+        assert np.array_equal(values, np.array([1.0, 1.0, 0.0, 1.0, 1.0]))
+
+    def test_boundary_is_inclusive(self):
+        axis = np.array([0.0, 1.0])
+        mzs = np.array([0.0])
+        values = np.ones(2)
+        zero_across_gaps(values, axis, mzs, 1.0)
+        assert np.array_equal(values, np.ones(2))
+
+    def test_it_masks_in_place_and_returns_the_same_array(self):
+        values = np.ones(3)
+        out = zero_across_gaps(values, np.array([0.0, 5.0, 10.0]), np.array([0.0]), 1.0)
+        assert out is values
+
+    @pytest.mark.parametrize("step", [0.001, 0.005, 0.017, 1.0])
+    def test_half_the_source_step_leaves_a_uniform_grid_untouched(self, step):
+        """The guarantee that makes this safe on flexImaging data.
+
+        RapiflexReader lays every spectrum out with np.linspace, so this is
+        the shape of the only source grid auto-selection interpolates.
+
+        The tolerance carries a relative hair above half the step. Exactly
+        half is a floating-point knife edge: the worst-case target bin sits
+        at the midpoint, and neither the accumulated grid nor the midpoint is
+        exactly representable, so the computed distance lands either side of
+        the bound by an ulp or two. Half the *widest* source gap is the
+        honest rule, and anything above it is safely a no-op.
+        """
+        mzs = np.arange(100.0, 200.0, step)
+        # A target axis deliberately offset from the source grid, so every
+        # bin sits as far from a source point as the geometry allows.
+        axis = mzs[:-1] + step / 2.0
+        values = np.ones(axis.size)
+        tolerance = float(np.diff(mzs).max()) / 2.0 * (1.0 + 1e-9)
+        zero_across_gaps(values, axis, mzs, tolerance)
+        assert np.count_nonzero(values) == values.size
+
+    def test_exactly_half_the_step_on_an_exact_grid(self):
+        """With representable arithmetic the bound holds exactly."""
+        mzs = np.linspace(0.0, 1024.0, 1025)  # step 1.0, all exact
+        axis = mzs[:-1] + 0.5
+        values = np.ones(axis.size)
+        zero_across_gaps(values, axis, mzs, 0.5)
+        assert np.count_nonzero(values) == values.size
+
+
+class TestTICPreservingWithGapTolerance:
+    """The strategy end to end, and what masking does to the total."""
+
+    def _spectrum(self, mzs, intensities):
+        return Spectrum(
+            mz=np.asarray(mzs, dtype=np.float64),
+            intensity=np.asarray(intensities, dtype=np.float64),
+            coordinates=(1, 1, 1),
+            metadata={},
+        )
+
+    def test_default_is_off(self):
+        """Unset, the strategy behaves exactly as before."""
+        axis = np.linspace(0.0, 100.0, 1001)
+        spectrum = self._spectrum([0.0, 100.0], [1.0, 1.0])
+        assert TICPreservingStrategy().gap_tolerance_da is None
+        without = TICPreservingStrategy().resample(spectrum, axis).intensity
+        assert np.count_nonzero(without) == axis.size
+
+    def test_tolerance_confines_intensity_to_the_measured_regions(self):
+        axis = np.linspace(0.0, 100.0, 1001)
+        spectrum = self._spectrum([0.0, 100.0], [1.0, 1.0])
+        with_tol = (
+            TICPreservingStrategy(gap_tolerance_da=1.0)
+            .resample(spectrum, axis)
+            .intensity
+        )
+        # Only bins within 1 Da of 0.0 or 100.0 survive: 0.0-1.0 and
+        # 99.0-100.0 at 0.1 Da spacing.
+        assert np.count_nonzero(with_tol) == 22
+        assert np.count_nonzero(with_tol[220:780]) == 0
+
+    def test_tic_is_still_preserved(self):
+        """Masking happens before the rescale, so the total is not lost."""
+        axis = np.linspace(0.0, 100.0, 1001)
+        spectrum = self._spectrum([0.0, 100.0], [3.0, 5.0])
+        out = TICPreservingStrategy(gap_tolerance_da=1.0).resample(spectrum, axis)
+        assert out.intensity.sum() == pytest.approx(8.0)
+
+    def test_uniform_source_is_unaffected(self):
+        """A dense uniform source: same answer with and without the tolerance."""
+        mzs = np.arange(100.0, 200.0, 0.01)
+        rng = np.random.default_rng(0)
+        intensities = rng.random(mzs.size)
+        spectrum = self._spectrum(mzs, intensities)
+        axis = np.linspace(100.0, 199.99, 20_000)
+
+        without = TICPreservingStrategy().resample(spectrum, axis).intensity
+        with_tol = (
+            TICPreservingStrategy(gap_tolerance_da=0.005)
+            .resample(spectrum, axis)
+            .intensity
+        )
+        np.testing.assert_allclose(with_tol, without)
+
+    def test_a_tolerance_that_masks_everything_leaves_zeros(self):
+        """No surviving bin means nothing to rescale into -- not a crash."""
+        axis = np.array([50.0, 51.0])
+        spectrum = self._spectrum([0.0, 100.0], [1.0, 1.0])
+        out = TICPreservingStrategy(gap_tolerance_da=1.0).resample(spectrum, axis)
+        assert np.array_equal(out.intensity, np.zeros(2))

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -243,6 +243,7 @@ def _build_resampling_config(
     resample_max_mz: Optional[float],
     resample_width_at_mz: Optional[float],
     resample_reference_mz: float,
+    resample_gap_tolerance: Optional[float] = None,
 ) -> dict:
     """Build resampling configuration dictionary."""
     return {
@@ -253,6 +254,7 @@ def _build_resampling_config(
         "max_mz": resample_max_mz,
         "width_at_mz": resample_width_at_mz,
         "reference_mz": resample_reference_mz,
+        "gap_tolerance_da": resample_gap_tolerance,
     }
 
 
@@ -536,6 +538,16 @@ class GroupedCommand(click.Command):
     default=1000.0,
     help="Reference m/z for width specification (default: 1000.0)",
 )
+@click.option(
+    "--resample-gap-tolerance",
+    type=float,
+    default=None,
+    help=(
+        "For tic_preserving only: discard target bins farther than this many "
+        "Da from any measured m/z, instead of interpolating across the gap "
+        "(default: no limit)"
+    ),
+)
 # -- Bruker-specific --
 @click.option(
     "--use-recalibrated/--no-recalibrated",
@@ -583,6 +595,7 @@ def main(
     resample_max_mz: Optional[float],
     resample_width_at_mz: Optional[float],
     resample_reference_mz: float,
+    resample_gap_tolerance: Optional[float],
     mass_axis_type: str,
     sparse_format: str,
     include_optical: bool,
@@ -603,6 +616,9 @@ def main(
         resample_max_mz,
         resample_width_at_mz,
         resample_reference_mz,
+    )
+    _validate_positive_float(
+        resample_gap_tolerance, "resample_gap_tolerance", "Gap tolerance"
     )
     _validate_positive_float(
         intensity_threshold, "intensity_threshold", "Intensity threshold"
@@ -641,6 +657,7 @@ def main(
             resample_max_mz,
             resample_width_at_mz,
             resample_reference_mz,
+            resample_gap_tolerance,
         )
         if resample
         else None

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -17,6 +17,7 @@ from ...core.base_converter import BaseMSIConverter, PixelSizeSource
 from ...core.base_reader import BaseMSIReader
 from ...metadata.types import ComprehensiveMetadata, EssentialMetadata
 from ...resampling import ResamplingDecisionTree, ResamplingMethod
+from ...resampling.gaps import zero_across_gaps
 from ...resampling.tic import preserved_tic, rescale_to_preserved_tic
 from ...resampling.types import ResamplingConfig
 from ...utils.zarr_atomic_write import install_windows_atomic_write_retry
@@ -137,6 +138,7 @@ def _normalize_resampling_config(
         ),
         min_mz=config.get("min_mz"),
         max_mz=config.get("max_mz"),
+        gap_tolerance_da=config.get("gap_tolerance_da"),
     )
 
 
@@ -378,6 +380,12 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         self._max_mz = config.max_mz
         self._width_at_mz = config.mass_width_da
         self._reference_mz = config.reference_mz
+        self._gap_tolerance_da = config.gap_tolerance_da
+        if self._gap_tolerance_da is not None:
+            logger.info(
+                f"Interpolation gap tolerance: {self._gap_tolerance_da} Da "
+                "(target bins farther than this from any source m/z are zeroed)"
+            )
 
     def _get_cached_metadata_for_resampling(self) -> Dict[str, Any]:
         """Get cached metadata for resampling decision tree to avoid multiple reader calls."""
@@ -1116,6 +1124,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         When the axis spans the spectrum, which is the default, that share
         is the whole input TIC.
 
+        When ``ResamplingConfig.gap_tolerance_da`` is set, bins farther than
+        that from any source m/z are zeroed before the rescale, so
+        interpolation cannot claim regions nothing was measured in. See
+        ``thyra.resampling.gaps``.
+
         Args:
             mzs: Original m/z values from the spectrum.
             intensities: Corresponding intensity values.
@@ -1161,6 +1174,16 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             intensities_sorted,
             left=0,
             right=0,
+        )
+
+        # Discard bins no source point vouches for, before the rescale so the
+        # intensity returns to the bins that were measured rather than being
+        # deleted. No-op when no tolerance was configured.
+        zero_across_gaps(
+            resampled,
+            axis,
+            mzs_sorted,
+            getattr(self, "_gap_tolerance_da", None),
         )
 
         # Rescale to the required TIC. This is the step that makes the

--- a/thyra/resampling/gaps.py
+++ b/thyra/resampling/gaps.py
@@ -1,0 +1,76 @@
+"""Refusing to interpolate across regions that were never measured.
+
+``np.interp`` has no notion of a gap. Handed a spectrum whose m/z values are
+sparse or thresholded, it draws a straight line from the last point before the
+gap to the first point after it, and every target bin in between comes back
+with a fabricated intensity. Nothing was measured there.
+
+On real data this is not a rounding-scale effect. Forcing ``tic_preserving``
+onto ``bellini.imzML`` -- 2,222 points per spectrum, median source spacing
+0.0072 Da, largest gap 1,269 Da -- puts 80.6% of the output total ion current
+into m/z regions more than 0.5 Da from any measured point.
+
+The fix is the parameter Cardinal (``tolerance``) and matter
+(``approx1(..., tol=)``) both expose: how far a target m/z may sit from the
+nearest source m/z before its interpolated value is discarded rather than
+trusted.
+
+Order matters
+-------------
+
+Masking happens **before** the TIC rescale, not after. The intensity was
+measured; it belongs somewhere. Interpolation had spread it across a gap where
+nothing was recorded, so returning it to the bins that do have measurements
+behind them keeps ``ResamplingMethod.TIC_PRESERVING``'s promise intact. Masking
+after the rescale would instead delete that intensity and quietly break the
+method's defining property.
+"""
+
+from typing import Any, Optional
+
+import numpy as np
+import numpy.typing as npt
+
+
+def zero_across_gaps(
+    resampled: npt.NDArray[Any],
+    axis: npt.NDArray[np.floating[Any]],
+    mzs: npt.NDArray[np.floating[Any]],
+    tolerance: Optional[float],
+) -> npt.NDArray[Any]:
+    """Zero the bins of ``resampled`` that no source point vouches for.
+
+    Modifies ``resampled`` in place and returns it.
+
+    A bin survives when some source m/z lies within ``tolerance`` of it. On a
+    source grid of uniform step ``s`` the farthest any target point can be
+    from a source point is ``s / 2``, so any tolerance of at least half the
+    source spacing leaves such a spectrum untouched -- which is what makes it
+    safe to switch on for continuous profile data. Half the *widest* source
+    gap is the rule to size it by; exactly half is a floating-point knife
+    edge, so give it a hair of margin.
+
+    Args:
+        resampled: Interpolated intensities on ``axis``, modified in place.
+        axis: The target mass axis, ascending.
+        mzs: Source m/z values, ascending.
+        tolerance: Maximum distance in Da from a target bin to the nearest
+            source m/z. ``None`` disables the check and returns ``resampled``
+            untouched, as does a non-positive tolerance.
+
+    Returns:
+        ``resampled``, with unsupported bins set to zero.
+    """
+    if tolerance is None or tolerance <= 0.0 or mzs.size == 0:
+        return resampled
+
+    # Distance from each target bin to the nearest source m/z. searchsorted
+    # gives the insertion point; the nearest source point is on one side or
+    # the other of it.
+    right = np.searchsorted(mzs, axis)
+    lo = np.clip(right - 1, 0, mzs.size - 1)
+    hi = np.clip(right, 0, mzs.size - 1)
+    nearest = np.minimum(np.abs(axis - mzs[lo]), np.abs(axis - mzs[hi]))
+
+    resampled[nearest > tolerance] = 0.0
+    return resampled

--- a/thyra/resampling/strategies/tic_preserving.py
+++ b/thyra/resampling/strategies/tic_preserving.py
@@ -13,17 +13,30 @@ cropped intensity rather than redistributing it over the bins that remain.
 When the axis spans the spectrum, the whole TIC is preserved exactly.
 """
 
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np
 import numpy.typing as npt
 
+from ..gaps import zero_across_gaps
 from ..tic import preserved_tic, rescale_to_preserved_tic
 from .base import ResamplingStrategy, Spectrum
 
 
 class TICPreservingStrategy(ResamplingStrategy):
     """TIC-preserving linear interpolation strategy for profile data."""
+
+    def __init__(self, gap_tolerance_da: Optional[float] = None) -> None:
+        """Initialize the strategy.
+
+        Args:
+            gap_tolerance_da: How far, in Daltons, a target bin may sit from
+                the nearest source m/z before its interpolated value is
+                discarded. ``None`` (the default) keeps ``np.interp``'s own
+                behaviour of drawing straight lines across unmeasured
+                regions. See :mod:`thyra.resampling.gaps`.
+        """
+        self.gap_tolerance_da = gap_tolerance_da
 
     def resample(
         self, spectrum: Spectrum, target_axis: npt.NDArray[np.floating[Any]]
@@ -108,6 +121,15 @@ class TICPreservingStrategy(ResamplingStrategy):
 
         # Ensure no negative values (can happen with extrapolation)
         interpolated_intensity = np.maximum(interpolated_intensity, 0.0)
+
+        # Discard bins no source point vouches for, before the rescale so the
+        # intensity returns to the measured bins rather than being deleted.
+        zero_across_gaps(
+            interpolated_intensity,
+            np.asarray(target_axis, dtype=np.float64),
+            mzs_sorted,
+            self.gap_tolerance_da,
+        )
 
         # Scale onto the TIC the target axis is entitled to carry. Shared
         # with the converters' hot path so the two cannot drift apart again.

--- a/thyra/resampling/types.py
+++ b/thyra/resampling/types.py
@@ -109,6 +109,13 @@ class ResamplingConfig:
             default.
         min_mz: Override the lower bound of the mass range.
         max_mz: Override the upper bound of the mass range.
+        gap_tolerance_da: How far, in Daltons, a target bin may sit from the
+            nearest source m/z before ``tic_preserving`` discards its
+            interpolated value instead of trusting it.  ``None`` -- the
+            default -- means no check, which is how ``np.interp`` behaves:
+            straight lines are drawn across regions where nothing was
+            measured.  Only affects ``tic_preserving``; ``nearest_neighbor``
+            never invents a bin.  See :mod:`thyra.resampling.gaps`.
     """
 
     method: Optional[ResamplingMethod] = None
@@ -118,3 +125,4 @@ class ResamplingConfig:
     reference_mz: float = DEFAULT_REFERENCE_MZ
     min_mz: Optional[float] = None
     max_mz: Optional[float] = None
+    gap_tolerance_da: Optional[float] = None


### PR DESCRIPTION
Handout item 6. Independent of the others — based on `main`.

## Does this change stored values?

**No.** The default is `None`, meaning no limit, which is exactly today's
behaviour. This adds a parameter; it does not turn it on.

## The defect

`np.interp` has no notion of a gap. Between the last source point before an
empty stretch of m/z and the first one after it, it draws a straight line, and
every target bin in between comes back carrying an intensity that was never
measured.

On sparse or thresholded m/z arrays that is most of the axis. Forcing
`tic_preserving` onto `bellini.imzML` — 2,223 points per spectrum, median
source spacing 0.0070 Da, largest gap 1,753 Da — puts **80.89%** of the output
total ion current more than 0.5 Da from any measured point.

## What changed

`gap_tolerance_da`: how far a target bin may sit from the nearest source m/z
before its interpolated value is discarded rather than trusted. This is the
parameter Cardinal calls `tolerance` and matter calls `approx1(..., tol=)`.

Exposed three ways:

```bash
thyra convert data.imzML out.zarr \
  --resample-method tic_preserving --resample-gap-tolerance 0.1
```

```python
ResamplingConfig(method=..., gap_tolerance_da=0.1)
TICPreservingStrategy(gap_tolerance_da=0.1)
```

The masking rule lives in one module, `thyra/resampling/gaps.py`, called by
both implementations of `tic_preserving` — the converters' hot path and the
public strategy. Same reason `thyra/resampling/tic.py` exists: those two have
drifted apart before.

### Masking runs *before* the TIC rescale

Not after, and this is the load-bearing detail. The intensity was measured and
belongs somewhere. Interpolation had spread it across a region with no
measurements behind it, so returning it to the bins that do have them keeps
`TIC_PRESERVING`'s defining property intact. Masking after the rescale would
delete it instead and quietly break the method's own name.

Measured: TIC out/in stays `1.000000` at every tolerance tested.

## What it does when you ask for it

100 real pixels, onto a 5 mDa `constant` axis.

### `bellini.imzML` — the case the parameter is for

| tolerance | non-zero bins | TIC out/in | output TIC >0.5 Da from a measurement |
|---|---|---|---|
| none | 48,998,585 | 1.000000 | **80.89%** |
| 1.00 Da | 12,223,893 | 1.000000 | 25.96% |
| 0.50 Da | 9,045,686 | 1.000000 | 0.00% |
| 0.10 Da | 2,769,243 | 1.000000 | 0.00% |
| 0.01 Da | 448,686 | 1.000000 | 0.00% |

### `pea.imzML` — denser, median spacing 0.0566 Da

| tolerance | non-zero bins | TIC out/in | output TIC >0.5 Da from a measurement |
|---|---|---|---|
| none | 17,404,632 | 1.000000 | 3.25% |
| 0.50 Da | 16,897,136 | 1.000000 | 0.00% |
| 0.10 Da | 8,311,872 | 1.000000 | 0.00% |

## How to size it

On a source grid of uniform step `s`, no target bin is ever more than `s/2`
from a source point. **So any tolerance above half the widest gap in your
source m/z values is a no-op.** That is the property that makes it safe to
switch on for continuous profile data, and it is what makes it useless there —
dense evenly-sampled data has nothing to refuse.

A test pins that across four step sizes. Exactly half is a floating-point
knife edge — the worst-case bin sits at the midpoint and neither it nor an
accumulated grid is exactly representable — so the parameterised test carries a
relative hair of margin, and a separate test on an exactly-representable grid
shows the bound is tight rather than approximate.

## Why the default is off

Turning it on by default would change output on the Rapiflex path, which is
the only route auto-selection sends to `tic_preserving`, and that path
currently measures exact (0.00000 ion-image error). Changing stored values
there is the owner's call, not the implementer's.

**A concrete proposal for whoever picks that up:** the handout records that on
the one continuous profile file available — max source gap 0.0834 Da — any
tolerance above ~0.1 Da is a no-op. That file is not in `test_data`, so it
could not be reproduced here. If it is reproduced against a real flexImaging
dataset, defaulting to 0.1 Da would be defensible and would cost that path
nothing. The measurement that would justify it: max `diff` of the source m/z
array across a flexImaging acquisition, versus 2× the proposed default.

## Tests

New `tests/unit/resampling/test_gaps.py`, 17 tests:

- the primitive — `None`, zero and negative tolerances, and an empty source
  are all no-ops; bins beyond the tolerance are zeroed; the boundary is
  inclusive; it masks in place;
- **the safety property** — half the source step leaves a uniform grid
  untouched, across four step sizes, plus the exact-arithmetic case;
- the strategy end to end — default off; a tolerance confines intensity to the
  measured regions; **TIC is still preserved**; a dense uniform source is
  bit-for-bit unaffected; a tolerance that masks everything returns zeros
  rather than crashing.

Full suite: **1022 passed, 11 skipped**. `black`, `isort`, `flake8`, `mypy`,
`bandit`, `pydocstyle` clean.

## Relation to the other PRs

With the modality-leak fix in, nothing of unknown provenance reaches this code
at all, so this is no longer urgent — it is the belt to that braces. It
matters for anyone passing `--resample-method tic_preserving` explicitly on
sparse data, which nothing else prevents.
