### PR TITLE
ci(release): release main's tip, not the commit that triggered the run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,37 @@ jobs:
       - name: Create Release
         id: release
         run: |
+          # Release main's tip, not the commit that triggered this run.
+          #
+          # The concurrency group at the top of this file serialises release
+          # RUNS. It cannot stop a MERGE landing while one is running, because a
+          # merge is a push, not a workflow run -- so it does not fix the
+          # "[LOCAL SHA] != [UPSTREAM SHA] / Upstream branch 'origin/main' has
+          # changed!" failure it was added for. That failure recurred eight
+          # minutes after #144 shipped, in a run whose own checkout contained the
+          # concurrency block: run 30806223426 checked out b5c3d8c, spent ~50s
+          # installing semantic-release, and by the time it pushed, two further
+          # merges had moved main to 9b9fd81.
+          #
+          # Any merge landing inside this job's ~60-90s window does that. The
+          # window cannot be closed by scheduling, only by not caring where main
+          # was when the run started.
+          #
+          # Re-pointing at the tip is also right on its own terms: what is on
+          # main is what ships, and semantic-release computes the bump from every
+          # commit since the last tag, so nothing is skipped by releasing a newer
+          # commit than the one that triggered us. It is what makes a replaced
+          # queue entry harmless -- GitHub keeps only one pending run per group,
+          # and the survivor now covers the replaced run's commits too.
+          #
+          # Explicit refspec rather than `git fetch origin main`, so that
+          # refs/remotes/origin/main is definitely updated and not just
+          # FETCH_HEAD.
+          git fetch origin +refs/heads/main:refs/remotes/origin/main
+          git checkout -B main refs/remotes/origin/main
+          RELEASE_SHA=$(git rev-parse HEAD)
+          echo "releasing from origin/main tip $RELEASE_SHA (this run was triggered by $GITHUB_SHA)"
+
           # `--print` reports the version semantic-release WOULD release. When
           # nothing on main is releasable -- a ci:/chore:/docs:/test: commit --
           # it prints the CURRENT version, not an empty string. So an emptiness


### PR DESCRIPTION
Follow-up to #144, and a correction to it. **#144 did not fix the failure it was added for.**

## Evidence

Run [30806223426](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/actions/runs/30806223426) failed eight minutes after #144 merged, with the identical error, in a run whose own checkout contained the concurrency block (`git show b5c3d8c:.github/workflows/release.yml` has it):

```
[LOCAL SHA] b5c3d8c9be66b67ba846ae547b8d8f38c4457603 != 9b9fd81328ac38f40e0a39b35978253829a8957c [UPSTREAM SHA].
Upstream branch 'origin/main' has changed!
```

## Why the concurrency group was never going to fix it

It serialises release **runs**. A merge is a **push**, not a workflow run, so nothing stops main advancing while a run is in flight.

Three merges landed within four seconds at 10:36 (#146, #148, #149) and the group did behave as designed -- one ran, one was cancelled as a replaced queue entry, one succeeded:

| run | sha | result |
|---|---|---|
| 30806223426 | `b5c3d8c` (#146, a `fix:`) | **failure** |
| 30806224606 | `ddbd236` (#148) | cancelled -- replaced in the queue |
| 30806228453 | `9b9fd81` (#149) | success |

The failing run checked out `b5c3d8c`, spent ~50s installing semantic-release, and by the time it pushed, main was two commits further on. Any merge landing inside the job's 60-90s window does this, and no amount of scheduling closes it.

## The change

Stop caring where main was when the run started -- re-point at the tip before computing the version:

```bash
git fetch origin +refs/heads/main:refs/remotes/origin/main
git checkout -B main refs/remotes/origin/main
```

Explicit refspec rather than `git fetch origin main`, so `refs/remotes/origin/main` is definitely updated and not just `FETCH_HEAD`.

This is also correct on its own terms rather than just as a workaround: what is on main is what ships, and semantic-release derives the bump from every commit since the last tag, so releasing a newer commit than the trigger skips nothing. It is what makes a replaced queue entry harmless -- GitHub keeps only one pending run per group, and the survivor now covers the replaced run's commits too.

## Verification

The two git commands were exercised against a clone replicating the runner's checkout state (`git init` + `fetch-depth: 0` refspec + local `main` deliberately 3 commits behind). Result: `HEAD` moved `3caad06` to `780df41`, gaining 5 commits, on branch `main` tracking `origin/main`. YAML parses.

**Not proven end to end.** That needs a real release to exercise it, which the current merge rate should provide quickly after merge. Left open for your call rather than merged, since a mistake here stops releases for every lane currently landing work.

## Scope

`ci:` commit, non-releasable. No release was lost to this bug -- v3.0.1 and v3.0.2 shipped and carried the fix from the run that failed. What it costs today is a false red X on a `fix:` merge, and an indefinitely delayed release if a failing run happens to be the last push for a while.

**Residual window.** This shrinks the race to the gap between the re-sync and the push; it does not eliminate it. Closing that fully needs a retry around `semantic-release version`, which is a larger change and not attempted here.