### PR TITLE
fix(spatialdata): stop writing the MSI table in ~1 KB zarr shards

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1071,123 +1071,6 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
-name = "crc32c"
-version = "2.7.1"
-description = "A python package implementing the crc32c algorithm in hardware and software"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "crc32c-2.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1fd1f9c6b50d7357736676278a1b8c8986737b8a1c76d7eab4baa71d0b6af67f"},
-    {file = "crc32c-2.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:805c2be1bc0e251c48439a62b0422385899c15289483692bc70e78473c1039f1"},
-    {file = "crc32c-2.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f4333e62b7844dfde112dbb8489fd2970358eddc3310db21e943a9f6994df749"},
-    {file = "crc32c-2.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f0fadc741e79dc705e2d9ee967473e8a061d26b04310ed739f1ee292f33674f"},
-    {file = "crc32c-2.7.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91ced31055d26d59385d708bbd36689e1a1d604d4b0ceb26767eb5a83156f85d"},
-    {file = "crc32c-2.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36ffa999b72e3c17f6a066ae9e970b40f8c65f38716e436c39a33b809bc6ed9f"},
-    {file = "crc32c-2.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e80114dd7f462297e54d5da1b9ff472e5249c5a2b406aa51c371bb0edcbf76bd"},
-    {file = "crc32c-2.7.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:676f5b46da268b5190f9fb91b3f037a00d114b411313664438525db876adc71f"},
-    {file = "crc32c-2.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8d0e660c9ed269e90692993a4457a932fc22c9cc96caf79dd1f1a84da85bb312"},
-    {file = "crc32c-2.7.1-cp310-cp310-win32.whl", hash = "sha256:17a2c3f8c6d85b04b5511af827b5dbbda4e672d188c0b9f20a8156e93a1aa7b6"},
-    {file = "crc32c-2.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:3208764c29688f91a35392073229975dd7687b6cb9f76b919dae442cabcd5126"},
-    {file = "crc32c-2.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:19e03a50545a3ef400bd41667d5525f71030488629c57d819e2dd45064f16192"},
-    {file = "crc32c-2.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8c03286b1e5ce9bed7090084f206aacd87c5146b4b10de56fe9e86cbbbf851cf"},
-    {file = "crc32c-2.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:80ebbf144a1a56a532b353e81fa0f3edca4f4baa1bf92b1dde2c663a32bb6a15"},
-    {file = "crc32c-2.7.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96b794fd11945298fdd5eb1290a812efb497c14bc42592c5c992ca077458eeba"},
-    {file = "crc32c-2.7.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9df7194dd3c0efb5a21f5d70595b7a8b4fd9921fbbd597d6d8e7a11eca3e2d27"},
-    {file = "crc32c-2.7.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d698eec444b18e296a104d0b9bb6c596c38bdcb79d24eba49604636e9d747305"},
-    {file = "crc32c-2.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e07cf10ef852d219d179333fd706d1c415626f1f05e60bd75acf0143a4d8b225"},
-    {file = "crc32c-2.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d2a051f296e6e92e13efee3b41db388931cdb4a2800656cd1ed1d9fe4f13a086"},
-    {file = "crc32c-2.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1738259802978cdf428f74156175da6a5fdfb7256f647fdc0c9de1bc6cd7173"},
-    {file = "crc32c-2.7.1-cp311-cp311-win32.whl", hash = "sha256:f7786d219a1a1bf27d0aa1869821d11a6f8e90415cfffc1e37791690d4a848a1"},
-    {file = "crc32c-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:887f6844bb3ad35f0778cd10793ad217f7123a5422e40041231b8c4c7329649d"},
-    {file = "crc32c-2.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f7d1c4e761fe42bf856130daf8b2658df33fe0ced3c43dadafdfeaa42b57b950"},
-    {file = "crc32c-2.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:73361c79a6e4605204457f19fda18b042a94508a52e53d10a4239da5fb0f6a34"},
-    {file = "crc32c-2.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:afd778fc8ac0ed2ffbfb122a9aa6a0e409a8019b894a1799cda12c01534493e0"},
-    {file = "crc32c-2.7.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56ef661b34e9f25991fface7f9ad85e81bbc1b3fe3b916fd58c893eabe2fa0b8"},
-    {file = "crc32c-2.7.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:571aa4429444b5d7f588e4377663592145d2d25eb1635abb530f1281794fc7c9"},
-    {file = "crc32c-2.7.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c02a3bd67dea95cdb25844aaf44ca2e1b0c1fd70b287ad08c874a95ef4bb38db"},
-    {file = "crc32c-2.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99d17637c4867672cb8adeea007294e3c3df9d43964369516cfe2c1f47ce500a"},
-    {file = "crc32c-2.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f4a400ac3c69a32e180d8753fd7ec7bccb80ade7ab0812855dce8a208e72495f"},
-    {file = "crc32c-2.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:588587772e55624dd9c7a906ec9e8773ae0b6ac5e270fc0bc84ee2758eba90d5"},
-    {file = "crc32c-2.7.1-cp312-cp312-win32.whl", hash = "sha256:9f14b60e5a14206e8173dd617fa0c4df35e098a305594082f930dae5488da428"},
-    {file = "crc32c-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:7c810a246660a24dc818047dc5f89c7ce7b2814e1e08a8e99993f4103f7219e8"},
-    {file = "crc32c-2.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:24949bffb06fc411cc18188d33357923cb935273642164d0bb37a5f375654169"},
-    {file = "crc32c-2.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2d5d326e7e118d4fa60187770d86b66af2fdfc63ce9eeb265f0d3e7d49bebe0b"},
-    {file = "crc32c-2.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba110df60c64c8e2d77a9425b982a520ccdb7abe42f06604f4d98a45bb1fff62"},
-    {file = "crc32c-2.7.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c277f9d16a3283e064d54854af0976b72abaa89824955579b2b3f37444f89aae"},
-    {file = "crc32c-2.7.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:881af0478a01331244e27197356929edbdeaef6a9f81b5c6bacfea18d2139289"},
-    {file = "crc32c-2.7.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:724d5ff4d29ff093a983ae656be3307093706d850ea2a233bf29fcacc335d945"},
-    {file = "crc32c-2.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b2416c4d88696ac322632555c0f81ab35e15f154bc96055da6cf110d642dbc10"},
-    {file = "crc32c-2.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:60254251b88ec9b9795215f0f9ec015a6b5eef8b2c5fba1267c672d83c78fc02"},
-    {file = "crc32c-2.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:edefc0e46f3c37372183f70338e5bdee42f6789b62fcd36ec53aa933e9dfbeaf"},
-    {file = "crc32c-2.7.1-cp313-cp313-win32.whl", hash = "sha256:813af8111218970fe2adb833c5e5239f091b9c9e76f03b4dd91aaba86e99b499"},
-    {file = "crc32c-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:7d9ede7be8e4ec1c9e90aaf6884decbeef10e3473e6ddac032706d710cab5888"},
-    {file = "crc32c-2.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db9ac92294284b22521356715784b91cc9094eee42a5282ab281b872510d1831"},
-    {file = "crc32c-2.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8fcd7f2f29a30dc92af64a9ee3d38bde0c82bd20ad939999427aac94bbd87373"},
-    {file = "crc32c-2.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5c056ef043393085523e149276a7ce0cb534b872e04f3e20d74d9a94a75c0ad7"},
-    {file = "crc32c-2.7.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03a92551a343702629af91f78d205801219692b6909f8fa126b830e332bfb0e0"},
-    {file = "crc32c-2.7.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb9424ec1a8ca54763155a703e763bcede82e6569fe94762614bb2de1412d4e1"},
-    {file = "crc32c-2.7.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88732070f6175530db04e0bb36880ac45c33d49f8ac43fa0e50cfb1830049d23"},
-    {file = "crc32c-2.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:57a20dfc27995f568f64775eea2bbb58ae269f1a1144561df5e4a4955f79db32"},
-    {file = "crc32c-2.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f7186d098bfd2cff25eac6880b7c7ad80431b90610036131c1c7dd0eab42a332"},
-    {file = "crc32c-2.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55a77e29a265418fa34bef15bd0f2c60afae5348988aaf35ed163b4bbf93cf37"},
-    {file = "crc32c-2.7.1-cp313-cp313t-win32.whl", hash = "sha256:ae38a4b6aa361595d81cab441405fbee905c72273e80a1c010fb878ae77ac769"},
-    {file = "crc32c-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:eee2a43b663feb6c79a6c1c6e5eae339c2b72cfac31ee54ec0209fa736cf7ee5"},
-    {file = "crc32c-2.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:04a56e9f4995559fa86bcf5d0ed5c48505a36e2be1c41d70cae5c080d9a00b74"},
-    {file = "crc32c-2.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88c5c9c21cd9fff593bb7dfe97d3287438c8aecbcc73d227f2366860a0663521"},
-    {file = "crc32c-2.7.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:595146cb94ba0055301d273113add2af5859b467db41b50367f47870c2d0a81c"},
-    {file = "crc32c-2.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9f3792872f1320961f33aaf0198edea371aee393bcc221fab66d10ecffd77d"},
-    {file = "crc32c-2.7.1-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:999a40d75cd1696e779f6f99c29fa52be777197d1d9e3ae69cb919a05a369c1e"},
-    {file = "crc32c-2.7.1-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:eff485526172cee7e6d1fa9c23913f92c7d38ab05674b0b578767c7b693faf5d"},
-    {file = "crc32c-2.7.1-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:541dac90c64ed9ce05f85a71066567e854c1b40743a01d83fa2c66419a2e97b6"},
-    {file = "crc32c-2.7.1-cp37-cp37m-win32.whl", hash = "sha256:7138ec26e79100c4cf4294ef40027a1cff26a1e23b7e5eb70efe5d7ff37cbc66"},
-    {file = "crc32c-2.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:35a3ed12ac2e2551a07d246b7e6512ac39db021e006205a40c1cfd32ea73fcc3"},
-    {file = "crc32c-2.7.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:af062f11aea283b7e9c95f3a97fb6bb96ac08a9063f71621c2140237df141ada"},
-    {file = "crc32c-2.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8f25ca521ecf7cccfff0ecae4d0538b5c0c7235d27bf098241f3e2bf86aed713"},
-    {file = "crc32c-2.7.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1410bcd909be36ccbf8a52c45e4bddca77adfd4e80789ac3cd575c024086516d"},
-    {file = "crc32c-2.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33fc8cb32f82685ebefd078e740925ea9da37a008ed5f43b68fc8324f8ca4a37"},
-    {file = "crc32c-2.7.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ad3dc6283ce53ad7d1dc5775003460110ab7eebf348efebe0486a531b28f8184"},
-    {file = "crc32c-2.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:758ead20e122496764ae50db26bb90fb47fc4b6d242c8e99e87c3f1dae1f1dce"},
-    {file = "crc32c-2.7.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:e436d9044bbd51936f7aeb8b322543c516bf22371a17970a370a10af1661fa54"},
-    {file = "crc32c-2.7.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:47e5be99057264b603e3cd88cf091985f33c16d3c8609f1c83ed6e72ec4179b4"},
-    {file = "crc32c-2.7.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:280509210e622a236f16f031856847fd0d6704df662d7209da819ccfb40c6167"},
-    {file = "crc32c-2.7.1-cp38-cp38-win32.whl", hash = "sha256:4ab48e048cfa123a9f9bdc5d4d687a3461723132c749c721a6d358605e6d470d"},
-    {file = "crc32c-2.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:65471d1b1b6e10a404ca8200a4271d5bc0a552c3f5dcd943c1c7835f766ea02d"},
-    {file = "crc32c-2.7.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:39ca842586084bca24f9c4ab43e2d99191b1186b2f89b2122b470d0730254d1b"},
-    {file = "crc32c-2.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a911abc33d453b3f171a3200b1e18b3fc39c204670b5b0a353cca99e4c664332"},
-    {file = "crc32c-2.7.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:22a72e81ec08a7ece6a35ac68d1ed32dd4a8be7949b164db88d4b4a4bade5c5a"},
-    {file = "crc32c-2.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54d6f8c5be6815eabd6e3e90fa0bc13045183a6aa33a30dd684eb0f062b92213"},
-    {file = "crc32c-2.7.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9c855726d71dee7ae25f81c6b54293455fc66802f34d334d22bea1f6ce8bc21c"},
-    {file = "crc32c-2.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98d5f7fc364bb9c4c4123d149406fbee063f2e8c2cff19a12f13e50faa146237"},
-    {file = "crc32c-2.7.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:51ffba582c95a281e5a3f71eacdafc96b9a1835ddae245385639458fff197034"},
-    {file = "crc32c-2.7.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3950d3c340c9d70889630ef81fba8666abfd0cf0aa19fd9c3a55634e0b383b0f"},
-    {file = "crc32c-2.7.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:522fba1770aad8f7eb189f21fca591a51d96dcc749859088f462281324aec30b"},
-    {file = "crc32c-2.7.1-cp39-cp39-win32.whl", hash = "sha256:812723e222b6a9fe0562554d72f4f072c3a95720c60ee500984e7d0e568caac3"},
-    {file = "crc32c-2.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:6793fcfe9d4130230d196abbe4021c01ffe8e85c92633bf3c8559f9836c227f5"},
-    {file = "crc32c-2.7.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:2e83fedebcdeb80c19e76b7a0e5103528bb062521c40702bf34516a429e81df3"},
-    {file = "crc32c-2.7.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30004a7383538ef93bda9b22f7b3805bc0aa5625ab2675690e1b676b19417d4b"},
-    {file = "crc32c-2.7.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a01b0983aa87f517c12418f9898ecf2083bf86f4ea04122e053357c3edb0d73f"},
-    {file = "crc32c-2.7.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb2b963c42128b38872e9ed63f04a73ce1ff89a1dfad7ea38add6fe6296497b8"},
-    {file = "crc32c-2.7.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cdd5e576fee5d255c1e68a4dae4420f21e57e6f05900b38d5ae47c713fc3330d"},
-    {file = "crc32c-2.7.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:79f0ff50863aeb441fbfa87e9db6542ddfe3e941189dece832b0af2e454dbab0"},
-    {file = "crc32c-2.7.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cd27a1e400d77e9872fa1303e8f9d30bd050df35ee4858354ce0b59f8227d32"},
-    {file = "crc32c-2.7.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:274739b3e1591bd4b7ec98764f2f79c6fbcc0f7d7676d5f17369832fe14ee4f0"},
-    {file = "crc32c-2.7.1-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:050f52045b4a033a245e0ee4357e1a793de5af6496c82250ef13d8cb90a21e20"},
-    {file = "crc32c-2.7.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ceb4ca126f75694bda020a307221563d3c522719c0acedcc81ffb985b4867c94"},
-    {file = "crc32c-2.7.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:eabefe7a6fb5dfc6318fb35f4d98893baef17ebda9b311498e870526d32168e7"},
-    {file = "crc32c-2.7.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:217edd9ba8c5f0c3ad60c82a11fa78f01162fa106fd7f5d17175dac6bf1eedf9"},
-    {file = "crc32c-2.7.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:15d640d9d4aa213aec6c837f602081a17d1522f8cd78b52334b62ee27b083410"},
-    {file = "crc32c-2.7.1-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:519878822bf9bdead63c25a5e4bdc26d2eae9da6056f92b9b5f3023c08f1d016"},
-    {file = "crc32c-2.7.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:2bf69cfa4c3ea9f060fe06db00b7e34f771c83f73dd2c3568c2c9019479e34c2"},
-    {file = "crc32c-2.7.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e89d51c90f6730b67b12c97d49099ba18d0fdce18541fab94d2be95d1c939adb"},
-    {file = "crc32c-2.7.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:488a0feba1bb005d0dd2f702c1da4849d083e88d82cd27b83ac2d2d93af80755"},
-    {file = "crc32c-2.7.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:919262b7a12ef63f222ec19c0e092f39268802652e11669315257ae6249ec79f"},
-    {file = "crc32c-2.7.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4181240f6080c38eec9dd1539cd23a304a12100d3f4ffe43234f32064fae5ef0"},
-    {file = "crc32c-2.7.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:fedde1e53507d0ede1980e8109442edd108c04ab100abcd5145c274820dacd4f"},
-    {file = "crc32c-2.7.1.tar.gz", hash = "sha256:f91b144a21eef834d64178e01982bb9179c354b3e9e5f4c803b0e5096384968c"},
-]
-
-[[package]]
 name = "cycler"
 version = "0.12.1"
 description = "Composable style cycles"
@@ -1850,6 +1733,49 @@ gitdb = ">=4.0.1,<5"
 [package.extras]
 doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
 test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+description = "A python wrapper of the C library 'Google CRC32C'"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "google_crc32c-1.8.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0470b8c3d73b5f4e3300165498e4cf25221c7eb37f1159e221d1825b6df8a7ff"},
+    {file = "google_crc32c-1.8.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:119fcd90c57c89f30040b47c211acee231b25a45d225e3225294386f5d258288"},
+    {file = "google_crc32c-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f35aaffc8ccd81ba3162443fabb920e65b1f20ab1952a31b13173a67811467d"},
+    {file = "google_crc32c-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:864abafe7d6e2c4c66395c1eb0fe12dc891879769b52a3d56499612ca93b6092"},
+    {file = "google_crc32c-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:db3fe8eaf0612fc8b20fa21a5f25bd785bc3cd5be69f8f3412b0ac2ffd49e733"},
+    {file = "google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8"},
+    {file = "google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7"},
+    {file = "google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15"},
+    {file = "google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a"},
+    {file = "google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2"},
+    {file = "google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113"},
+    {file = "google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb"},
+    {file = "google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411"},
+    {file = "google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454"},
+    {file = "google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962"},
+    {file = "google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b"},
+    {file = "google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27"},
+    {file = "google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa"},
+    {file = "google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8"},
+    {file = "google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f"},
+    {file = "google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697"},
+    {file = "google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651"},
+    {file = "google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2"},
+    {file = "google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21"},
+    {file = "google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2"},
+    {file = "google_crc32c-1.8.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:ba6aba18daf4d36ad4412feede6221414692f44d17e5428bdd81ad3fc1eee5dc"},
+    {file = "google_crc32c-1.8.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:87b0072c4ecc9505cfa16ee734b00cd7721d20a0f595be4d40d3d21b41f65ae2"},
+    {file = "google_crc32c-1.8.0-cp39-cp39-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d488e98b18809f5e322978d4506373599c0c13e6c5ad13e53bb44758e18d215"},
+    {file = "google_crc32c-1.8.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01f126a5cfddc378290de52095e2c7052be2ba7656a9f0caf4bcd1bfb1833f8a"},
+    {file = "google_crc32c-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:61f58b28e0b21fcb249a8247ad0db2e64114e201e2e9b4200af020f3b6242c9f"},
+    {file = "google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93"},
+    {file = "google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c"},
+    {file = "google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79"},
+]
 
 [[package]]
 name = "griffelib"
@@ -4003,7 +3929,6 @@ files = [
 ]
 
 [package.dependencies]
-crc32c = {version = ">=2.7", optional = true, markers = "extra == \"crc32c\""}
 deprecated = "*"
 numpy = ">=1.24"
 
@@ -7171,31 +7096,29 @@ propcache = ">=0.2.1"
 
 [[package]]
 name = "zarr"
-version = "3.1.3"
+version = "3.1.6"
 description = "An implementation of chunked, compressed, N-dimensional arrays for Python"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "zarr-3.1.3-py3-none-any.whl", hash = "sha256:45f67f87f65f14fa453f99dd8110a5936b7ac69f3a21981d33e90407c80c302a"},
-    {file = "zarr-3.1.3.tar.gz", hash = "sha256:01342f3e26a02ed5670db608a5576fbdb8d76acb5c280bd2d0082454b1ba6f79"},
+    {file = "zarr-3.1.6-py3-none-any.whl", hash = "sha256:b5a82c5079d1c3d4ee8f06746fa3b9a98a7d804300fa3f4be154362a33e1207e"},
+    {file = "zarr-3.1.6.tar.gz", hash = "sha256:d95e72cbea4b90e9a70679468b8266400331756232576ae2b43400ac5108d0eb"},
 ]
 
 [package.dependencies]
 donfig = ">=0.8"
-numcodecs = {version = ">=0.14", extras = ["crc32c"]}
-numpy = ">=1.26"
+google-crc32c = ">=1.5"
+numcodecs = ">=0.14"
+numpy = ">=2.0"
 packaging = ">=22.0"
-typing-extensions = ">=4.9"
+typing-extensions = ">=4.12"
 
 [package.extras]
 cli = ["typer"]
-docs = ["astroid (<4)", "numcodecs[msgpack]", "numpydoc", "pydata-sphinx-theme", "pytest", "rich", "s3fs (>=2023.10.0)", "sphinx (==8.1.3)", "sphinx-autoapi (==3.4.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx-copybutton", "sphinx-design", "sphinx-issues", "sphinx-reredirects", "towncrier"]
 gpu = ["cupy-cuda12x"]
-optional = ["rich", "universal-pathlib"]
+optional = ["universal-pathlib"]
 remote = ["fsspec (>=2023.10.0)", "obstore (>=0.5.1)"]
-remote-tests = ["botocore", "fsspec (>=2023.10.0)", "moto[s3,server]", "obstore (>=0.5.1)", "requests", "s3fs (>=2023.10.0)"]
-test = ["coverage (>=7.10)", "hypothesis", "mypy", "numpydoc", "packaging", "pytest (<8.4)", "pytest-accept", "pytest-asyncio", "pytest-cov", "pytest-xdist", "rich", "tomlkit", "uv"]
 
 [[package]]
 name = "zict"
@@ -7212,4 +7135,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12, <3.14"
-content-hash = "bef71e6385fe784a8933b882f0f6ce6e765b282a91b5cdefda8c54420cf4e038"
+content-hash = "dc91cd0dfb58e8792133bcd998f49708371b5e17f14102d7e3b5f0a0498a579c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,16 @@ spatialdata = ">=0.8.0, <0.9"       # tested 0.8.0
 # bit ome_zarr 0.12.x with newer dask, and spatialdata 0.8 requires >= 0.16.
 ome-zarr = ">=0.16.0, <0.19"        # tested 0.18.0
 tqdm = ">=4.50.0"
-zarr = ">=3.0.0, <3.2"              # tested 3.1.3
+# Floor is 3.1.4, and it is load-bearing. anndata >= 0.13 writes every zarr v3
+# array with `shards="auto"`. zarr < 3.1.4 sized the auto chunk with
+# `max_bytes=1024` where its own comment says "aim for a 1MiB chunk" (compare
+# `_auto_partition` in 3.1.3 vs 3.1.4), so one shard -- one FILE -- came out at
+# ~1 KB. Measured on test_data/pea.imzML: 393,310 files for a single table and
+# 434 s of a 445 s conversion spent in the write, against 12 files and 2.7 s on
+# 3.1.6. Nothing in Thyra changed; the anndata 0.13 bump alone did this.
+# 3.1.4 is also where `array.target_shard_size_bytes` arrives, which is the
+# knob _chunking.table_write_config sets to claim the budget from anndata.
+zarr = ">=3.1.4, <3.2"              # tested 3.1.6
 imagecodecs = ">=2024.1.1"  # For reading compressed TIFF optical images
 # Floor is 0.13.2, not 0.13.0. anndata 0.13.0 imports
 # `typing_extensions.sentinel` (needs typing-extensions >= 4.16) but declares

--- a/tests/unit/converters/test_chunking_policy.py
+++ b/tests/unit/converters/test_chunking_policy.py
@@ -1,37 +1,188 @@
-"""Foundation tests for the Thyra raster chunk/shard policy.
+"""Foundation tests for the Thyra chunk/shard policy.
 
-Locks the current chunk tuples (so the future zarr v3 sharding wiring, gated on
-spatialdata PR #1106, cannot silently change output) and documents the
-cross-repo INNER_TILE_EDGE contract with Ousia's serving tile size.
+Two halves, for the two things Thyra writes:
+
+**Rasters.** Locks the current chunk tuples (so the future zarr v3 sharding
+wiring, gated on spatialdata PR #1106, cannot silently change output) and
+documents the cross-repo INNER_TILE_EDGE contract with Ousia's serving tile
+size.
+
+**The MSI table.** Locks the shard size the table's ``X`` arrays land in. This
+half exists because of a real, shipped regression: anndata >= 0.13 writes every
+zarr v3 array with ``shards="auto"``, and zarr < 3.1.4 sized the auto chunk with
+``max_bytes=1024`` where it meant 1 MiB. Nothing in Thyra changed -- a
+dependency bump alone was enough to turn one table into ~400,000 files of
+roughly 1 KB each, and the zarr write into 98% of conversion wall-clock
+(pea.imzML: 434 s of 445 s).
+
+That failure is invisible to every other test in this suite. The store still
+round-trips, ``read_lazy`` still opens it, and the values are all correct --
+only the geometry is catastrophic. Hence a test that asserts geometry, on a
+store big enough for the geometry to be non-degenerate: below ~1 KB of ``data``
+the broken and fixed layouts agree, so a 4-pixel fixture would prove nothing.
 """
 
-import pytest
+from __future__ import annotations
 
+import contextlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+
+from thyra.converters.spatialdata import _chunking
 from thyra.converters.spatialdata._chunking import (
     IMAGE_CHUNK_EDGE,
     INNER_TILE_EDGE,
+    MIN_TABLE_SHARD_BYTES,
+    TABLE_SHARD_TARGET_BYTES,
     image_chunks,
+    table_write_config,
 )
 
-
-def test_image_chunks_2d_reproduces_todays_literal():
-    # No-op-refactor lock: the helper must return exactly the (1, 4096, 4096)
-    # literal it replaced at base_spatialdata_converter.py's optical parse.
-    assert image_chunks(2) == (1, 4096, 4096)
+_ZARR_CONFIG_KEY = "array.target_shard_size_bytes"
 
 
-def test_image_chunks_3d_prepends_a_z_chunk():
-    assert image_chunks(3) == (1, 1, 4096, 4096)
+class TestRasterChunkPolicy:
+    def test_image_chunks_2d_reproduces_todays_literal(self):
+        # No-op-refactor lock: the helper must return exactly the (1, 4096, 4096)
+        # literal it replaced at base_spatialdata_converter.py's optical parse.
+        assert image_chunks(2) == (1, 4096, 4096)
+
+    def test_image_chunks_3d_prepends_a_z_chunk(self):
+        assert image_chunks(3) == (1, 1, 4096, 4096)
+
+    def test_image_chunks_rejects_other_ndim(self):
+        with pytest.raises(ValueError):
+            image_chunks(4)
+
+    def test_inner_tile_edge_matches_ousia_serving_contract(self):
+        # Duplicated-by-contract with Ousia DEFAULT_TILE_SIZE = 512 (Thyra cannot
+        # import Ousia). If Ousia's serving tile changes, update this in lockstep.
+        assert INNER_TILE_EDGE == 512
+        # Outer chunk must tile exactly into inner tiles (no ragged remainder).
+        assert IMAGE_CHUNK_EDGE % INNER_TILE_EDGE == 0
 
 
-def test_image_chunks_rejects_other_ndim():
-    with pytest.raises(ValueError):
-        image_chunks(4)
+class TestTableWriteConfig:
+    """The zarr-config seam itself."""
+
+    def test_publishes_thyras_budget_while_open(self):
+        with table_write_config():
+            assert zarr.config.get(_ZARR_CONFIG_KEY) == TABLE_SHARD_TARGET_BYTES
+
+    def test_restores_the_previous_value_on_exit(self):
+        before = zarr.config.get(_ZARR_CONFIG_KEY, None)
+        with table_write_config():
+            pass
+        assert zarr.config.get(_ZARR_CONFIG_KEY, None) == before
+
+    def test_budget_is_an_int_so_anndata_yields_to_it(self):
+        # anndata only skips its own 1 GB default when the configured value is
+        # an int (anndata._io.specs.methods.zarr_v3_sharding). A float here
+        # would silently hand the budget back to anndata.
+        assert isinstance(TABLE_SHARD_TARGET_BYTES, int)
+        assert TABLE_SHARD_TARGET_BYTES > MIN_TABLE_SHARD_BYTES
 
 
-def test_inner_tile_edge_matches_ousia_serving_contract():
-    # Duplicated-by-contract with Ousia DEFAULT_TILE_SIZE = 512 (Thyra cannot
-    # import Ousia). If Ousia's serving tile changes, update this in lockstep.
-    assert INNER_TILE_EDGE == 512
-    # Outer chunk must tile exactly into inner tiles (no ragged remainder).
-    assert IMAGE_CHUNK_EDGE % INNER_TILE_EDGE == 0
+@pytest.fixture(scope="module")
+def converted_store(tmp_path_factory) -> tuple[Path, int]:
+    """A real converted store, plus how many times the policy context opened.
+
+    Sized so ``X/data`` is a few hundred KB: comfortably past the ~1 KB cliff
+    where the broken and fixed layouts diverge, and still a couple of seconds
+    to convert.
+    """
+    from pyimzml.ImzMLWriter import ImzMLWriter
+
+    from thyra.convert import convert_msi
+
+    n_side, n_mz = 16, 200
+    tmp_path = tmp_path_factory.mktemp("table_chunks")
+    imzml_path = tmp_path / "grid.imzML"
+
+    mzs = np.linspace(100.0, 1000.0, n_mz)
+    with ImzMLWriter(str(imzml_path), mode="processed") as writer:
+        for x in range(1, n_side + 1):
+            for y in range(1, n_side + 1):
+                # Every channel non-zero, so nnz is n_side**2 * n_mz and the
+                # array size the assertions rely on is not a function of how
+                # aggressively the converter drops zeros.
+                intensities = np.full(n_mz, 1.0) + x + y
+                writer.addSpectrum(mzs, intensities, (x, y, 1))
+
+    entered = 0
+    real = _chunking.table_write_config
+
+    @contextlib.contextmanager
+    def counting_config():
+        nonlocal entered
+        entered += 1
+        with real():
+            yield
+
+    output_path = tmp_path / "out.zarr"
+    with pytest.MonkeyPatch.context() as mp:
+        # Patch the name the converter module bound at import time.
+        mp.setattr(
+            "thyra.converters.spatialdata.base_spatialdata_converter."
+            "table_write_config",
+            counting_config,
+        )
+        assert convert_msi(
+            str(imzml_path),
+            str(output_path),
+            format_type="spatialdata",
+            dataset_id="ds",
+            pixel_size_um=10.0,
+        ), "conversion fixture failed"
+
+    return output_path, entered
+
+
+class TestConvertedTableGeometry:
+    def test_save_output_holds_the_policy_open(self, converted_store):
+        # Catches the wiring being dropped from _save_output. The geometry
+        # assertion below cannot: with the zarr floor in place, anndata's own
+        # 1 GB fallback also yields large shards on a fixture this size.
+        _, entered = converted_store
+        assert entered >= 1, "_save_output wrote the table outside table_write_config()"
+
+    @pytest.mark.parametrize("member", ["data", "indices", "indptr"])
+    def test_x_arrays_are_not_kilobyte_sharded(self, converted_store, member):
+        store, _ = converted_store
+        arr = zarr.open_group(str(store), mode="r")[f"tables/ds_z0/X/{member}"]
+
+        # One shard is one file; with no sharding the chunk is the file.
+        unit = arr.shards[0] if arr.shards else arr.chunks[0]
+        file_bytes = unit * arr.dtype.itemsize
+        array_bytes = arr.shape[0] * arr.dtype.itemsize
+
+        # An array smaller than the floor can only ever be one short file.
+        assert file_bytes >= min(array_bytes, MIN_TABLE_SHARD_BYTES), (
+            f"X/{member}: {file_bytes} B per file over {array_bytes} B of data "
+            f"-> {int(np.ceil(arr.shape[0] / unit)):,} files. Below "
+            f"{MIN_TABLE_SHARD_BYTES} B this is the zarr < 3.1.4 "
+            "auto-shard defect; check the zarr floor in pyproject.toml."
+        )
+
+    def test_data_array_is_large_enough_for_that_to_mean_anything(
+        self, converted_store
+    ):
+        # Guards the fixture, not the code. The assertion above is
+        # `file_bytes >= min(array_bytes, MIN_TABLE_SHARD_BYTES)`, so it says
+        # nothing at all unless X/data is bigger than the floor -- which it
+        # stops being if the converter ever drops these spectra to a handful of
+        # non-zeros. Today it is ~400 KB.
+        store, _ = converted_store
+        data = zarr.open_group(str(store), mode="r")["tables/ds_z0/X/data"]
+        assert data.shape[0] * data.dtype.itemsize > MIN_TABLE_SHARD_BYTES
+
+    def test_whole_table_stays_in_a_handful_of_files(self, converted_store):
+        store, _ = converted_store
+        x_dir = store / "tables" / "ds_z0" / "X"
+        n_files = sum(1 for p in x_dir.rglob("*") if p.is_file())
+        # Fixed this is single digits (each array fits one shard). Broken, the
+        # same table is ~400 files: X/data alone shards at 200 elements.
+        assert n_files < 100, f"{n_files} files under tables/ds_z0/X"

--- a/thyra/converters/spatialdata/_chunking.py
+++ b/thyra/converters/spatialdata/_chunking.py
@@ -1,4 +1,4 @@
-"""Image chunk/shard policy for Thyra-written SpatialData rasters.
+"""Chunk/shard policy for the zarr Thyra writes: rasters and the MSI table.
 
 Single source of truth for how Thyra chunks the raster images it writes to
 SpatialData zarr -- and the designated seam for tile-aligned zarr v3 sharding
@@ -11,9 +11,20 @@ separate package and CANNOT import Ousia, so the coupling is DUPLICATED BY
 CONTRACT here -- keep ``INNER_TILE_EDGE`` numerically in sync with Ousia's
 ``DEFAULT_TILE_SIZE``; a silent divergence reintroduces cold-tile amplification
 on the viewer. See the Ousia ADR docs/ADR-pyramid-tile-sharding.md.
+
+The raster policy above is passed per-array. The TABLE policy below cannot be:
+``SpatialData.write`` hands the table straight to ``anndata.write_elem`` and
+exposes no ``dataset_kwargs`` seam, so the only supported lever is zarr's own
+config. ``table_write_config()`` is that lever, and every writer that reaches
+zarr through spatialdata (the 2D, 3D and streaming-COO converters, all via
+``_save_output``) must hold it open across the write. The streaming-PCS writer
+hand-rolls its ``create_array`` calls and sizes them itself.
 """
 
-from typing import Tuple
+from contextlib import contextmanager
+from typing import Iterator, Tuple
+
+import zarr
 
 # Outer chunk edge used TODAY (pre-sharding the chunk IS the outer block): a 4096
 # block means a viewer 512-tile read decompresses at most one chunk per request.
@@ -22,6 +33,43 @@ IMAGE_CHUNK_EDGE = 4096
 # Future zarr INNER chunk edge once #1106 lands == Ousia DEFAULT_TILE_SIZE (512).
 # Duplicated by contract (Thyra cannot import Ousia).
 INNER_TILE_EDGE = 512
+
+# Uncompressed byte budget for ONE SHARD of a table array -- X/data, X/indices,
+# X/indptr and every obs/var column anndata writes. One shard is one FILE, so
+# this is what keeps a 36M-nnz table (test_data/bellini.imzML) in 11 files
+# instead of 394,699.
+#
+# anndata >= 0.13 turns on ``shards="auto"`` for zarr v3 and would otherwise
+# pick its own 1 GB budget; it explicitly yields to a caller-set value (see
+# ``anndata._io.specs.methods.zarr_v3_sharding``). We set a smaller one because
+# a shard is assembled in memory before it is written -- anndata's own comment
+# says so -- and Thyra converts multi-GB acquisitions on workstations, where a
+# 1 GB write buffer is a real cost. 128 MiB is still enormous relative to the
+# file counts that hurt: test_data/pea.imzML (60.1M nnz, 481 MB of X/data)
+# lands in 4 data files, so even a table 100x that size stays in the hundreds.
+#
+# The INNER chunk stays zarr's ~1 MiB auto pick: that is the unit a random read
+# decompresses, and it is the size the non-sharded path used before anndata
+# began auto-sharding, so read amplification is unchanged.
+TABLE_SHARD_TARGET_BYTES = 128 * 1024 * 1024
+
+# zarr < 3.1.4 computed the auto chunk with ``max_bytes=1024`` where 1 MiB was
+# meant, so ``shards="auto"`` produced ~1 KB shards -- one file per KB of table.
+# It also predates ``array.target_shard_size_bytes``, making the budget above
+# unenforceable. pyproject pins the floor at 3.1.4 for exactly this reason;
+# this constant is what the regression test checks the floor still buys us.
+MIN_TABLE_SHARD_BYTES = 64 * 1024
+
+
+@contextmanager
+def table_write_config() -> Iterator[None]:
+    """Hold Thyra's table shard budget open across a ``SpatialData.write``.
+
+    Wraps zarr's global config, so it must stay open for the *whole* write --
+    the arrays are created lazily inside anndata, not up front.
+    """
+    with zarr.config.set({"array.target_shard_size_bytes": TABLE_SHARD_TARGET_BYTES}):
+        yield
 
 
 def image_chunks(spatial_ndim: int, edge: int = IMAGE_CHUNK_EDGE) -> Tuple[int, ...]:

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -21,7 +21,7 @@ from ...resampling.gaps import zero_across_gaps
 from ...resampling.tic import preserved_tic, rescale_to_preserved_tic
 from ...resampling.types import ResamplingConfig
 from ...utils.zarr_atomic_write import install_windows_atomic_write_retry
-from ._chunking import image_chunks
+from ._chunking import image_chunks, table_write_config
 
 logger = logging.getLogger(__name__)
 
@@ -1921,8 +1921,12 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             # Add metadata
             self.add_metadata(sdata)
 
-            # Write to disk
-            with _suppress_upstream_warnings():
+            # Write to disk. table_write_config() must wrap the write itself,
+            # not just the SpatialData construction: anndata creates the table's
+            # zarr arrays lazily inside sdata.write, and that is where the shard
+            # budget is read. Without it the table lands in ~1 KB shards -- one
+            # file per KB -- and the write dominates conversion wall-clock.
+            with _suppress_upstream_warnings(), table_write_config():
                 sdata.write(str(self.output_path))
                 zarr.consolidate_metadata(str(self.output_path))
             logger.info(f"Successfully saved SpatialData to {self.output_path}")


### PR DESCRIPTION
## The defect

Converting `test_data/pea.imzML` takes **445 s, of which 434 s (98%) is the zarr write**, and produces **393,310 files for a single table**. `bellini.imzML`: 449 s, 443 s of it the write, 394,699 files.

Nothing in Thyra caused this. It arrived with the dependency bump in 0ef2263:

- anndata >= 0.13 writes **every** zarr v3 array with `shards="auto"`.
- zarr < 3.1.4 sizes the auto chunk with `max_bytes=1024` where its own comment says *"aim for a 1MiB chunk"* — compare `_auto_partition` in 3.1.3 vs 3.1.4.
- One shard is one **file**, so the table landed at roughly 1 KB per file.

0ef2263 moved anndata to 0.13.2 and deliberately left zarr at 3.1.3. That combination is what shipped.

The reported shapes confirm it exactly. Reproduced on bellini, matching the original report's `data` 140 / `indices` 278 — those numbers were the **shard** shape, which is the file granularity:

| array | shape | dtype | chunk | shard | bytes/file | files |
|---|---|---|---|---|---|---|
| `data` | 36,371,295 | float64 | 70 | 140 | 560 | 259,795 |
| `indices` | 36,371,295 | int32 | 139 | 278 | 556 | 130,832 |
| `indptr` | 1,122,722 | int32 | 138 | 276 | 552 | 4,068 |

The pin was also **spanning both behaviours**: `>=3.0.0, <3.2` admits 3.1.4+, where anndata's own 1 GB fallback engages. Two users `pip install thyra` and get stores three orders of magnitude apart in file count.

## The fix

`spatialdata` hands the table straight to `anndata.write_elem` and exposes no `dataset_kwargs` seam, so zarr's config is the only write-time lever. Post-hoc rechunking stays rejected (#109).

1. **Floor zarr at 3.1.4** — both where the chunk sizing is correct and where `array.target_shard_size_bytes` exists. Lock moves 3.1.3 → 3.1.6 (plus zarr's crc32c provider swap); nothing else moves.
2. **Own the budget** rather than inherit anndata's 1 GB. `_chunking` grows `table_write_config()` (128 MiB) and `_save_output` holds it open across `sdata.write`. anndata explicitly yields to a caller-set value. A shard is assembled in memory before writing and Thyra converts multi-GB acquisitions on workstations, so a 1 GB write buffer is worth not taking.

## Measured

| | pea before | pea after | bellini before | bellini after |
|---|---|---|---|---|
| total | 444.5 s | **12.4 s** | 449.2 s | **8.9 s** |
| zarr write | 433.9 s | **2.7 s** | 443.0 s | **2.5 s** |
| files (X) | 393,310 | **12** | 394,699 | **11** |
| files (store) | 397,984 | **107** | 412,555 | **106** |
| on-disk (X) | 278.4 MB | **196.1 MB** | 139.5 MB | **74.2 MB** |

36x and 50x end-to-end. X also shrinks 30% / 47% — 1 KB chunks barely compress.

## Read latency — one regression, stated plainly

Both stores read with zarr 3.1.6 so the comparison isolates layout. Warm cache; byte counts are the deterministic part.

| pattern | pea before | pea after | bellini before | bellini after |
|---|---|---|---|---|
| A. single ion image ×20 | 69.6 ms / 0.04 MB | **87.9 ms** / 12.1 MB | 47.3 ms / 0.01 MB | **74.5 ms** / 6.2 MB |
| B. 1000-column m/z window | 631.4 ms / 1047 reqs | **7.0 ms** / 7 reqs | 59.5 ms / 126 reqs | **3.4 ms** / 4 reqs |
| C. single pixel spectrum | 72.7 s / 130,762 reqs | **0.20 s** / 116 reqs | 66.4 s / 130,832 reqs | **0.14 s** / 22 reqs |

B is **90x faster** and C **360x faster**, because both stop issuing ~130,000 requests.

**A is 1.26x slower** (~0.9 ms per ion image). The table is CSC with a median 70 non-zero pixels per m/z column, so a single ion image now decompresses a ~918 KB chunk for a handful of values. That inner chunk is zarr's ~1 MiB auto pick — the same size the non-sharded path used before anndata began auto-sharding, so this is not an amplification the fix invents.

**The trade:** 0.9 ms per single ion image against 7 minutes per conversion, with the two bulk patterns 90–360x faster. Taken. If single-column latency ever matters more than that, the lever is the inner chunk (zarr's `_guess_chunks` target), not the shard budget — they are independent.

Ousia is unaffected either way: it pins zarr 3.2.1 with `auto_shard_zarr_v3` off, and `assemble.py` re-reads and rewrites the store anyway.

## Test

`tests/unit/converters/test_chunking_policy.py` grows a table half. It asserts **on-disk geometry**, which no existing test covers — the broken store round-trips, reads back correct values, and opens under `read_lazy`; only the geometry is catastrophic.

Verified as a real lock: on zarr 3.1.3 three tests fail with `X/data: 1600 B per file over 409600 B of data -> 256 files`. The fixture is sized past the ~1 KB cliff on purpose (a 4-pixel fixture proves nothing, since broken and fixed agree below it) and a guard test keeps it that way. A separate test pins that `_save_output` actually holds the policy open, which the geometry assertion cannot catch on its own.

## Checks

- Unit: **1049 passed, 11 skipped** on zarr 3.1.6.
- Integration: 4 failed / 14 passed — the same four in `test_streaming_converter.py` verified failing identically on `main` with zarr 3.1.3. Pre-existing.
- pre-commit: all hooks pass.