### PR TITLE
test: revive the integration lane and run it in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,19 @@
 name: Tests
 
 on:
+  # Kept narrow on purpose -- only main, never every push to every feature
+  # branch, whose PRs the trigger below already covers. Without this, NOTHING
+  # ran the suite against main: a release is cut from a push to main
+  # (release.yml) and publishes to PyPI, so v3.0.0 shipped from a commit no
+  # test job had ever seen.
+  push:
+    branches: [ main ]
   # Deliberately unfiltered. `branches:` on a pull_request trigger matches the
   # BASE branch, not the head, so `branches: [ main ]` skipped every stacked PR
   # (one feature branch based on another) until its parent merged and GitHub
   # retargeted it onto main -- i.e. the tests only ran after review, never
-  # before. There is no `push:` trigger in this workflow, so accepting every
-  # base branch cannot double up with anything.
+  # before. This cannot double up with the `push:` above, because a commit
+  # pushed to main is never also the head of an open pull request.
   pull_request:
   workflow_dispatch:
 
@@ -40,6 +47,42 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
+
+  # The integration lane, which `addopts` in pyproject.toml deselects from every
+  # default `pytest` run. It is its own job rather than one more step in `test`
+  # so that it appears as a separately named check: the lane sat with 15 of its
+  # 18 tests failing precisely because no job anywhere ran it, and a step buried
+  # in another job would be just as easy to lose again.
+  #
+  # Most of these cover the streaming/CSC converter, which writes the Zarr store
+  # a downstream consumer opens with anndata.experimental.read_lazy(), so both
+  # operating systems are worth the runner time -- the atomic-write and path
+  # behaviour under test differs between them.
+  integration:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.12', '3.13']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+        poetry install
+    - name: Test with pytest
+      # `-m integration` on the command line overrides the `-m "not integration"`
+      # that addopts supplies, so this is exactly the invocation documented in
+      # tests/README.md -- which keeps that documentation honest.
+      run: |
+        poetry run pytest -m integration --disable-warnings
 
   # Installs thyra the way an end user does: a plain `pip install .` that
   # resolves dependencies fresh from PyPI, WITHOUT poetry.lock. This is the

--- a/tests/unit/converters/test_streaming_converter.py
+++ b/tests/unit/converters/test_streaming_converter.py
@@ -84,17 +84,34 @@ class MockMSIReader:
     def iter_spectra(
         self, batch_size: Optional[int] = None
     ) -> Generator[Tuple[Tuple[int, int, int], np.ndarray, np.ndarray], None, None]:
-        """Yield mock spectra for all pixels."""
+        """Yield mock spectra for all pixels.
+
+        Peaks are drawn from the very axis :meth:`get_common_mass_axis`
+        reports, not merely from the same mass RANGE. Without resampling,
+        ``BaseMSIConverter._map_mass_to_indices`` keeps only the peaks
+        landing within 1e-6 Da of a common-axis point and silently drops
+        the rest, so m/z values that just fall inside the range map to
+        nothing: every spectrum arrives empty, the occupancy is empty,
+        and the shapes frame is built from zero pixels. A mock whose two
+        methods describe different mass axes is not a stand-in for any
+        real reader.
+        """
         n_x, n_y, n_z = self.dimensions
-        min_mz, max_mz = self.mass_range
+        common_mass_axis = self.get_common_mass_axis()
 
         for z in range(n_z):
             for y in range(n_y):
                 for x in range(n_x):
-                    # Generate random m/z values within range
-                    mzs = np.sort(
-                        np.random.uniform(min_mz, max_mz, self.peaks_per_spectrum)
+                    # Sample distinct axis positions: a duplicate index would
+                    # write the same (pixel, m/z) cell twice.
+                    peak_indices = np.sort(
+                        np.random.choice(
+                            common_mass_axis.size,
+                            self.peaks_per_spectrum,
+                            replace=False,
+                        )
                     )
+                    mzs = common_mass_axis[peak_indices]
                     # Generate random intensities
                     intensities = np.random.exponential(1000, self.peaks_per_spectrum)
 
@@ -525,9 +542,9 @@ def test_streaming_converter_memory_efficiency():
     # Resampling config is required for memory-efficient conversion
     # Without it, raw mass axis collection can explode memory
     resampling_config = {
-        "method": "linear",
+        "method": "tic_preserving",
         "target_bins": 1000,
-        "axis_type": "uniform",
+        "axis_type": "constant",
     }
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -702,7 +719,7 @@ def test_auto_use_csc_mode_with_resampling():
     )
 
     resampling_config = {
-        "method": "linear",
+        "method": "tic_preserving",
         "target_bins": 5000,  # Custom target bins
     }
 


### PR DESCRIPTION
## What was wrong

`pytest -m integration` was 15 failed, 3 passed. Nothing ran it, so nothing said so.

`addopts` in `pyproject.toml:155` deselects the marker on every default run, both
CI jobs re-assert `-m "not integration"`, and no workflow anywhere re-selected it --
while `tests/README.md:43` documents `pytest -m integration` as a supported
invocation. The default suite stayed green throughout.

Both causes were environment-independent, in
`tests/unit/converters/test_streaming_converter.py`:

1. **`MockMSIReader` described two different mass axes.** It drew peaks from
   `np.random.uniform` across the mass range, but `get_common_mass_axis()`
   reported an `np.linspace`. With no resampling, `_map_mass_to_indices`
   (`thyra/core/base_converter.py:436-462`) keeps only peaks within `1e-6` Da of
   an axis point and returns `indices[mask]` -- it drops the rest silently. A
   uniform draw matches nothing, so every spectrum arrived empty, the occupancy
   was empty, and building the shapes frame from zero pixels raised `IndexError`
   at `streaming_converter.py:1798`.

   Peaks are now sampled from the axis the reader itself reports. That is not a
   new convention: `tests/fixtures/mock_msi_generator.py:215` already does
   exactly this (`mz_values = self._common_mass_axis[mz_indices]`).

2. **Two resampling configs named methods that do not exist.** `"method":
   "linear"` and `"axis_type": "uniform"` are not implemented; the accepted sets
   are `nearest_neighbor`/`tic_preserving` and
   `constant`/`linear_tof`/`reflector_tof`/`orbitrap`/`fticr`. They became a hard
   `ValueError` when `_resolve_config_enum` stopped silently ignoring unknown
   values, which was the right call -- silently dropping a typo hands back a
   conversion that ignored the request without saying so. They now name the
   implemented equivalents. (The brief for this work flagged only `method`;
   `axis_type` would have tripped immediately after.)

## Verification

| Check | Result |
| --- | --- |
| `pytest -m integration` (before) | 15 failed, 3 passed, 1282 deselected |
| `pytest -m integration` (after) | **18 passed**, 1282 deselected, 20s |
| Default suite | **1269 passed**, 13 skipped, 18 deselected -- unchanged |
| `read_lazy` contract | **41 passed** (`test_read_lazy_contract.py`, `test_lazy_loading_encoding.py`) |

Green is not by itself evidence the tests do anything -- that is how this lane
rotted. So I checked the data actually flows:

- `nnz = 2500` for a 5x5 grid at 100 peaks/pixel: exactly 25 x 100, **zero peaks
  dropped**. Every one of those was previously discarded.
- `max |axis[idx] - mz| = 0.0` against a 1e-6 tolerance; 50 unique m/z of 50, so
  no duplicate `(pixel, m/z)` cell.
- `reset()` reproduces identical m/z across passes -- load-bearing, because the
  CSC build iterates the reader twice and a differing second pass would corrupt
  the indptr.
- Minimum per-pixel TIC is non-zero, and the shapes frame has 25 rows.

17 of the 18 cover the streaming/CSC converter, the path a downstream consumer
opens with `anndata.experimental.read_lazy()`. The contract tests assert
materialised values (`assert_allclose` on dense output), not merely that
`read_lazy` succeeded.

## CI

**A job for the integration lane.** Separate rather than one more step in `test`,
so it reports as its own named check -- a step folded into an existing job would
be as easy to lose again. Both operating systems, because most of these tests
write a Zarr store and the atomic-write and path behaviour differs by platform.
It runs the exact command `tests/README.md` documents, so CI now keeps that page
honest.

**A `push: branches: [main]` trigger.** There was none, so no test job had ever
run against main. Check runs on main HEAD were exactly three -- Create Release,
complexity-check, and a skipped publish. Since a push to main cuts a release,
v3.0.0 was published from a commit no test job had seen.

The existing comment explaining why `pull_request` is deliberately unfiltered is
preserved; `branches:` there matches the *base*, which silently skipped stacked
PRs. Only its closing sentence changed, which asserted no `push:` trigger
existed. The narrow `push` and the unfiltered `pull_request` cannot double up: a
commit pushed to main is never also the head of an open PR. This mirrors the
pattern already in `complexity-monitoring.yml`.

## One thing this does not do

It makes main's test status **visible, not enforced**. `release.yml` triggers on
the same push to main and runs *alongside* this workflow, not after it -- so a
failing test job will not stop the publish. Gating that is a change to
`release.yml`, which is outside this lane and worth deciding deliberately.

`test:` and `ci:` are both non-releasable, so merging this publishes nothing.
