### PR TITLE
fix(cli): put every --help option in a category, and keep it that way

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,9 +9,10 @@ thyra [OPTIONS] INPUT OUTPUT
 **OUTPUT** -- Path for output `.zarr` directory
 
 !!! tip "Grouped help"
-    Run `thyra --help` to see all options organised by category (Conversion,
-    Logging, Resampling, Performance, Bruker-Specific, Other), and
-    `thyra --version` to print the installed version.
+    `thyra --help` lists every option under a category heading -- Conversion,
+    Logging, Resampling (advanced), Performance, imzML-specific,
+    Bruker-specific, Other, and a General section holding `--version` and
+    `--help` -- in the same order as the sections on this page.
 
 ---
 

--- a/tests/unit/test_cli_help_grouping.py
+++ b/tests/unit/test_cli_help_grouping.py
@@ -1,0 +1,129 @@
+# tests/unit/test_cli_help_grouping.py
+"""Tests that ``thyra --help`` really is organised by category.
+
+``GroupedCommand.format_help`` sweeps anything missing from
+``GroupedCommand.GROUPS`` into a trailing ``Options:`` section. That makes a
+forgotten option invisible as a bug -- the help still renders, the option is
+still listed, and only a reader comparing it against docs/cli.md's promise of
+"all options organised by category" would notice. Two options sat there for
+two releases exactly that way.
+
+These tests make the sweep bucket assert-on-non-empty, so classifying a new
+option is part of adding it rather than a thing to remember.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from thyra.__main__ import GroupedCommand, main
+
+
+@pytest.fixture
+def ctx():
+    with click.Context(main) as context:
+        yield context
+
+
+def _visible_params(ctx):
+    """Options that actually render in --help.
+
+    Hidden options (``--optimize-chunks``) return no help record and are
+    excluded, which is correct: they are not shown, so they need no section.
+    """
+    return [
+        p for p in ctx.command.get_params(ctx) if p.get_help_record(ctx) is not None
+    ]
+
+
+def _spellings(param):
+    """Every name a param answers to, primary and secondary."""
+    return set(getattr(param, "opts", [])) | set(getattr(param, "secondary_opts", []))
+
+
+def _groups_for(param):
+    """The GROUPS sections that claim this param, by any of its spellings."""
+    names = _spellings(param)
+    return {
+        group
+        for group, members in GroupedCommand.GROUPS.items()
+        if names & set(members)
+    }
+
+
+class TestEveryOptionIsClassified:
+    """The mapping between options and sections must be total and unique."""
+
+    def test_every_visible_option_is_in_exactly_one_group(self, ctx):
+        misfiled = {
+            sorted(_spellings(p))[0]: sorted(_groups_for(p))
+            for p in _visible_params(ctx)
+            if len(_groups_for(p)) != 1
+        }
+
+        assert not misfiled, (
+            "every option shown in --help must belong to exactly one "
+            "GroupedCommand.GROUPS section. Offenders map to the sections "
+            f"that claim them (an empty list means none): {misfiled}"
+        )
+
+    def test_groups_lists_no_option_that_does_not_exist(self, ctx):
+        real = set()
+        for param in _visible_params(ctx):
+            real |= _spellings(param)
+
+        phantom = {
+            group: [name for name in members if name not in real]
+            for group, members in GroupedCommand.GROUPS.items()
+            if any(name not in real for name in members)
+        }
+
+        assert not phantom, (
+            "GroupedCommand.GROUPS names options the command does not have. "
+            "A renamed or removed option leaves its old spelling behind here, "
+            "where it silently stops matching anything: " + repr(phantom)
+        )
+
+
+class TestRenderedHelp:
+    """The end-to-end assertion: what a user actually sees."""
+
+    def test_help_has_no_ungrouped_options_section(self):
+        result = CliRunner().invoke(main, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "\nOptions:\n" not in result.output, (
+            "--help ended with an ungrouped 'Options:' section, so at least "
+            "one option is missing from GroupedCommand.GROUPS. Rendered "
+            "help:\n" + result.output
+        )
+
+    def test_help_renders_every_declared_section(self):
+        result = CliRunner().invoke(main, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        missing = [
+            group
+            for group in GroupedCommand.GROUPS
+            if f"\n{group}:\n" not in result.output
+        ]
+
+        assert not missing, (
+            "sections declared in GROUPS did not render, which means every "
+            f"option in them has gone: {missing}"
+        )
+
+    @pytest.mark.parametrize(
+        "option, group",
+        [
+            ("--resample-gap-tolerance", "Resampling (advanced)"),
+            ("--spectrum-type", "imzML-specific"),
+            ("--version", "General"),
+            ("--help", "General"),
+        ],
+    )
+    def test_previously_ungrouped_options_are_classified(self, option, group):
+        """The four that were in the sweep bucket, pinned to their sections."""
+        assert option in GroupedCommand.GROUPS[group]

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -350,7 +350,22 @@ def _handle_post_conversion(success: bool, output: Path) -> bool:
 
 
 class GroupedCommand(click.Command):
-    """Command that groups options into sections in --help output."""
+    """Command that groups options into sections in --help output.
+
+    Every visible option must appear in exactly one ``GROUPS`` entry.
+    Anything missing still shows up -- ``format_help`` sweeps the remainder
+    into a trailing ``Options:`` section rather than dropping it -- but that
+    section is a defect signal, not a home. It is where
+    ``--resample-gap-tolerance`` and ``--spectrum-type`` sat for two
+    releases, next to ``--version`` and ``--help``, while docs/cli.md told
+    readers the help was organised by category.
+
+    ``tests/unit/test_cli_help_grouping.py`` fails if the trailing section is
+    ever non-empty again, so adding an option without classifying it here is
+    caught before release rather than by a reader.
+
+    Section order is mirrored by docs/cli.md; keep the two in step.
+    """
 
     GROUPS = {
         "Conversion": [
@@ -371,8 +386,10 @@ class GroupedCommand(click.Command):
             "--resample-max-mz",
             "--resample-width-at-mz",
             "--resample-reference-mz",
+            "--resample-gap-tolerance",
         ],
         "Performance": ["--streaming", "--sparse-format"],
+        "imzML-specific": ["--spectrum-type"],
         "Bruker-specific": [
             "--use-recalibrated",
             "--no-recalibrated",
@@ -380,6 +397,7 @@ class GroupedCommand(click.Command):
             "--intensity-threshold",
         ],
         "Other": ["--dataset-id", "--handle-3d"],
+        "General": ["--version", "--help"],
     }
 
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:


### PR DESCRIPTION
Split out of #148 because it is a `fix:` and cuts a release, where that PR was
deliberately release-free.

## The defect

`thyra --help` ended with an ungrouped `Options:` section:

```
Options:
  --version                       Show the version and exit.
  --resample-gap-tolerance FLOAT  For tic_preserving only: discard target bins
                                  ...
  --spectrum-type [auto|profile|centroid]
                                  Spectrum representation ...
  --help                          Show this message and exit.
```

Directly above it, `docs/cli.md` told the reader `--help` shows "all options
organised by category".

Both real flags post-date `GroupedCommand.GROUPS` and were never added to it.
`format_help` sweeps whatever the dict does not name into that trailing
section rather than dropping it, which is the right failure mode but an
invisible one -- the option still renders, so nothing looks broken. They sat
there for two releases.

## The fix

- `--resample-gap-tolerance` joins **Resampling (advanced)**.
- `--spectrum-type` gets an **imzML-specific** section, matching how
  `docs/cli.md` already files it.
- `--version` and `--help` go into a **General** section rather than being
  exempted as boilerplate.

That last one is the deliberate part. Grouping them leaves the sweep bucket
empty in the steady state, so a trailing `Options:` section now *means*
"someone added an option without classifying it" instead of being a permanent
fixture nobody reads. The bucket becomes a signal.

Section order matches `docs/cli.md`'s, and the docstring says to keep them in
step.

## The test

`tests/unit/test_cli_help_grouping.py` pins the invariant three ways:

1. every visible option resolves to **exactly one** section -- catching both
   the unclassified option and the one accidentally listed twice;
2. `GROUPS` names no option that no longer exists, which is how a renamed flag
   would otherwise leave a dead spelling behind that silently matches nothing;
3. the rendered `--help` contains no trailing `Options:` section at all.

Checked against the pre-fix code, where **6 of the 8 fail**. A test that
passes either way would not have been worth adding.

Hidden options are excluded on purpose: `--optimize-chunks` returns no help
record, so it is not shown and needs no section.

## Verification

- `pytest -q` -> **1277 passed**, 13 skipped (1269 before, plus these 8).
- `mkdocs build --strict` clean.
- `thyra --help` now ends at `General:` with no ungrouped bucket.

## Note on merging

This cuts a patch release when it lands (`patch_tags = ["fix", "perf"]`), so
it publishes to PyPI. Left for you to merge rather than merged for you.