### PR TITLE
ci(docs): serialise gh-pages deploys so a slow older run cannot win

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,34 @@ on:
 permissions:
   contents: write
 
+# Every run of this workflow ends in `mkdocs gh-deploy --force`, which force-pushes
+# the whole built site over gh-pages. Two runs overlapping is therefore a lost-update
+# race, and the loser is decided by build duration, not by commit order: on
+# 2026-08-03 the merges of #146 and #148 started one second apart (10:36:11 and
+# 10:36:12) and took 1m25s and 2m59s. The newer content happened to finish last, so
+# the site is correct. Reverse the durations and #146's checkout -- which predates
+# #148's changes to 9 doc files -- would have force-pushed over them. Both runs
+# still report success and neither log mentions the other, so the only symptom is a
+# published site silently missing merged documentation.
+#
+# Unlike release.yml's group, this one is deliberately NOT keyed on the event or the
+# ref. There is exactly one gh-pages branch, so a workflow_dispatch and a push to
+# main are contending for the same force-push and must serialise against each other.
+# Keying the group would let precisely the two runs that conflict run concurrently.
+#
+# cancel-in-progress stays false, but not because gh-deploy is fragile -- it is not.
+# It publishes via `git fast-import` into a local ref and one `git push --force`,
+# never a gh-pages working tree, and a remote ref update is atomic, so a killed push
+# leaves gh-pages untouched. The reason is that cancellation is not synchronous: a
+# cancelled step gets SIGINT, 7.5s, SIGTERM, 2.5s before its process tree is killed,
+# and nothing documents that a queued run waits for that to finish. With `true` the
+# older run's force-push can still be in flight when the newer run starts, which
+# reintroduces the exact race this group exists to remove. Queueing has no such
+# window.
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## The race

`docs.yml` had no `concurrency:` group, and its only real step is
`mkdocs gh-deploy --force`, which force-pushes the entire built site over
`gh-pages`. Two overlapping runs are therefore a lost-update race, and the
winner is decided by **build duration, not commit order**.

Observed on 2026-08-03, both triggered by merges to main one second apart:

| run | PR | sha | started | duration | finished |
|---|---|---|---|---|---|
| 30806223125 | #146 | `b5c3d8c9` | 10:36:11 | 1m25s | 10:37:36 |
| 30806224510 | #148 | `ddbd2368` | 10:36:12 | 2m59s | 10:39:11 |

`b5c3d8c9` is an ancestor of `ddbd2368` (`git merge-base --is-ancestor`
confirms), and #148 changed nine files the site publishes:

```
docs/api.md  docs/changelog.md  docs/cli.md  docs/contributing.md
docs/getting-started.md  docs/index.md  docs/resampling.md
docs/tutorial.md  mkdocs.yml
```

The newer content finished last, so the deployed site is correct **by luck**.
Reverse the two durations and #146's build -- made from a checkout predating
every one of those changes -- force-pushes over #148's deploy. Both runs still
report success, and neither log mentions the other. The only symptom is a
published site silently missing merged documentation.

This is a live risk rather than a curiosity: several lanes merge close
together, and the workflow triggers on every push to main touching `docs/**`,
`mkdocs.yml`, `thyra/**` or `CHANGELOG.md`.

## Why `cancel-in-progress: false`

The intuition for queueing was that a cancelled `gh-deploy` could leave the
gh-pages checkout mid-push. **That specific concern does not hold**, and it is
worth recording why, so nobody re-derives it later:

- `mkdocs gh-deploy` delegates to `ghp-import`, which never creates a gh-pages
  working tree. It builds the commit with `git fast-import` into a local ref
  and then runs a single `git push --force`.
- A remote ref update is atomic. A killed push leaves `gh-pages` pointing at
  its previous commit, not at something half-written.
- The local ref lives on an ephemeral runner that is discarded either way.

So `gh-deploy` **is** atomic enough, and on that argument alone
`cancel-in-progress: true` would have been the cheaper choice.

The reason to queue anyway is different: **cancellation is not synchronous.**
A cancelled step gets SIGINT, then 7.5s, then SIGTERM, then 2.5s before its
process tree is killed, and the server allows up to five minutes before forcing
termination. Nothing in the Actions documentation states that a queued run in
the same concurrency group waits for that teardown to finish. With `true`, the
older run's `git push --force` can still be in flight when the newer run starts
-- which reintroduces precisely the race this group exists to remove, in a
narrower window. Queueing has no such window, and costs one extra build.

## Why the group is not keyed

`release.yml` keys its group on `github.event_name` and `github.ref`, for a
documented reason specific to that workflow. This one is deliberately a
constant. There is exactly one `gh-pages` branch, so a `workflow_dispatch` and
a push to main are contending for the same force-push and must serialise
against each other. Keying the group would let precisely the two runs that
conflict run concurrently. The comment in the file says so, to stop the
inconsistency with `release.yml` being "fixed" later.

## Residual risk, not closed by this PR

GitHub's own documentation says concurrency-group ordering is FIFO by the time
each run started waiting, but that **"ordering is not guaranteed."** So this
change serialises the two force-pushes without guaranteeing they run in commit
order. If the older run were admitted to the group second, it would still
publish stale content, with both runs green.

That turns a coin flip decided by build duration into a rare admission-order
inversion, which is a large improvement but not a proof. The belt-and-braces
fix is to have the job check out `main` at its current tip rather than the
triggering sha, so that whichever run goes last builds current `main` regardless
of admission order. That changes deploy semantics (a re-run would publish
today's docs rather than reproduce the old build), so it is left out of this PR
rather than bundled in silently.

## Separate defect found while verifying

Not fixed here, and worth its own issue: `780df41` ("3.0.2") rewrote
`CHANGELOG.md`, and `docs/changelog.md` is a snippets include of that file --
but there is **no docs run for `780df41`**. The newest docs run is for
`de221fe`, and `gh-pages` is currently at `Deployed de221fe with MkDocs version:
1.6.1`.

The cause is that `release.yml` checks out and pushes with
`secrets.GITHUB_TOKEN`, and pushes made with `GITHUB_TOKEN` do not trigger
further workflow runs. The consequence is that **every release leaves the
published changelog page one version stale** until some later unrelated docs
push happens to rebuild it. The `CHANGELOG.md` path filter in `docs.yml` was
added to catch exactly this case and cannot fire.

## Verification

Two `workflow_dispatch` runs triggered in quick succession: the second must
report as queued/waiting on the group rather than running concurrently, and
`gh-pages` must end at the later sha. `gh-deploy` writes
`Deployed <sha> with MkDocs version: ...` as the gh-pages commit message, so the
sha is checkable directly rather than by looking at the rendered site.
