### PR TITLE
ci(complexity): give --files-changed a base ref that exists, and stop guessing

### DIFF
--- a/.github/scripts/complexity_monitor.py
+++ b/.github/scripts/complexity_monitor.py
@@ -4,10 +4,25 @@
 import argparse
 import ast
 import json
+import os
+
+# nosec B404: CI tooling that shells out to git with a fixed argument list and
+# no shell. B603 and B607, which cover the calls themselves, are already
+# skipped repository-wide in pyproject.toml.
+import subprocess  # nosec B404
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, NamedTuple
+
+# Generous enough that a cold pack on a CI runner cannot make the timeout the
+# thing that fails the build: since --files-changed now refuses to guess, a
+# timeout here is a hard error rather than a quiet fallback.
+GIT_TIMEOUT_SECONDS = 30
+
+# Distinct from 1 ("complexity violations found") so that a broken --files-changed
+# mode cannot be mistaken for a code-quality failure.
+EXIT_CHANGED_FILES_UNKNOWN = 2
 
 
 class ComplexityResult(NamedTuple):
@@ -160,60 +175,133 @@ def find_python_files(root_dir: Path) -> List[Path]:
     return python_files
 
 
-def get_changed_files() -> List[Path]:
-    """Get list of changed Python files from git diff.
+class ChangedFiles(NamedTuple):
+    """The changed Python files, and the git ref they were compared against."""
 
-    Compares current branch against origin/main to find modified files.
-    Falls back to comparing against HEAD~1 if origin/main doesn't exist.
-    Returns empty list if git operations fail.
+    base_ref: str
+    files: List[Path]
+
+
+class ChangedFilesError(RuntimeError):
+    """Raised when the set of changed files cannot be determined.
+
+    This is deliberately not representable as an empty file list: "nothing
+    changed" and "we have no idea what changed" call for opposite responses,
+    and conflating them is what let --files-changed scan the whole repository
+    while announcing itself as fast mode.
+    """
+
+
+def _run_git(args: List[str]) -> "subprocess.CompletedProcess[str]":
+    """Run a git command and return it without raising on a non-zero status.
+
+    Args:
+        args: Arguments after ``git`` itself.
 
     Returns:
-        List of Path objects for changed Python files that exist
-    """
-    # nosec B404: CI tooling that shells out to git with a fixed argument
-    # list and no shell. B603 and B607, which cover the calls themselves,
-    # are already skipped repository-wide in pyproject.toml.
-    import subprocess  # nosec B404
+        The completed process, whatever its exit status. Callers decide what a
+        failure means; nothing here falls through to a silent default.
 
+    Raises:
+        ChangedFilesError: if git could not be run at all.
+    """
     try:
-        # Try comparing against origin/main first
-        result = subprocess.run(
-            ["git", "diff", "--name-only", "origin/main...HEAD"],
+        return subprocess.run(
+            ["git", *args],
             capture_output=True,
             text=True,
-            check=True,
-            timeout=5,
+            check=False,
+            timeout=GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ChangedFilesError(f"could not run `git {' '.join(args)}`: {exc}") from exc
+
+
+def _base_ref_candidates() -> List[str]:
+    """Return the refs to compare against, most authoritative first.
+
+    On a GitHub ``pull_request`` run, GITHUB_BASE_REF holds the branch the PR
+    targets, which is not necessarily ``main``: this workflow also runs on
+    stacked PRs, whose base is another feature branch. A stacked PR diffed
+    against ``main`` reports the union of its own changes and its parent's, so
+    when the real base is known it is the only acceptable answer -- there is no
+    fallback to ``main`` from here.
+    """
+    base_branch = os.environ.get("GITHUB_BASE_REF", "").strip()
+    if base_branch:
+        return [f"origin/{base_branch}", base_branch]
+
+    # Not a pull_request run: a developer invoking this by hand, or a push or
+    # schedule run that passed --files-changed anyway.
+    return ["origin/main", "main", "HEAD~1"]
+
+
+def _resolve_base_ref() -> str:
+    """Return the first candidate base ref that exists in this checkout.
+
+    Returns:
+        A ref name that ``git diff`` can resolve.
+
+    Raises:
+        ChangedFilesError: if none of the candidates exist, which on CI almost
+            always means the checkout is too shallow to contain the base branch.
+    """
+    candidates = _base_ref_candidates()
+    for ref in candidates:
+        # --verify --quiet exits non-zero rather than printing when the ref is
+        # missing, which is what separates "no such ref" from "diff failed".
+        probe = _run_git(["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"])
+        if probe.returncode == 0:
+            return ref
+
+    base_branch = os.environ.get("GITHUB_BASE_REF", "").strip()
+    if base_branch:
+        hint = (
+            f"GITHUB_BASE_REF is {base_branch!r}, so this is a pull_request run "
+            "whose checkout does not contain its own base branch. Give "
+            "actions/checkout `fetch-depth: 0`."
+        )
+    else:
+        hint = (
+            "GITHUB_BASE_REF is unset. Set it to the branch to compare against, "
+            "or run this from a checkout that has an origin/main ref."
+        )
+    raise ChangedFilesError(
+        f"no base ref found (tried: {', '.join(candidates)}). {hint}"
+    )
+
+
+def get_changed_files() -> ChangedFiles:
+    """Get the Python files changed relative to this branch's base.
+
+    Returns:
+        The base ref that was used, and the changed Python files that still
+        exist on disk. An empty file list means exactly that: the diff was
+        computed and touched no Python file.
+
+    Raises:
+        ChangedFilesError: if the base ref cannot be resolved or the diff fails.
+    """
+    base_ref = _resolve_base_ref()
+
+    result = _run_git(["diff", "--name-only", f"{base_ref}...HEAD"])
+    if result.returncode != 0:
+        raise ChangedFilesError(
+            f"`git diff --name-only {base_ref}...HEAD` exited "
+            f"{result.returncode}: {result.stderr.strip()}"
         )
 
-        if result.returncode != 0 or not result.stdout.strip():
-            # Fallback: compare against HEAD~1
-            result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=5,
-            )
+    changed = []
+    for line in result.stdout.splitlines():
+        name = line.strip()
+        if not name.endswith(".py"):
+            continue
+        path = Path(name)
+        # Deleted files are in the diff but cannot be analysed.
+        if path.exists():
+            changed.append(path)
 
-        files = result.stdout.strip().split("\n")
-        python_files = []
-
-        for f in files:
-            if f and f.endswith(".py"):
-                file_path = Path(f)
-                if file_path.exists():
-                    python_files.append(file_path)
-
-        return python_files
-
-    except (
-        subprocess.CalledProcessError,
-        subprocess.TimeoutExpired,
-        FileNotFoundError,
-    ) as e:
-        print(f"Warning: Could not detect changed files via git: {e}")
-        print("Falling back to analyzing all files")
-        return []
+    return ChangedFiles(base_ref=base_ref, files=changed)
 
 
 def generate_report(results: List[ComplexityResult], threshold: int) -> Dict:
@@ -294,7 +382,12 @@ def main():
     parser.add_argument(
         "--files-changed",
         action="store_true",
-        help="Only analyze files changed compared to main branch (speeds up PR checks)",
+        help=(
+            "Only analyze files changed against this branch's base -- "
+            "$GITHUB_BASE_REF on a pull_request run, otherwise origin/main "
+            f"(speeds up PR checks; exits {EXIT_CHANGED_FILES_UNKNOWN} if the "
+            "base cannot be resolved)"
+        ),
     )
 
     args = parser.parse_args()
@@ -309,18 +402,24 @@ def main():
 
     # Filter to only changed files if requested
     if args.files_changed:
-        changed_files = get_changed_files()
-        if changed_files:
-            # Filter python_files to only include changed files
-            changed_files_set = set(changed_files)
-            python_files = [f for f in python_files if f in changed_files_set]
-            if not args.quiet:
-                print(
-                    f"Analyzing {len(python_files)} changed files (--files-changed mode)"
-                )
-        else:
-            if not args.quiet:
-                print("Warning: Could not detect changed files, analyzing all files")
+        try:
+            changed = get_changed_files()
+        except ChangedFilesError as e:
+            print(
+                f"ERROR: --files-changed cannot tell which files changed: {e}",
+                file=sys.stderr,
+            )
+            print(
+                "ERROR: refusing to scan the whole repository and call it fast mode.",
+                file=sys.stderr,
+            )
+            return EXIT_CHANGED_FILES_UNKNOWN
+
+        changed_files_set = set(changed.files)
+        python_files = [f for f in python_files if f in changed_files_set]
+        if not args.quiet:
+            print(f"Comparing against base ref: {changed.base_ref}")
+            print(f"Analyzing {len(python_files)} changed files (--files-changed mode)")
 
     if not python_files:
         if not args.quiet:

--- a/.github/workflows/complexity-monitoring.yml
+++ b/.github/workflows/complexity-monitoring.yml
@@ -24,6 +24,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # The monitor's --files-changed mode diffs this checkout against the
+        # PR's base branch, so that ref has to be here. The default
+        # fetch-depth: 1 leaves a shallow clone that has no base branch at all,
+        # which is what made fast mode dead on every PR: the diff exited 128
+        # and the script quietly scanned the whole repository instead.
+        # `git fetch --depth=1 origin $GITHUB_BASE_REF` would be cheaper, but a
+        # three-dot diff needs a common ancestor and two depth-1 tips have none.
+        # The cost is small enough not to be worth that risk: a full clone of
+        # this repo packs to 26 MiB against 12 MiB shallow, next to a
+        # `poetry install` that dominates the job either way.
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -84,6 +96,9 @@ jobs:
 
         if [ $COMPLEXITY_EXIT_CODE -eq 0 ]; then
           echo "SUCCESS: No complexity violations found"
+        elif [ $COMPLEXITY_EXIT_CODE -eq 2 ]; then
+          echo "BROKEN: The monitor could not work out which files changed (see the error above)."
+          echo "BROKEN: This is a CI configuration problem, not a complexity violation."
         else
           echo "FAILURE: Complexity violations found (exit code: $COMPLEXITY_EXIT_CODE)"
         fi

--- a/tests/unit/tools/test_complexity_monitor.py
+++ b/tests/unit/tools/test_complexity_monitor.py
@@ -1,0 +1,291 @@
+# tests/unit/tools/test_complexity_monitor.py
+"""Tests for the CI complexity monitor's ``--files-changed`` fast mode.
+
+Fast mode was dead for the whole of its life: it hardcoded a diff against
+``origin/main``, which a shallow ``actions/checkout`` does not provide, and the
+resulting failure was swallowed into an empty file list that the caller read as
+"could not detect changes, analyze everything". Every PR ran a full-repository
+scan while the log announced fast mode.
+
+These tests therefore drive the real thing against real throwaway git
+repositories -- a mocked ``subprocess`` would have happily agreed with the
+broken version.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_MONITOR_PATH = (
+    Path(__file__).resolve().parents[3]
+    / ".github"
+    / "scripts"
+    / "complexity_monitor.py"
+)
+
+
+def _load_monitor():
+    """Import the monitor by path: .github/scripts is not an importable package."""
+    spec = importlib.util.spec_from_file_location("complexity_monitor", _MONITOR_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+monitor = _load_monitor()
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run git in ``repo`` with an identity, so this works on a bare CI runner."""
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _commit(repo: Path, relative: str, body: str, message: str) -> None:
+    """Write a file and commit it."""
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", message)
+
+
+@pytest.fixture
+def stacked_repo(tmp_path):
+    """A repo with a PR branch stacked on another feature branch.
+
+    ``main`` -> ``parent`` (adds thyra/parent.py) -> ``child`` (adds
+    thyra/child.py), with an ``origin`` remote carrying all three, the way a
+    checkout with ``fetch-depth: 0`` sees them.
+    """
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    _git(upstream, "init", "-b", "main")
+    _commit(upstream, "thyra/base.py", "def base():\n    return 1\n", "base")
+
+    _git(upstream, "checkout", "-b", "parent")
+    _commit(upstream, "thyra/parent.py", "def parent():\n    return 2\n", "parent")
+
+    _git(upstream, "checkout", "-b", "child")
+    _commit(upstream, "thyra/child.py", "def child():\n    return 3\n", "child")
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", str(upstream), str(clone))
+    _git(clone, "checkout", "child")
+    return clone
+
+
+@pytest.mark.unit
+def test_stacked_pr_diffs_against_its_own_base_not_main(
+    stacked_repo, monkeypatch
+) -> None:
+    """A PR based on a feature branch must not inherit that branch's changes."""
+    monkeypatch.chdir(stacked_repo)
+    monkeypatch.setenv("GITHUB_BASE_REF", "parent")
+
+    changed = monitor.get_changed_files()
+
+    assert changed.base_ref == "origin/parent"
+    assert [p.as_posix() for p in changed.files] == ["thyra/child.py"], (
+        "a stacked PR diffed against main would also report thyra/parent.py, "
+        "which belongs to the parent PR"
+    )
+
+
+@pytest.mark.unit
+def test_pr_against_main_reports_only_its_own_changes(
+    stacked_repo, monkeypatch
+) -> None:
+    """The ordinary case still works: base main, both branch commits reported."""
+    monkeypatch.chdir(stacked_repo)
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+
+    changed = monitor.get_changed_files()
+
+    assert changed.base_ref == "origin/main"
+    assert sorted(p.as_posix() for p in changed.files) == [
+        "thyra/child.py",
+        "thyra/parent.py",
+    ]
+
+
+@pytest.mark.unit
+def test_falls_back_to_a_local_branch_when_there_is_no_remote(
+    tmp_path, monkeypatch
+) -> None:
+    """Without an origin remote, the bare base branch name is still usable."""
+    repo = tmp_path / "local"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _commit(repo, "thyra/base.py", "def base():\n    return 1\n", "base")
+    _git(repo, "checkout", "-b", "feature")
+    _commit(repo, "thyra/feature.py", "def feature():\n    return 2\n", "feature")
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+
+    changed = monitor.get_changed_files()
+
+    assert changed.base_ref == "main"
+    assert [p.as_posix() for p in changed.files] == ["thyra/feature.py"]
+
+
+@pytest.mark.unit
+def test_shallow_checkout_raises_instead_of_returning_nothing(
+    tmp_path, monkeypatch
+) -> None:
+    """The bug's exact shape: no base ref must be an error, not an empty list."""
+    repo = tmp_path / "shallow"
+    repo.mkdir()
+    _git(repo, "init", "-b", "detached")
+    _commit(repo, "thyra/only.py", "def only():\n    return 1\n", "only")
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+
+    with pytest.raises(monitor.ChangedFilesError) as excinfo:
+        monitor.get_changed_files()
+
+    message = str(excinfo.value)
+    assert "origin/main" in message, "the message should name what it tried"
+    assert "fetch-depth: 0" in message, "the message should name the fix"
+
+
+@pytest.mark.unit
+def test_a_missing_base_ref_never_falls_back_to_main(tmp_path, monkeypatch) -> None:
+    """An unresolvable stacked base must fail, not quietly become main.
+
+    Falling back to main here would resurrect the original defect in a subtler
+    form: a plausible-looking file set that is wrong.
+    """
+    repo = tmp_path / "no-parent"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _commit(repo, "thyra/base.py", "def base():\n    return 1\n", "base")
+    _git(repo, "checkout", "-b", "child")
+    _commit(repo, "thyra/child.py", "def child():\n    return 2\n", "child")
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("GITHUB_BASE_REF", "parent-that-was-deleted")
+
+    with pytest.raises(monitor.ChangedFilesError):
+        monitor.get_changed_files()
+
+
+@pytest.mark.unit
+def test_no_changed_python_files_is_an_empty_list_not_a_failure(
+    tmp_path, monkeypatch
+) -> None:
+    """A docs-only PR analyzes nothing, rather than scanning the repository."""
+    repo = tmp_path / "docs-only"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _commit(repo, "thyra/base.py", "def base():\n    return 1\n", "base")
+    _git(repo, "checkout", "-b", "docs")
+    _commit(repo, "README.md", "# docs\n", "docs")
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+
+    changed = monitor.get_changed_files()
+
+    assert changed.files == []
+
+
+@pytest.mark.unit
+def test_deleted_files_are_dropped(tmp_path, monkeypatch) -> None:
+    """A file removed by the PR is in the diff but cannot be analysed."""
+    repo = tmp_path / "deletion"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _commit(repo, "thyra/gone.py", "def gone():\n    return 1\n", "gone")
+    _git(repo, "checkout", "-b", "remove")
+    (repo / "thyra" / "gone.py").unlink()
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "remove")
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+
+    assert monitor.get_changed_files().files == []
+
+
+@pytest.mark.unit
+def test_main_exits_two_and_analyzes_nothing_when_the_base_is_missing(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """--files-changed must fail loudly rather than full-scan under a fast-mode label.
+
+    This is the end-to-end version of the original bug: in CI the script printed
+    a warning and went on to analyze every file in the repository.
+    """
+    repo = tmp_path / "shallow-main"
+    repo.mkdir()
+    _git(repo, "init", "-b", "detached")
+    _commit(repo, "thyra/only.py", "def only():\n    return 1\n", "only")
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+    monkeypatch.setattr(
+        sys, "argv", ["complexity_monitor.py", "--files-changed", "--no-save"]
+    )
+
+    exit_code = monitor.main()
+
+    assert exit_code == monitor.EXIT_CHANGED_FILES_UNKNOWN
+    captured = capsys.readouterr()
+    assert "ERROR" in captured.err
+    assert "Analyzed" not in captured.out, "it must not have analyzed anything"
+    assert "analyzing all files" not in captured.out.lower()
+
+
+@pytest.mark.unit
+def test_main_reports_the_base_ref_it_used(stacked_repo, monkeypatch, capsys) -> None:
+    """The log must say what fast mode compared against, so it can be checked."""
+    monkeypatch.chdir(stacked_repo)
+    monkeypatch.setenv("GITHUB_BASE_REF", "parent")
+    monkeypatch.setattr(
+        sys, "argv", ["complexity_monitor.py", "--files-changed", "--no-save"]
+    )
+
+    exit_code = monitor.main()
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Comparing against base ref: origin/parent" in out
+    assert "Analyzing 1 changed files" in out
+
+
+@pytest.mark.unit
+def test_base_ref_candidates_do_not_include_main_when_a_base_is_known(
+    monkeypatch,
+) -> None:
+    """The candidate list itself encodes the rule, so pin it down."""
+    monkeypatch.setenv("GITHUB_BASE_REF", "some/feature-branch")
+    assert monitor._base_ref_candidates() == [
+        "origin/some/feature-branch",
+        "some/feature-branch",
+    ]
+
+    monkeypatch.delenv("GITHUB_BASE_REF")
+    assert monitor._base_ref_candidates() == ["origin/main", "main", "HEAD~1"]


### PR DESCRIPTION
## The bug

The `--files-changed` "fast mode" of `.github/scripts/complexity_monitor.py` has never once run. On every pull request it fell back to a full-repository scan, under a log line announcing fast mode.

From the Complexity Monitoring run on #132 ([run 30702877059](https://github.com/M4i-Imaging-Mass-Spectrometry/Thyra/actions/runs/30702877059)):

```
PR detected: Analyzing changed files only (fast mode)
Warning: Could not detect changed files via git: Command '['git', 'diff', '--name-only', 'origin/main...HEAD']' returned non-zero exit status 128.
Falling back to analyzing all files
Warning: Could not detect changed files, analyzing all files
```

Three faults stacked on top of each other:

1. `get_changed_files()` hardcoded `git diff origin/main...HEAD`, but `complexity-monitoring.yml` checks out with `actions/checkout` at the default `fetch-depth: 1`. For a `pull_request` that fetches **only** `refs/pull/N/merge` — there is no `origin/main` ref of any kind — so the diff exits 128.
2. The `HEAD~1` fallback below it was unreachable. The first call carried `check=True`, so its failure jumped straight past the fallback to the `except` clause.
3. The handler returned an empty list, which the caller could not distinguish from "nothing changed" and therefore read as "analyze everything".

This predates #132 and failed identically on PRs based on `main`.

## The fix

**`complexity_monitor.py`**

- Diff against `$GITHUB_BASE_REF` rather than a hardcoded `main`. Now that the `pull_request` trigger is unfiltered (#132), this workflow also runs on stacked PRs, whose base is another feature branch; against `origin/main` such a PR reports the union of its own changes and its parent's. When the real base is known there is deliberately **no** fallback to `main` — a plausible-looking wrong file set is the same defect in a subtler form. With `GITHUB_BASE_REF` unset (local use) the chain is `origin/main`, `main`, `HEAD~1`.
- Probe refs with `git rev-parse --verify --quiet` before using them, so candidates genuinely fall through to each other. Every git call now uses `check=False`; nothing routes a first failure into an exception handler.
- An unresolvable base raises `ChangedFilesError` instead of returning `[]`. `main()` turns that into **exit 2** — distinct from 1, "violations found" — with a message naming what it tried and what to do. It no longer scans the repository and calls that fast mode.
- An empty result now means only what it says: the diff ran and touched no Python file. A docs-only PR analyzes nothing and passes, instead of triggering a full scan.

**`complexity-monitoring.yml`**

- `fetch-depth: 0` on the checkout, so the base ref is actually present.
- The status echo distinguishes exit 2 (CI misconfiguration) from exit 1 (real violations), so a broken fast mode cannot be misread as a code-quality failure.

**`tests/unit/tools/test_complexity_monitor.py`** — 10 tests driving the real script against real throwaway git repositories. A mocked `subprocess` would have agreed with the broken version just as happily. All 10 pass against the fix; all 10 fail against the code being replaced.

## Verification

Reproduced the CI condition faithfully with `git init` + `git fetch --depth=1 origin +<sha>:refs/remotes/pull/1/merge`. Worth recording: a plain `git clone --depth=1 --branch main` **does** create `origin/main`, so it does not reproduce this bug — that near-miss is why the first attempt at a repro came back green.

| scenario | old script | this branch |
|---|---|---|
| shallow checkout, base `main` | exit status 128 → `analyzing all files` → **85 files, 674 functions**, exit 0 | exit **2**, names `fetch-depth: 0` as the fix |
| `fetch-depth: 0`, stacked base | — | 1 file (its own change) |
| `fetch-depth: 0`, base `main` | — | 2 files (the union the old hardcode produced) |

The first row reproduces the #132 log verbatim.

Because GitHub resolves a `pull_request` workflow file from the merge ref rather than the base, **this PR's own Complexity Monitoring run exercises the fix** — its log should read `Comparing against base ref: origin/main` with a real file count.

pre-commit (black, isort, flake8, mypy, bandit, pydocstyle) passes on all three files; the unit suite still collects 1051 tests.

## Notes

- **`fetch-depth: 0` over a cheaper shallow base fetch.** A `git fetch --depth=1 origin $GITHUB_BASE_REF` costs less, but a three-dot diff needs a common ancestor and two depth-1 tips have none. Measured before committing to it: a fresh full clone of this repo packs to **26 MiB** against 12 MiB shallow, negligible next to the `poetry install` that dominates this job either way. (A working checkout's `.git` can read far larger — 230 MiB here — but that is loose-object cruft from many worktrees, not history. The comment in the workflow records this so the decision is not re-litigated from the wrong number.)
- **Exit 2 fails the job.** A future CI-config regression now turns this check red rather than degrading quietly. That is the intent, but it is a behaviour change worth being aware of.
- **Not touched:** the "DIRECT COMPLEXITY CHECK (for debugging)" step at the end of the workflow runs with `--quiet`, which suppresses the violation printout too — so it emits its banner and nothing else on every run. Separate from this bug; left for its own change.
