### PR TITLE
fix(imzml): parse with ElementTree so unindented CRLF files load

### DIFF
--- a/tests/unit/readers/test_imzml_reader.py
+++ b/tests/unit/readers/test_imzml_reader.py
@@ -2,10 +2,40 @@
 Tests for the imzML reader.
 """
 
+from pathlib import Path
+
 import numpy as np
 import pytest
+from pyimzml.ImzMLWriter import ImzMLWriter
 
+from thyra.readers.imzml import imzml_reader as imzml_reader_module
 from thyra.readers.imzml.imzml_reader import ImzMLReader
+
+
+def write_crlf_unindented_imzml(directory: Path, n_spectra: int) -> Path:
+    """Write an imzML laid out the way IONTOF SurfaceLab writes it.
+
+    pyimzml's writer indents its output and terminates lines with LF. IONTOF
+    emits neither, so the only text between a spectrum's close tag and the
+    next one's open tag is a bare carriage-return/newline pair. That exact
+    layout is what trips libxml2 (see ``_initialize_parser``), so a fixture
+    only guards the bug if it reproduces the formatting.
+
+    Rewriting the whitespace is semantically a no-op -- imzML carries no mixed
+    content -- and the .ibd is left untouched, so every offset stays valid.
+    """
+    imzml_path = directory / f"crlf_{n_spectra}.imzML"
+    mzs = np.linspace(100.0, 500.0, 5)
+    intensities = np.arange(1.0, 6.0)
+
+    with ImzMLWriter(str(imzml_path), mode="processed") as writer:
+        for i in range(n_spectra):
+            writer.addSpectrum(mzs, intensities, (i % 8 + 1, i // 8 + 1, 1))
+
+    normalised = imzml_path.read_bytes().replace(b"\r\n", b"\n")
+    lines = [line.lstrip(b" \t") for line in normalised.split(b"\n")]
+    imzml_path.write_bytes(b"\r\n".join(lines))
+    return imzml_path
 
 
 class TestImzMLReader:
@@ -222,3 +252,80 @@ class TestImzMLReader:
 
         assert count == 4, f"Expected 4 spectra, got {count}"
         reader.close()
+
+
+class TestCrlfUnindentedImzML:
+    """Unindented CRLF imzML (IONTOF SurfaceLab) must parse.
+
+    pyimzml removes each <spectrum> from the tree while iterparse is still
+    streaming. Under lxml that leaves libxml2's text-node accelerator pointing
+    at a freed node, and on this one layout the parser eventually dies with
+    ``XMLSyntaxError: xmlSAX2Characters`` -- an out-of-memory error dressed up
+    as a syntax error, on a file that is perfectly well-formed.
+    """
+
+    def test_parser_is_not_constructed_with_lxml(
+        self, create_minimal_imzml, monkeypatch
+    ):
+        """Pin the parser choice: lxml is unsafe for pyimzml's pruning loop.
+
+        This asserts on the constructor argument rather than on behaviour
+        because reproducing the corruption needs a ~16k-spectrum file, and the
+        exact threshold shifts with heap layout. The behavioural test below
+        covers it where it reproduces; this one holds the line everywhere else.
+        """
+        imzml_path, _, _, _ = create_minimal_imzml
+        recorded = {}
+        real_parser = imzml_reader_module.ImzMLParser
+
+        def recording_parser(*args, **kwargs):
+            recorded.update(kwargs)
+            return real_parser(*args, **kwargs)
+
+        monkeypatch.setattr(imzml_reader_module, "ImzMLParser", recording_parser)
+
+        reader = ImzMLReader(imzml_path)
+        reader.get_essential_metadata()
+        reader.close()
+
+        assert recorded.get("parse_lib") != "lxml"
+
+    def test_reads_crlf_unindented_file(self, temp_dir):
+        """The IONTOF layout round-trips through the reader."""
+        imzml_path = write_crlf_unindented_imzml(temp_dir, 16)
+
+        # Guard the fixture itself: if the writer or the reformatting changes
+        # so the file is no longer unindented CRLF, this stops testing the
+        # thing it claims to test.
+        raw = imzml_path.read_bytes()
+        assert b"\r\n<spectrum" in raw, "fixture is not unindented CRLF"
+
+        reader = ImzMLReader(imzml_path)
+        coordinates = [coords for coords, _, _ in reader.iter_spectra()]
+        reader.close()
+
+        assert len(coordinates) == 16
+        # 16 spectra written across an 8-wide grid, 1-based in the file and
+        # 0-based once the reader has converted them.
+        assert coordinates[0] == (0, 0, 0)
+        assert coordinates[-1] == (7, 1, 0)
+
+    def test_reads_crlf_file_large_enough_to_corrupt_lxml(self, temp_dir):
+        """The size that actually reproduces the libxml2 failure.
+
+        Below roughly 16k spectra the stale-offset writes stay inside the
+        buffer libxml2 already had, so the parse survives and proves nothing.
+        The exact threshold moves with heap layout, so this may not reproduce
+        on every platform -- but it can only ever under-report, never fail on
+        correct code, since ElementTree does not go near libxml2. Deliberately
+        NOT marked integration: CI runs -m "not integration", and this is the
+        only test that exercises the actual defect. Costs ~2s and a ~33 MB
+        temporary file.
+        """
+        imzml_path = write_crlf_unindented_imzml(temp_dir, 16000)
+
+        reader = ImzMLReader(imzml_path)
+        essential = reader.get_essential_metadata()
+        reader.close()
+
+        assert essential.n_spectra == 16000

--- a/thyra/readers/imzml/imzml_reader.py
+++ b/thyra/readers/imzml/imzml_reader.py
@@ -399,9 +399,26 @@ class ImzMLReader(BaseMSIReader):
         # Initialize the parser
         logger.info(f"Initializing ImzML parser for {imzml_path}")
         try:
+            # ElementTree, NOT lxml. pyimzml prunes each <spectrum> out of the
+            # tree (`slist.remove(elem)`) while iterparse is still streaming the
+            # document, which invalidates libxml2's text-node coalescing
+            # accelerator: ctxt->nodelen/nodemem go on describing a text node
+            # inside the subtree that was just removed, so later character data
+            # is appended at a stale offset and the buffer is doubled on every
+            # miss until xmlRealloc fails. lxml surfaces libxml2's
+            # XML_ERR_NO_MEMORY as a *syntax* error, so it reads as a corrupt
+            # file when nothing is wrong with it:
+            #     XMLSyntaxError: xmlSAX2Characters, line 212575, column 1
+            # It only bites when the text between </spectrum> and <spectrum> is
+            # exactly "\r\n" -- CRLF with no indentation, how IONTOF SurfaceLab
+            # writes imzML. Indented or LF-only files coalesce differently and
+            # survive, which is why most files never hit it. ElementTree builds
+            # the tree in Python, so there is no C parser state to invalidate;
+            # it is also pyimzml's own default, parses byte-identically, and is
+            # faster here -- 67s vs 118s on a 2.1 GB imzML at the same peak RSS.
             self.parser = ImzMLParser(
                 filename=str(imzml_path),
-                parse_lib="lxml",
+                parse_lib="ElementTree",
                 ibd_file=self.ibd_file,
             )
         except Exception as e:


### PR DESCRIPTION
`thyra convert test_data/bellini.imzML` has never worked. It dies immediately with

```
lxml.etree.XMLSyntaxError: xmlSAX2Characters, line 212575, column 1
```

Found while trying to run an end-to-end conversion to verify something else. Pre-existing on
unmodified `main`, unrelated to the resampling work.

## Does this change stored values?

**No.** This changes which XML library parses the imzML header, not what is parsed out of it.
On `pea.imzML`, where both libraries work, every field pyimzml produces compares equal:
coordinates, `mzOffsets`, `intensityOffsets`, `mzLengths`, `intensityLengths`, both precisions,
both group ids, polarity, spectrum mode, and the whole `imzmldict`. Files that converted before
convert to the same bytes; `bellini.imzML` converts at all for the first time.

## The defect

It is not a malformed file, not an encoding problem, and not the empty spectrum on line 212575.

`XMLSyntaxError` is a disguise. Reading `e.error_log[0]` gives the real error:

```
domain=PARSER  type=ERR_NO_MEMORY  level=ERROR  line=212575 col=1  message='xmlSAX2Characters'
```

That is libxml2's `xmlSAX2ErrMemory`, whose message is just the name of the function that raised
it. lxml surfaces `XML_ERR_NO_MEMORY` as a *syntax* error, so a well-formed file reads as a
corrupt one.

The cause is in pyimzml. `__iter_read_spectrum_meta` prunes each spectrum as it goes:

```python
elif elem.tag == self.sl + "spectrum" and event == "end":
    self.__process_spectrum(elem, include_spectra_metadata)
    slist.remove(elem)          # <- mutating a tree lxml is still building
```

libxml2 keeps an accelerator for appending to the text node it is currently filling —
`ctxt->nodelen` and `ctxt->nodemem`. Removing the subtree does not reset it, so it goes on
describing a text node that no longer exists. Subsequent character data is memcpy'd into the
surviving whitespace node at a stale offset, and the buffer is doubled on every miss until
`xmlRealloc` finally fails.

Evidence: replaying exactly that loop reproduces the failure at exactly line 212575, while the
same walk with the `remove` taken out completes all 622,716 events. `huge_tree=True` makes no
difference, which rules out the text-node size limit.

## What actually triggers it

Not empty spectra. **Every** spectrum in all three local test files carries
`defaultArrayLength="0"` -- 16384 in bellini, 12737 in pea, 918855 in the Xenium export. That is
normal for processed-mode imzML; the real length lives in the `IMS:1000103` cvParam. pea and
Xenium survive the identical pruning loop.

The discriminator is the whitespace between `</spectrum>` and `<spectrum>`. It has to be exactly
CRLF, with no indentation, for the stale-offset writes to land where they do damage. Both
conditions are necessary -- synthetic files, 20000 spectra each:

| | unindented | indented |
|---|---|---|
| **CRLF** | fails at spectrum 3963 | ok |
| **LF** | ok | ok |

bellini is unindented CRLF, which is how IONTOF SurfaceLab writes imzML. pea and Xenium are
indented LF, which is how pyimzml's own writer does it. That is the whole difference.

## The fix

Parse with ElementTree. This is not a workaround with a cost attached:

- It is **pyimzml's own default**. The `parse_lib="lxml"` opt-in has been there since the
  initial commit in Feb 2025 and was never benchmarked.
- It is **faster**. On the 2.1 GB Xenium imzML: **67.2s vs 117.8s**, at the same peak RSS
  (347 MB vs 350 MB). pyimzml's `slist.remove` is a C-tree splice under lxml and a list
  operation under ElementTree, and the doubling reallocs above are pure waste.
- It builds the tree in Python, so there is no C parser state left to invalidate.

I did not add an lxml-first-with-fallback path. It would keep a corrupting parser on the happy
path for no speed, and pay for a full re-parse whenever it trips.

`remove_blank_text=True` also cures it, but reaching it means monkeypatching
`pyimzml.ImzMLParser.choose_iterparse`, which is worse than using the supported argument.

## Tests

Three, in `TestCrlfUnindentedImzML`. Two of them fail on unfixed code with the original error.

- `test_parser_is_not_constructed_with_lxml` asserts the constructor argument. Deliberately an
  implementation test: the behavioural reproduction needs ~16k spectra and its exact threshold
  moves with heap layout, so this is what holds the line cheaply and everywhere.
- `test_reads_crlf_unindented_file` reads a 16-spectrum unindented-CRLF file through
  `ImzMLReader`. Asserts the fixture really is unindented CRLF first, so it cannot quietly stop
  testing what it claims to.
- `test_reads_crlf_file_large_enough_to_corrupt_lxml` is the real reproduction, at 16000
  spectra. **Not** marked `integration`, because CI runs `-m "not integration"` and this is the
  only test that exercises the actual defect. Costs ~2.4s and a ~33 MB temp file. It can
  under-report on a platform whose allocator behaves differently, but it can never fail on
  correct code -- ElementTree does not go near libxml2.

The fixture is built by writing a real imzML with pyimzml's writer and then rewriting only the
whitespace. The `.ibd` is untouched, so every offset stays valid.

## Verification

- `bellini.imzML` now reads completely: 16384 spectra, 36,371,295 peaks, including spectrum
  11185 at `(49, 87, 0)` -- the one it used to die on. Parse plus metadata, 0.98s.
- `thyra convert test_data/bellini.imzML` now **completes**, having never run before:
  16384 spectra at ~168 spectrum/s, 36,292,563 non-zero entries written as CSC, SpatialData
  saved, exit 0. Ten minutes end to end, nearly all of it the zarr write -- resampling picks a
  2,373,513-bin reflector-TOF axis for this file.
- Full suite: 1008 passed, 11 skipped. All pre-commit hooks clean.
- Audit: this was Thyra's only exposure. There are no direct lxml imports anywhere in `thyra/`,
  and the other `iterparse` site (`imzml_extractor.py:558`) is ElementTree and does not mutate.

## Upstream

This is a pyimzml bug and will bite any lxml user of it. pyimzml is not actively maintained, so
handling it here is the practical answer.
