### PR TITLE
fix(converters): guard the streaming COO path against out-of-grid coordinates

### DIFF
--- a/tests/unit/converters/test_coo_out_of_grid_guard.py
+++ b/tests/unit/converters/test_coo_out_of_grid_guard.py
@@ -1,0 +1,276 @@
+"""The streaming COO path skips spectra outside the declared grid.
+
+The PCS pre-scan grew this guard in 87f287c; the COO path never got it.
+Both passes index a row by ``z * (n_x * n_y) + y * n_x + x`` and neither
+checked the result, so a negative coordinate was a legal negative numpy
+index and wrapped silently onto an unrelated pixel.
+
+The two passes fail differently, which is why both are guarded here:
+
+* **Pass 1** assigns ``nnz_per_row[pixel_idx] = nnz`` *unconditionally*,
+  so even an empty wrapped spectrum overwrites a real row's count with
+  zero -- the reason this guard sits outside the ``nnz > 0`` test that
+  its PCS counterpart lives inside.
+* **Pass 2** writes at ``write_pos[pixel_idx]`` and advances it, so the
+  wrapped-onto row's own entries get pushed past the end of the space
+  pass 1 reserved for it and are dropped by the slice assignment.
+
+The result was neither the intruder's value nor the victim's but a
+mixture of the two, which is the shape of failure that makes this worth
+a test: every number stayed plausible and nothing warned. On the 4x4
+fixture below, pixel (3, 3) stored 39,508.05 against a truth of
+47,363.47, while ``use_csc=True`` on the same input warned and stored
+47,363.47.
+
+**Reachability.** ``imzml_reader`` subtracts 1 from the 1-based positions
+an imzML declares, so a file that is already 0-based yields ``x = -1``
+-- the same base-convention hazard ``_z_base()`` documents for z. That
+route is inferred from the reader source rather than measured against a
+vendor file, so the fixture reproduces the coordinate directly.
+
+Only x and y are exercised. ``_refuse_multiple_z_planes`` runs before
+either route is chosen, so ``n_z == 1`` and a z term cannot reach here.
+"""
+
+import logging
+from pathlib import Path
+
+import anndata
+import numpy as np
+import pytest
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+)
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+_N_X = 4
+_N_Y = 4
+_TABLE_KEY = "mock_z0"
+
+# The spectrum that gets relocated, and where it is yielded instead.
+_RELOCATED_FROM = (0, 0, 0)
+_OUT_OF_GRID = (-1, 0, 0)
+# y * n_x + x == -1 for that coordinate, which indexes the *last* row.
+_WRAP_TARGET = (_N_X - 1, _N_Y - 1)
+
+_WARNING_FRAGMENT = "outside the declared"
+
+
+class _OutOfGridReader(MockMSIReader):
+    """Yields one spectrum at ``x = -1``, the rest on the declared grid.
+
+    Dimensions and spectrum count still say 4x4x1: the point is a reader
+    whose *coordinates* disagree with the grid it declares, which is what
+    an off-by-one in base convention produces.
+    """
+
+    def iter_spectra(self, batch_size=None):
+        for coords, mzs, intensities in super().iter_spectra(batch_size):
+            yield (
+                _OUT_OF_GRID if coords == _RELOCATED_FROM else coords
+            ), mzs, intensities
+
+
+def _config() -> MockMSIConfig:
+    return MockMSIConfig(
+        n_x=_N_X,
+        n_y=_N_Y,
+        n_z=1,
+        n_mz_bins=100,
+        peaks_per_spectrum=(8, 15),
+        sparsity=0.0,
+    )
+
+
+def _convert(output_path: Path, reader, use_csc: bool) -> bool:
+    return StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=output_path,
+        dataset_id="mock",
+        pixel_size_um=10.0,
+        use_csc=use_csc,
+    ).convert()
+
+
+class _CaptureWarnings(logging.Handler):
+    """Collect warnings straight off the converter's own logger.
+
+    Attached to the module logger rather than going through ``caplog``,
+    which sees nothing here: the converters configure logging themselves
+    and the suite's global state is whatever ran before this file.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.WARNING)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+    def __enter__(self) -> "_CaptureWarnings":
+        self._logger = logging.getLogger(
+            "thyra.converters.spatialdata.streaming_converter"
+        )
+        self._logger.addHandler(self)
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._logger.removeHandler(self)
+
+    @property
+    def out_of_grid(self) -> list[str]:
+        return [m for m in self.messages if _WARNING_FRAGMENT in m]
+
+
+def _reader_totals(reader) -> dict:
+    """Total intensity per (x, y) as the reader yields it.
+
+    The independent oracle: computed from the input, never read back off
+    the store, so the store cannot grade its own homework. Mock peaks sit
+    exactly on the common mass axis, so resampling is lossless and these
+    totals are directly comparable to the stored ones.
+    """
+    totals: dict = {}
+    for (x, y, _z), _mzs, intensities in reader.iter_spectra():
+        totals[(x, y)] = totals.get((x, y), 0.0) + float(intensities.sum())
+    return totals
+
+
+def _stored_totals(store_path: Path) -> dict:
+    """Stored intensity per (x, y), keyed by the obs coordinates."""
+    adata = anndata.read_zarr(store_path / "tables" / _TABLE_KEY)
+    row_sums = np.asarray(adata.X.sum(axis=1)).ravel()
+    xs = np.asarray(adata.obs["x"]).astype(int)
+    ys = np.asarray(adata.obs["y"]).astype(int)
+    return {(int(x), int(y)): float(v) for x, y, v in zip(xs, ys, row_sums)}
+
+
+def test_the_fixture_actually_wraps_onto_a_populated_pixel():
+    """Guard the guard: the setup must reproduce the collision.
+
+    If the mock ever stops emitting the corner spectrum, or the row
+    formula changes, every assertion below would pass vacuously against
+    a fixture that no longer collides with anything.
+    """
+    truth = _reader_totals(_OutOfGridReader(_config()))
+
+    assert (_OUT_OF_GRID[0], _OUT_OF_GRID[1]) in truth, "no out-of-grid spectrum"
+    assert _WRAP_TARGET in truth, "nothing at the position it wraps onto"
+    assert truth[_WRAP_TARGET] > 0.0
+
+
+@pytest.mark.parametrize("use_csc", [True, False])
+def test_out_of_grid_spectrum_leaves_the_wrapped_pixel_alone(tmp_path, use_csc):
+    """Every in-grid pixel keeps its own intensity, on both routes.
+
+    Asserted over the whole grid rather than just the victim: a guard
+    that skipped too much would show up as some *other* pixel going
+    missing or short.
+    """
+    truth = _reader_totals(_OutOfGridReader(_config()))
+    in_grid = {
+        (x, y): total
+        for (x, y), total in truth.items()
+        if 0 <= x < _N_X and 0 <= y < _N_Y
+    }
+
+    out = tmp_path / f"oog_{use_csc}.zarr"
+    assert _convert(out, _OutOfGridReader(_config()), use_csc) is True
+
+    stored = _stored_totals(out)
+
+    assert set(stored) == set(in_grid), "the stored grid positions changed"
+    assert stored[_WRAP_TARGET] == pytest.approx(truth[_WRAP_TARGET], rel=1e-9)
+    for position, expected in in_grid.items():
+        assert stored[position] == pytest.approx(expected, rel=1e-9), position
+
+
+def test_both_routes_agree_on_out_of_grid_input(tmp_path):
+    """The two routes must produce the same store from the same input.
+
+    This is the assertion the bug would have failed: PCS already skipped
+    the spectrum and COO wrapped it, so the same file converted two
+    different ways gave two different answers for pixel (3, 3) and only
+    one of them warned.
+    """
+    pcs = tmp_path / "pcs.zarr"
+    coo = tmp_path / "coo.zarr"
+
+    assert _convert(pcs, _OutOfGridReader(_config()), use_csc=True) is True
+    assert _convert(coo, _OutOfGridReader(_config()), use_csc=False) is True
+
+    pcs_totals = _stored_totals(pcs)
+    coo_totals = _stored_totals(coo)
+
+    assert set(pcs_totals) == set(coo_totals)
+    for position, pcs_value in pcs_totals.items():
+        assert coo_totals[position] == pytest.approx(pcs_value, rel=1e-9), position
+
+
+@pytest.mark.parametrize("use_csc", [True, False])
+def test_the_skipped_spectrum_is_reported(tmp_path, use_csc):
+    """Dropping data silently is what made this expensive to find."""
+    with _CaptureWarnings() as captured:
+        out = tmp_path / f"warn_{use_csc}.zarr"
+        assert _convert(out, _OutOfGridReader(_config()), use_csc) is True
+
+    assert len(captured.out_of_grid) == 1, captured.messages
+    assert "1 spectra" in captured.out_of_grid[0]
+    assert f"{_N_X}x{_N_Y}" in captured.out_of_grid[0]
+
+
+@pytest.mark.parametrize("use_csc", [True, False])
+def test_a_clean_grid_is_untouched_and_silent(tmp_path, use_csc):
+    """No false positives: the ordinary case keeps every spectrum.
+
+    The stored values for an in-grid dataset are unchanged by this fix,
+    which is the claim that matters to anyone holding an existing store.
+    """
+    truth = _reader_totals(MockMSIReader(_config()))
+
+    with _CaptureWarnings() as captured:
+        out = tmp_path / f"clean_{use_csc}.zarr"
+        assert _convert(out, MockMSIReader(_config()), use_csc) is True
+
+    assert captured.out_of_grid == []
+
+    stored = _stored_totals(out)
+    assert len(stored) == _N_X * _N_Y
+    for position, expected in truth.items():
+        assert stored[position] == pytest.approx(expected, rel=1e-9), position
+
+
+def test_the_coo_store_still_opens_lazily(tmp_path):
+    """Ousia opens these stores through ``anndata.experimental.read_lazy``.
+
+    Pass 1 now sizes the Zarr arrays from a smaller ``total_nnz`` than it
+    used to, and ``indptr`` is built from the same skipped counts. Those
+    two have to stay consistent or the CSR is malformed -- a mismatch
+    that an eager read can absorb but the lazy path need not. Values are
+    materialised rather than trusting the handle: encoding corruption is
+    invisible until the blocks are computed (see
+    ``tests/unit/test_read_lazy_contract.py``).
+    """
+    truth = _reader_totals(_OutOfGridReader(_config()))
+
+    out = tmp_path / "lazy.zarr"
+    assert _convert(out, _OutOfGridReader(_config()), use_csc=False) is True
+
+    adata = anndata.experimental.read_lazy(str(out / "tables" / _TABLE_KEY))
+    materialised = adata.X.compute()
+
+    assert materialised.shape[0] == _N_X * _N_Y - 1, "one position had no spectrum"
+
+    row_sums = np.asarray(materialised.sum(axis=1)).ravel()
+    xs = np.asarray(adata.obs["x"]).astype(int)
+    ys = np.asarray(adata.obs["y"]).astype(int)
+    lazy_totals = {(int(x), int(y)): float(v) for x, y, v in zip(xs, ys, row_sums)}
+
+    assert lazy_totals[_WRAP_TARGET] == pytest.approx(truth[_WRAP_TARGET], rel=1e-9)

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -461,6 +461,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         nnz_per_row = np.zeros(n_rows, dtype=np.int64)
         total_nnz = 0
         pixel_count = 0
+        n_out_of_bounds = 0
 
         region_map, region_total, region_count = self._init_region_accumulators(n_cols)
 
@@ -476,11 +477,22 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 mz_indices, resampled_ints = self._process_spectrum(mzs, intensities)
                 nnz = len(mz_indices)
 
-                nnz_per_row[pixel_idx] = nnz
-                total_nnz += nnz
-
+                # The row count and the TIC are both indexed by grid
+                # position, so both need the bounds check: a coordinate
+                # outside the declared dimensions would otherwise wrap
+                # round and land on an unrelated pixel. Unlike the PCS
+                # pre-scan the guard sits outside the `nnz > 0` test,
+                # because this assignment is unconditional -- a wrapped
+                # empty spectrum would overwrite a real row's count with
+                # zero. total_nnz travels with nnz_per_row so that
+                # indptr[-1] keeps matching the array size derived from
+                # it; pass 2 skips the same spectra.
                 if 0 <= y < n_y and 0 <= x < n_x:
+                    nnz_per_row[pixel_idx] = nnz
+                    total_nnz += nnz
                     tic_values[y, x] = float(np.sum(resampled_ints))
+                else:
+                    n_out_of_bounds += 1
 
                 if nnz > 0:
                     np.add.at(total_intensity, mz_indices, resampled_ints)
@@ -500,6 +512,15 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 pbar.update(1)
 
         logger.info(f"Pass 1 complete: {total_nnz:,} total non-zeros")
+        if n_out_of_bounds:
+            logger.warning(
+                "%d spectra sat outside the declared %dx%d grid and were "
+                "skipped. Previously they were written to a wrapped-round "
+                "row index, silently overwriting an unrelated pixel.",
+                n_out_of_bounds,
+                n_x,
+                n_y,
+            )
 
         # Build indptr from nnz counts
         indptr = np.zeros(n_rows + 1, dtype=np.int64)
@@ -628,7 +649,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 mz_indices, resampled_ints = self._process_spectrum(mzs, intensities)
                 nnz = len(mz_indices)
 
-                if nnz > 0:
+                # Same bounds check as pass 1, and it has to be the same
+                # one: that pass reserved no room for a spectrum outside
+                # the grid, so writing it here would overrun the row it
+                # wrapped onto and displace that row's own entries.
+                if nnz > 0 and 0 <= y < n_y and 0 <= x < n_x:
                     pos = write_pos[pixel_idx]
                     positions = np.arange(pos, pos + nnz)
                     buf_positions.append(positions)


### PR DESCRIPTION
Ports the bounds guard the PCS pre-scan grew in 87f287c to the COO path,
which never got it.

## The bug

Both COO passes index a row by `z * (n_x * n_y) + y * n_x + x` and neither
checked the result. A negative coordinate is a legal negative numpy index, so
it wrapped silently onto an unrelated pixel.

The two passes fail differently, which is why both needed guarding:

- **Pass 1** (`_coo_pass1_count_nonzeros`) assigns `nnz_per_row[pixel_idx] = nnz`
  *unconditionally*, so even an empty wrapped spectrum overwrites a real row's
  count with zero. That is why this guard sits outside the `nnz > 0` test its
  PCS counterpart lives inside.
- **Pass 2** (`_coo_pass2_write_data`) writes at `write_pos[pixel_idx]` and
  advances it, pushing the wrapped-onto row's own entries past the end of the
  space pass 1 reserved for it, where the slice assignment drops them.

What came out was neither the intruder's value nor the victim's but a mixture
of the two: every number stayed plausible and nothing warned.

## Measured

4x4 grid, one spectrum relocated to `x = -1` (which indexes the last row, so it
collides with pixel (3, 3)). Truth for (3, 3) is 47,363.47.

| route | `convert()` | warned | stored (3, 3) |
|---|---|---|---|
| `use_csc=True` (PCS) | True | yes | 47,363.47 |
| `use_csc=False` (COO), before | True | **no** | **39,508.05** |
| `use_csc=False` (COO), after | True | yes | 47,363.47 |

Both routes now warn with the same text and produce the same store.

## Do stored values change?

**Only for a dataset that yields a coordinate outside its declared grid.** For
those, the out-of-grid spectrum is dropped instead of overwriting a pixel, so
the pixel it used to corrupt reads back correct, and `obs` loses the row whose
spectrum went out of grid.

**An in-grid dataset is unchanged** -- that is every dataset the suite had
before this. `test_a_clean_grid_is_untouched_and_silent` pins it on both routes:
every pixel keeps its value and nothing warns.

`total_nnz` travels with `nnz_per_row` rather than accumulating separately, so
`indptr[-1]` keeps matching the array size derived from it and the CSR stays
well-formed. `test_the_coo_store_still_opens_lazily` materialises the store
through `anndata.experimental.read_lazy` rather than trusting the handle, since
Ousia opens these stores lazily and encoding damage is invisible until the
blocks are computed.

## Reachability

Inferred from the reader source, **not measured against a vendor file**:
`_get_spectrum_coordinates` does `x - 1, y - 1` on 1-based positions, so a file
that is already 0-based yields `x = -1`. That is the same base-convention
hazard `_z_base()` already rebases z against; x and y have no equivalent. Worth
confirming against a real 0-based export, but the guard is right either way.

Only x and y are reachable regardless: `_refuse_multiple_z_planes` runs before
either route is chosen, so `n_z == 1`.

## Verification

- Full suite: **1278 passed, 13 skipped, 18 deselected** (baseline on `main` was
  1269 passed, 13 skipped, 18 deselected; this adds 9).
- The new module was run against unpatched source: the 4 COO assertions fail and
  the PCS ones pass, confirming it discriminates the bug rather than the fixture.
- `tests/unit/test_read_lazy_contract.py` still passes.
- black, isort, flake8, mypy, pydocstyle, bandit all clean on the changed files.

Note this cuts a release on merge.
