### PR TITLE
ci(release): serialise release runs and fix the stale tag guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,25 @@ on:
         default: false
         type: boolean
 
+# Two merges landing close together used to race: each run checked out main,
+# spent ~25s installing semantic-release, and then both tried to push a version
+# commit. Run 30708175547 (merge of #138) died at exactly that -- "[LOCAL SHA]
+# != [UPSTREAM SHA]. Upstream branch 'origin/main' has changed!" -- because #139
+# pushed 29 seconds earlier. Serialising the whole workflow is what fixes it.
+#
+# cancel-in-progress MUST stay false. `semantic-release version` creates the
+# version commit and the tag and then pushes them; cancelling between those
+# steps leaves the repo tagged-but-not-bumped, which is far worse than a queued
+# run. Nothing here is safe to interrupt.
+#
+# The group is keyed on the event as well as the ref so a publish-only
+# workflow_dispatch is not stuck behind a push run -- it never calls
+# semantic-release (the release job is `if: github.event_name == 'push'`), so it
+# has nothing to race with. Only push-to-main runs need to serialise.
+concurrency:
+  group: release-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Create Release
@@ -79,6 +98,15 @@ jobs:
 
           # Past this point $NEXT is a genuine bump, so an existing tag really
           # does mean another run got there first.
+          #
+          # Re-fetch before asking. Checkout does fetch every tag (fetch-depth: 0
+          # fetches refs/tags/* regardless of fetch-tags), but it did so before
+          # the ~25s pip install above, so the local tag list is a stale
+          # snapshot. A sibling run that tagged inside that window is invisible
+          # here, and the guard waves it through. --force because a tag that
+          # moved must not be silently kept at its old value.
+          git fetch --tags --force origin
+
           if git rev-parse -q --verify "refs/tags/v$NEXT" >/dev/null; then
             echo "No release: v$NEXT is a new version but is already tagged -- a concurrent run created it."
             echo "released=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What broke

Run [30708175547](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/actions/runs/30708175547) (the merge of #138, 2026-08-01T16:27:38Z) failed at **Create Release**:

```
[LOCAL SHA] 17a2d5b8e52fae212b87e4fb5952ab95cace6d3e != e1842d3a35cb3d99c3ec5efd45b43bf7c0ea4806 [UPSTREAM SHA].
Upstream branch 'origin/main' has changed!
```

PR #139 pushed 29 seconds earlier, while this run was still installing `semantic-release`. `grep -rn concurrency .github/workflows/` returned nothing -- no workflow in the repo had a concurrency group, so nothing serialised the two runs.

## Changes

**1. Workflow-level concurrency.**

```yaml
concurrency:
  group: release-${{ github.event_name }}-${{ github.ref }}
  cancel-in-progress: false
```

- `cancel-in-progress: false` is load-bearing. `semantic-release version` creates the version commit *and* the tag before pushing them; cancelling in between leaves the repo tagged-but-not-bumped. Nothing in this workflow is safe to interrupt.
- The group includes `github.event_name` so a publish-only `workflow_dispatch` is not queued behind a push run. It never calls semantic-release (the release job is `if: github.event_name == 'push'`), so it has nothing to race with. Only push-to-main runs need to serialise with each other.

**2. Re-fetch tags before the already-tagged guard.**

The guard at `release.yml:82` ran `git rev-parse -q --verify refs/tags/v$NEXT` against the clone from checkout.

One correction to how this was originally described: the clone is *not* missing its tags. `fetch-depth: 0` fetches `+refs/tags/*:refs/tags/*` regardless of what `fetch-tags: false` says, and the run log above confirms it -- `* [new tag] v0.1.0`, `v0.2.0`, `v1.0.0`, and the rest all arrive at checkout.

The actual defect is staleness. Those tags are fetched *before* the ~25s `pip install python-semantic-release` step, so by the time the guard runs, the local tag list is a ~25s-old snapshot. A sibling run that tagged inside that window is invisible, and the guard waves it through. Fixed by re-fetching immediately before the check.

## Note on queued runs

With `cancel-in-progress: false` GitHub keeps at most one *pending* run per group, so a third merge replaces the queued second one. That is fine here and not a lost release: semantic-release computes the bump from every commit since the last tag, so the surviving run still includes the replaced run's commits.

## Verification

- `yaml.safe_load` parses the file; `concurrency` and both jobs resolve as intended.
- This is a `ci:` commit and therefore non-releasable (`patch_tags = ["fix", "perf"]`, `minor_tags = ["feat"]`), so merging it will correctly cut no release. main is currently at v3.0.0 with zero releasable commits since. The release + publish chain is proven end to end separately, on a real releasable commit.

Part 1 of 3 of the release-gating work. Parts 2 and 3 are branch protection with a release bypass, and the end-to-end proof.