### PR TITLE
ci: run tests on stacked PRs, not only on PRs into main

### DIFF
--- a/.github/workflows/complexity-monitoring.yml
+++ b/.github/workflows/complexity-monitoring.yml
@@ -3,8 +3,11 @@ name: Complexity Monitoring
 on:
   push:
     branches: [ main, develop ]
+  # Deliberately unfiltered, as in tests.yml: `branches:` here would match the
+  # PR's BASE branch, which silently excludes stacked PRs. The `push:` filter
+  # above is left narrow on purpose -- this should not start running on every
+  # push to every feature branch, only on the PRs those branches open.
   pull_request:
-    branches: [ main, develop ]
   schedule:
     # Run weekly on Sundays at 2 AM UTC
     - cron: '0 2 * * 0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,13 @@
 name: Tests
 
 on:
+  # Deliberately unfiltered. `branches:` on a pull_request trigger matches the
+  # BASE branch, not the head, so `branches: [ main ]` skipped every stacked PR
+  # (one feature branch based on another) until its parent merged and GitHub
+  # retargeted it onto main -- i.e. the tests only ran after review, never
+  # before. There is no `push:` trigger in this workflow, so accepting every
+  # base branch cannot double up with anything.
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## The problem

`branches:` on a `pull_request` trigger filters on the PR's **base** branch, not
its head. Both CI workflows listed only `main`:

- `.github/workflows/tests.yml` -> `pull_request: branches: [ main ]`
- `.github/workflows/complexity-monitoring.yml` -> `pull_request: branches: [ main, develop ]`

A PR based on another feature branch matches neither list, so **nothing runs at
all**. This repo genuinely uses stacked PRs, so this is not hypothetical.

Reproduced before changing anything:

```
gh pr checks 126   # base=main                                       -> 7 checks, all pass
gh pr checks 127   # base was #126's branch, now retargeted to main  -> 7 checks (see below)
gh pr checks 130   # base=fix/spectrum-representation-from-accession -> "no checks reported"
```

#127 is the mechanism caught in the act. It was based on #126's branch and had
no checks; when #126 merged, GitHub retargeted #127 onto `main` and only then
did CI start. The green tick arrives *after* the review it was supposed to
inform.

Then it happened a second time, live, while this PR was being written. #127
merged at 14:00:59, which retargeted #130 onto `main` at 14:01:24 -- and only
at that moment did #130 get its first checks, under the *old* trigger. #130
merged at 14:05:13, about four minutes after CI first saw it. So both stacked
PRs in this stack did eventually go green, but neither was tested at any point
when the result could have informed a review. That is the whole failure mode in
one afternoon.

Worth noting: `main` has no branch protection, so there is no required-check
gate either. Nothing stops an untested stacked PR from being merged.

## The change

Drop the `branches:` filter from the `pull_request` trigger in both workflows.
Nothing else.

## What now triggers, and what does not

**Tests** (`tests.yml`)

- Now runs on **every** pull request regardless of base branch, including
  stacked ones.
- Still runs on `workflow_dispatch`.
- Still has **no** `push:` trigger, so pushing to a branch with no PR open
  runs nothing.

**Complexity Monitoring** (`complexity-monitoring.yml`)

- Now runs on **every** pull request regardless of base branch.
- `push:` is **unchanged**, still `[ main, develop ]`. Pushing to a feature
  branch does not trigger it; only the PR that branch opens does.
- The weekly Sunday `schedule:` is unchanged.

**Unchanged entirely**

- `docs.yml` -- still `push` to `main` only, still path-filtered to
  `docs/**`, `mkdocs.yml`, `thyra/**`.
- `release.yml` -- still `push` to `main`, `release: published`, and
  `workflow_dispatch`.

Merging this does not cut a release: `ci` is in `allowed_tags` but in neither
`minor_tags` nor `patch_tags`, and `ci*` is in `changelog.exclude_commit_patterns`.

One thing a reviewer might reasonably worry about, checked and cleared: the
complexity workflow runs the monitor in `--files-changed` mode on PRs, and that
script hardcodes `git diff origin/main...HEAD`, which would give a stacked PR
the union of its own changes and its parent's. In practice it never gets that
far -- the checkout is shallow, `origin/main` does not resolve, and the script
already falls back to scanning the whole repo on *every* PR, main-based ones
included:

```
Warning: Could not detect changed files via git: ... returned non-zero exit status 128.
Falling back to analyzing all files
```

So stacked PRs get exactly the same full analysis every other PR gets, and this
change introduces no new inaccuracy. The dead fast-mode is a real but separate
pre-existing bug and is not addressed here.

## Run volume: does anything double-run?

No. Measured, not assumed -- see the run count in the next section: **4 runs for
2 PR-opened events**, i.e. exactly one `Tests` + one `Complexity Monitoring` per
event, and zero `push` runs.

The reasoning behind that:

- `tests.yml` has no `push:` trigger whatsoever, so a PR run is the only run
  that can exist for a commit. Duplication is structurally impossible.
- `complexity-monitoring.yml` keeps its narrow `push: [ main, develop ]`. A
  stacked PR's head branch is neither, so it gets exactly one run -- the
  `pull_request` one.
- The only shape that could double up is a PR whose *head* is `main` or
  `develop` (a back-merge). That was already true before this change for
  `develop -> main`, so it is not newly introduced -- and `develop` does not
  exist in this repo at all (`git ls-remote --heads origin develop` is empty),
  which makes it moot. The `develop` entries in the `push:` filter are
  vestigial; I left them alone rather than widen the scope of this PR.

Net effect on run volume: one extra `Tests` run and one extra
`Complexity Monitoring` run per stacked PR that previously ran nothing. That is
the entire point.

## Verified empirically, not just by reading the docs

I opened a throwaway draft PR (#133, since closed) from this same branch but
targeting **`fix/spectrum-representation-from-accession`** instead of `main`, to
check that the unfiltered trigger really does fire on a non-main base.

All workflow runs on this branch:

```
2026-08-01T14:01:58Z  Complexity Monitoring  event=pull_request   <- #133 opened (base = feature branch)
2026-08-01T14:01:58Z  Tests                  event=pull_request   <- #133 opened
2026-08-01T14:00:27Z  Tests                  event=pull_request   <- #132 opened (base = main)
2026-08-01T14:00:27Z  Complexity Monitoring  event=pull_request   <- #132 opened
total runs on branch: 4
```

All four completed `success`.

Two conclusions:

1. **The fix works.** Opening a PR onto a feature-branch base produced real
   runs. Before this change it produced none.
2. **GitHub does not read the workflow file from the base branch.** #133's base
   branch still contains the *old* filtered trigger, and the run fired anyway.
   Only this PR's head carried the fix. So the trigger config is resolved from
   the PR's merge ref (head merged into base), not from the base.

## Consequence worth knowing: the fix has to be *in* the stacked PR to help it

Conclusion 2 means merging this to `main` does not retroactively rescue a
stacked PR that is already open. Such a PR's merge ref is its head merged into
its base; if neither branch contains this commit, landing it on `main` changes
nothing for it and it keeps reporting no checks.

This is moot for #126/#127/#130 -- that whole stack merged today. But for any
stacked PR opened from branches cut *before* this lands (`fix/scils-bin-cap`,
`fix/optimize-chunks-sparse`, `fix/interp-gap-tolerance`,
`build/drop-py311-upgrade-cluster`, `docs/anndata-hatch-precision` are all in
that category), the fix is to merge `main` into the stacked PR's base or head
once. After that the problem is self-correcting: any branch cut from `main` from
now on carries the trigger, so future stacked PRs are checked from the moment
they open.

## Until this lands

Anyone merging a stacked PR should run the suite locally and say so on the PR,
because the green tick they would normally look for does not exist for those
PRs. This afternoon's #130 is the cautionary example -- it merged with a green
tick, but that tick only appeared because its parent had merged four minutes
earlier, not because anything checked it while it was reviewable.
