### PR TITLE
docs(resampling): source the SCiLS claims, and stop recommending a forbidden pairing

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -36,7 +36,7 @@ success = convert_msi(
     "input.imzML",
     "output.zarr",
     resampling_config={
-        "method": "tic_preserving",
+        "method": "nearest_neighbor",
         "axis_type": "orbitrap",
         "target_bins": 50000,
     },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,9 +116,15 @@ For advanced control you can specify the method and instrument type:
 ```bash
 # Physics-based resampling for Orbitrap data
 thyra input.imzML output.zarr \
-    --resample-method tic_preserving \
+    --resample-method nearest_neighbor \
     --mass-axis-type orbitrap
 ```
+
+`nearest_neighbor` is the right pairing for a non-uniform axis:
+`tic_preserving` applies one scaling factor to the whole spectrum, which
+cannot account for bin widths that vary across the mass range. See
+[Resampling](resampling.md#methods) for the measured cost of getting that
+combination wrong.
 
 !!! info "When to disable resampling"
     Disable resampling (`--no-resample`) if you need the raw, unmodified spectra

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -123,6 +123,14 @@ default. This table is the actual observed behaviour of that chain:
     which hardcodes `"MALDI-TOF"`. Neither the imzML nor the Bruker `.d`
     metadata extractor emits it at all.
 
+    Still true: reading the declared `MS:1000127`/`MS:1000128` accession fixed
+    how *spectrum representation* is detected, not how `instrument_type` is
+    populated. Nothing writes `"Orbitrap"` or `"FT-ICR"` into it, so these two
+    detectors remain unreachable. What did change is which row such data lands
+    on: a profile-mode Orbitrap file now correctly reports profile, so it falls
+    to the default row (`constant`) rather than being misread as centroid and
+    given `reflector_tof`.
+
     So Orbitrap and FT-ICR data does **not** get the `orbitrap` or `fticr`
     axis automatically -- it falls through to the generic centroid or default
     row above and gets `reflector_tof` or `constant`. Set
@@ -247,13 +255,19 @@ The axis type sets how bin width grows with m/z. Each corresponds to the
 physics of a mass analyser, so that bins track the instrument's real resolving
 power instead of over-sampling the low end and under-sampling the high end.
 
-| Axis type | Bin width scales as | Rationale |
-|---|---|---|
-| `constant` | constant Da | Equidistant bins; the SCiLS Lab convention for MALDI-TOF profile data |
-| `linear_tof` | `sqrt(m/z)` | Linear TOF: flight time `t ∝ sqrt(m/z)`, so equal time bins give `sqrt(m/z)` mass bins |
-| `reflector_tof` | `m/z` | Constant *relative* resolution `R = m/Δm`; bins are uniform in `ln(m/z)` |
-| `orbitrap` | `m/z^1.5` | Orbitrap frequency `f ∝ 1/sqrt(m/z)`, so equal frequency bins give `m/z^1.5` mass bins |
-| `fticr` | `m/z^2` | Cyclotron frequency `f ∝ 1/(m/z)`, so equal frequency bins give `m/z^2` mass bins |
+| Axis type | In SCiLS Lab | Bin width scales as | Rationale |
+|---|---|---|---|
+| `constant` | Constant (equidistant) | constant Da | Equidistant bins |
+| `linear_tof` | **Axial TOF** | `sqrt(m/z)` | Linear TOF: flight time `t ∝ sqrt(m/z)`, so equal time bins give `sqrt(m/z)` mass bins |
+| `reflector_tof` | **Orthogonal TOF** | `m/z` | Constant *relative* resolution `R = m/Δm`; bins are uniform in `ln(m/z)` |
+| `orbitrap` | Orbitrap | `m/z^1.5` | Orbitrap frequency `f ∝ 1/sqrt(m/z)`, so equal frequency bins give `m/z^1.5` mass bins |
+| `fticr` | **MRMS** (Fourier-transform) | `m/z^2` | Cyclotron frequency `f ∝ 1/(m/z)`, so equal frequency bins give `m/z^2` mass bins |
+
+The five types, and their scaling laws, are the ones SCiLS Lab offers for the
+common mass axis (2026b User Guide, p.75). **Thyra's names are SCiLS's older
+ones**: `linear_tof` and `reflector_tof` were "Linear TOF" and "Reflector TOF"
+in earlier SCiLS versions and are now Axial TOF and Orthogonal TOF, and the
+FT-ICR type is now called MRMS. The laws are unchanged; only the labels moved.
 
 `reflector_tof` is the most broadly useful of these: constant relative
 resolution means constant relative mass accuracy across the whole range, which
@@ -274,8 +288,16 @@ When you specify neither, these defaults apply:
 | `linear_tof` | 17 mDa | 300 |
 | everything else | 5 mDa | 1000 |
 
-The 17 mDa / m/z 300 pairing for `linear_tof` reproduces the axis SCiLS Lab
-produces for FlexImaging data. The count is then derived per axis type:
+The 17 mDa / m/z 300 pairing for `linear_tof` was chosen to be close to the
+axis SCiLS Lab produces for FlexImaging data. Treat it as a working default
+rather than a reproduction: **the figure does not appear in the SCiLS Lab
+2026b User Guide**, and no version that states it has been identified, so
+nothing here is a claim of exact equivalence. The code comment implementing it
+says "SCiLS-like ~17 mDa", which is the accurate description. If you need to
+match a particular SCiLS project, set `--resample-width-at-mz` and
+`--resample-reference-mz` from that project's own axis.
+
+The count is then derived per axis type:
 
 | Axis type | Bin count |
 |---|---|
@@ -389,7 +411,7 @@ automatic.
         "input.imzML",
         "output.zarr",
         resampling_config={
-            "method": "tic_preserving",
+            "method": "nearest_neighbor",
             "axis_type": "orbitrap",
             "width_at_mz": 0.01,
             "reference_mz": 500.0,


### PR DESCRIPTION
Handout item 7. Documentation only — no code changes.

**Stacked on #127**, which is stacked on #126. Item 7's last bullet asks for
the Orbitrap/FT-ICR warning to be revisited *after* the spectrum-representation
fix lands, so it has to sit on top of it.

## 1. The 17 mDa / m/z 300 claim is now sourced honestly

`docs/resampling.md` said the `linear_tof` default "reproduces the axis SCiLS
Lab produces for FlexImaging data".

That figure **does not appear in the SCiLS Lab 2026b User Guide**, and no
version that states it has been identified. The code implementing it is more
careful than the doc was — `base_spatialdata_converter.py` says "SCiLS-like
~17 mDa at m/z 300" in both places it appears.

Softened to match the code, with a pointer at `--resample-width-at-mz` /
`--resample-reference-mz` for anyone who needs to match a specific SCiLS
project's axis. If someone finds the version that states 17 mDa, this can go
back to being a reproduction claim — with a citation.

## 2. The axis-type table gains the current SCiLS names

Thyra's names are SCiLS's **legacy** names. The table now carries both:

| Thyra | In SCiLS Lab | Law |
|---|---|---|
| `constant` | Constant (equidistant) | constant Da |
| `linear_tof` | **Axial TOF** (was "Linear TOF") | `sqrt(m/z)` |
| `reflector_tof` | **Orthogonal TOF** (was "Reflector TOF") | `m/z` |
| `orbitrap` | Orbitrap | `m/z^1.5` |
| `fticr` | **MRMS** (Fourier-transform) | `m/z^2` |

The laws are unchanged; only the labels moved. This also finally cites the
claim the page has been making without one: these five types and their scaling
laws are what SCiLS offers for the common mass axis (2026b User Guide, p.75).

## 3. Three docs still recommended a pairing the docs forbid

`docs/resampling.md` carries a `!!! danger` box saying not to combine
`tic_preserving` with a non-uniform axis type, with measured numbers: two ions
of equal abundance come back with their ratio distorted by 1.9x on
`linear_tof`, 3.7x on `reflector_tof`, **7.0x on `orbitrap`**, 13.4x on
`fticr`.

Three examples did exactly that:

- `docs/resampling.md` — its own Python tab, `tic_preserving` + `orbitrap`;
- `docs/api.md` — identical snippet under "With resampling configuration";
- `docs/getting-started.md` — `--resample-method tic_preserving
  --mass-axis-type orbitrap`, headed "Physics-based resampling for Orbitrap
  data".

PR #124 fixed the CLI tab and left these three. All now use
`nearest_neighbor`, which moves each peak into a single bin and is unaffected
by bin width, with a sentence in `getting-started.md` explaining why.

## 4. The Orbitrap/FT-ICR dead-code warning: checked, still accurate

The handout flagged this for review once item 3 landed. Verified on the
post-item-3 tree: reading the declared `MS:1000127`/`MS:1000128` accession
changed how *spectrum representation* is detected, not how `instrument_type`
is populated. A grep over `thyra/` confirms `rapiflex_reader.py:139` is still
the only writer of that key, hardcoding `"MALDI-TOF"`, so both detectors
remain unreachable and the warning stands.

What *did* change is which row such data lands on, and the warning now says
so: a profile-mode Orbitrap file reports profile correctly and falls to the
default row (`constant`), instead of being misread as centroid and given
`reflector_tof`.

## Verification

`mkdocs build --strict` passes. Docs-only, so the lint hooks skip; the full
test suite is unaffected and still green from #127.
