### PR TITLE
ci(complexity): make --quiet mean what it says, and let the debug step speak

### DIFF
--- a/.github/scripts/complexity_monitor.py
+++ b/.github/scripts/complexity_monitor.py
@@ -24,6 +24,10 @@ GIT_TIMEOUT_SECONDS = 30
 # mode cannot be mistaken for a code-quality failure.
 EXIT_CHANGED_FILES_UNKNOWN = 2
 
+# The console listing is a pointer, not the record: every violation is in the
+# saved JSON report, which the workflow uploads as an artifact.
+TOP_VIOLATIONS_SHOWN = 5
+
 
 class ComplexityResult(NamedTuple):
     """Result of complexity analysis for a function."""
@@ -361,6 +365,23 @@ def generate_report(results: List[ComplexityResult], threshold: int) -> Dict:
     }
 
 
+def print_violations(report: Dict) -> None:
+    """Print the worst offenders in a report.
+
+    Lives outside the ``--quiet`` guard in :func:`main` on purpose. The flag
+    advertises "suppress output except violations", so this listing is the one
+    thing it must not silence.
+    """
+    print("Top violations:")
+    for i, func in enumerate(
+        report["high_complexity_functions"][:TOP_VIOLATIONS_SHOWN], 1
+    ):
+        print(
+            f"  {i}. {func['file']}:{func['line']} - "
+            f"{func['function']} ({func['complexity']})"
+        )
+
+
 def main():
     """Main function."""
     parser = argparse.ArgumentParser(description="Monitor cyclomatic complexity")
@@ -435,25 +456,27 @@ def main():
     # Generate report
     report = generate_report(all_results, args.threshold)
 
+    violations = report["total_violations"]
+
     # Print summary
     if not args.quiet:
         print(
             f"Analyzed {len(python_files)} files, {report['total_functions']} functions"
         )
         print(f"Complexity threshold: {args.threshold}")
-        print(f"Violations found: {report['total_violations']}")
+        print(f"Violations found: {violations}")
 
-        if report["total_violations"] > 0:
+        if violations > 0:
             print(f"Average complexity: {report['average_complexity']}")
             print(f"Maximum complexity: {report['max_complexity']}")
 
-            print("\nTop violations:")
-            for i, func in enumerate(report["high_complexity_functions"][:5], 1):
-                func_info = func["function"]
-                print(
-                    f"  {i}. {func['file']}:{func['line']} - "
-                    f"{func_info} ({func['complexity']})"
-                )
+    # Not guarded by --quiet: the flag reads "Suppress output except
+    # violations", and until now it suppressed these too, which left a
+    # --quiet run with no way to say anything at all.
+    if violations > 0:
+        if not args.quiet:
+            print()  # separate the listing from the statistics above it
+        print_violations(report)
 
     # Save report if requested
     if args.save and not args.no_save:

--- a/.github/workflows/complexity-monitoring.yml
+++ b/.github/workflows/complexity-monitoring.yml
@@ -205,7 +205,12 @@ jobs:
         echo ""
         echo "DIRECT COMPLEXITY CHECK (for debugging):"
         echo "================================="
-        poetry run python .github/scripts/complexity_monitor.py --threshold 15 --no-save --quiet || true
+        # No --quiet: that flag prints the violations and nothing else, so on a
+        # repository with none -- the steady state, and the state today -- this
+        # banner would introduce an empty stretch of log. What is wanted here is
+        # the whole-repo summary, which is also the part `--files-changed` runs
+        # above deliberately do not compute.
+        poetry run python .github/scripts/complexity_monitor.py --threshold 15 --no-save || true
 
     - name: Set complexity check status
       run: |

--- a/tests/unit/tools/test_complexity_monitor.py
+++ b/tests/unit/tools/test_complexity_monitor.py
@@ -1,5 +1,5 @@
 # tests/unit/tools/test_complexity_monitor.py
-"""Tests for the CI complexity monitor's ``--files-changed`` fast mode.
+"""Tests for the CI complexity monitor's ``--files-changed`` mode and output.
 
 Fast mode was dead for the whole of its life: it hardcoded a diff against
 ``origin/main``, which a shallow ``actions/checkout`` does not provide, and the
@@ -10,6 +10,10 @@ scan while the log announced fast mode.
 These tests therefore drive the real thing against real throwaway git
 repositories -- a mocked ``subprocess`` would have happily agreed with the
 broken version.
+
+The second group covers what the script prints. ``--quiet`` documented itself
+as "Suppress output except violations" while suppressing the violations too,
+which made it a flag with no output at any verbosity.
 """
 
 from __future__ import annotations
@@ -274,6 +278,120 @@ def test_main_reports_the_base_ref_it_used(stacked_repo, monkeypatch, capsys) ->
     out = capsys.readouterr().out
     assert "Comparing against base ref: origin/parent" in out
     assert "Analyzing 1 changed files" in out
+
+
+@pytest.fixture
+def tree_with_one_tangled_function(tmp_path):
+    """A working directory whose ``thyra`` package holds one function of complexity 4.
+
+    ``main`` analyzes ``./thyra`` when it exists, so the package name matters;
+    the threshold each test passes decides whether that function counts as a
+    violation.
+    """
+    package = tmp_path / "thyra"
+    package.mkdir()
+    (package / "tangled.py").write_text(
+        "def tangled(a, b, c):\n"
+        "    if a:\n"
+        "        return 1\n"
+        "    if b:\n"
+        "        return 2\n"
+        "    if c:\n"
+        "        return 3\n"
+        "    return 4\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.mark.unit
+def test_quiet_still_lists_the_violations(
+    tree_with_one_tangled_function, monkeypatch, capsys
+) -> None:
+    """The whole point of the flag: everything suppressed *except* violations.
+
+    It used to suppress those as well, so ``--quiet`` was silent whatever the
+    state of the code -- and the workflow step that used it printed a heading
+    over nothing on every run.
+    """
+    monkeypatch.chdir(tree_with_one_tangled_function)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["complexity_monitor.py", "--threshold", "3", "--no-save", "--quiet"],
+    )
+
+    exit_code = monitor.main()
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "tangled" in out, "the violation itself must survive --quiet"
+    assert "Analyzed" not in out, "the summary is what --quiet is for"
+    assert "Complexity threshold" not in out
+
+
+@pytest.mark.unit
+def test_quiet_prints_nothing_when_there_are_no_violations(
+    tree_with_one_tangled_function, monkeypatch, capsys
+) -> None:
+    """The other half of the contract: nothing to report means no output."""
+    monkeypatch.chdir(tree_with_one_tangled_function)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["complexity_monitor.py", "--threshold", "15", "--no-save", "--quiet"],
+    )
+
+    exit_code = monitor.main()
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.unit
+def test_the_summary_and_the_listing_both_print_without_quiet(
+    tree_with_one_tangled_function, monkeypatch, capsys
+) -> None:
+    """Moving the listing out of the guard must not thin out the default output."""
+    monkeypatch.chdir(tree_with_one_tangled_function)
+    monkeypatch.setattr(
+        sys, "argv", ["complexity_monitor.py", "--threshold", "3", "--no-save"]
+    )
+
+    exit_code = monitor.main()
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "Analyzed 1 files, 1 functions" in out
+    assert "Complexity threshold: 3" in out
+    assert "Violations found: 1" in out
+    assert "Maximum complexity: 4" in out
+    assert "Top violations:" in out
+    assert "tangled (4)" in out
+
+
+@pytest.mark.unit
+def test_the_workflow_debug_invocation_says_something_on_a_clean_tree(
+    tree_with_one_tangled_function, monkeypatch, capsys
+) -> None:
+    """The flags of complexity-monitoring.yml's "DIRECT COMPLEXITY CHECK" step.
+
+    That step exists to show a human the whole-repo numbers, so on a repository
+    with no violations -- the state this one is in -- it still has to report
+    them. This is why the step does not pass ``--quiet``, even now that
+    ``--quiet`` behaves.
+    """
+    monkeypatch.chdir(tree_with_one_tangled_function)
+    monkeypatch.setattr(
+        sys, "argv", ["complexity_monitor.py", "--threshold", "15", "--no-save"]
+    )
+
+    exit_code = monitor.main()
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Violations found: 0" in out
+    assert "Analyzed 1 files" in out
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## The bug

`complexity-monitoring.yml`'s last step ends with:

```
echo "DIRECT COMPLEXITY CHECK (for debugging):"
poetry run python .github/scripts/complexity_monitor.py --threshold 15 --no-save --quiet || true
```

In `complexity_monitor.py`, the entire summary block in `main()` -- including the "Top violations" listing -- sits inside `if not args.quiet:`. So `--quiet` suppresses every line the script can print, and the step has emitted its banner followed by nothing on every run of the workflow since it was added.

The flag's help text says "Suppress output except violations", which is not what it does.

## The fix, at both ends

Fixing only one of these leaves a hole, so this does both.

**The script.** The violations listing moves out of the `if not args.quiet:` guard. `--quiet` now prints the violations and nothing else. Default (non-quiet) output is byte-identical to before:

```
$ python .github/scripts/complexity_monitor.py --threshold 8 --no-save --quiet
Top violations:
  1. thyra\converters\spatialdata\base_spatialdata_converter.py:1373 - _create_pixel_shapes (11)
  ...
```

**The workflow.** The debug step drops `--quiet`. A *correct* `--quiet` still prints nothing when there are no violations -- and at threshold 15 this repo has none, so the banner would go on introducing an empty stretch of log. What that step wants is the whole-repo summary, which is also the part a `--files-changed` PR run never computes:

```
Analyzed 85 files, 674 functions
Complexity threshold: 15
Violations found: 0
```

**Nothing else depended on `--quiet` being totally silent.** It appears exactly twice in the repo: the argparse definition and that one workflow line.

## Tests

Four tests drive `main()` over a throwaway tree with one function of complexity 4:

- the listing survives `--quiet`, while the summary lines do not
- a clean tree under `--quiet` prints nothing at all (the other half of the contract)
- the default summary and listing are both still there, so the refactor cannot thin them out
- the debug step's exact flags report numbers on a tree with no violations

The first fails against the pre-fix script with `assert 'tangled' in ''` -- the reported symptom exactly. Verified by checking the old script back out and re-running.

`pre-commit run --files ...` clean on all three files; `tests/unit/tools/` 25 passed.

## Context

Noticed while fixing the dead `--files-changed` mode in the same script (#134, merged as c47e3b2) and deliberately left out of scope there. Unrelated to that bug.
