### PR TITLE
ci: refuse to release from a commit whose tests did not pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Needed by the test gate below, which reads this commit's workflow runs.
+      # Declaring `permissions` at all makes every unlisted scope `none`, so
+      # omitting this denies it rather than falling back to a default.
+      actions: read
     outputs:
       released: ${{ steps.release.outputs.released }}
       version: ${{ steps.release.outputs.version }}
@@ -127,8 +131,88 @@ jobs:
             exit 0
           fi
 
-          # Past this point $NEXT is a genuine bump, so an existing tag really
-          # does mean another run got there first.
+          # Past this point a release is actually going to be cut, so this is
+          # where the commit has to earn it.
+          #
+          # Nothing has ever stood between a merge and PyPI: this workflow and
+          # tests.yml both fire on the same push and run alongside each other,
+          # so a red suite never stopped a publish. v3.0.0 went out from a
+          # commit no test job had even seen.
+          #
+          # Branch protection is the obvious gate and it is a MEASURED dead
+          # end -- see handouts/loose-ends-after-scils-alignment.md. A
+          # secrets.GITHUB_TOKEN push cannot bypass required status checks, so
+          # turning them on blocks this workflow's own version commit while the
+          # tag still lands, leaving the repo tagged-but-not-bumped. This gate
+          # needs no bypass: rather than stop the merge, refuse to release from
+          # it.
+          #
+          # The gate is on tests specifically, not on "every check for this
+          # commit". Waiting on every check sounds safer and is worse: it makes
+          # advisory workflows (complexity monitoring) able to veto a release,
+          # and "some check finished and none are pending" can be satisfied by
+          # one fast unrelated check that completed before the test run had
+          # even registered. Naming the workflow also means this can never wait
+          # on itself -- this workflow has a different name, so no self
+          # exclusion is needed.
+          #
+          # It gates $RELEASE_SHA, NOT $GITHUB_SHA. Those are usually the same
+          # commit and deliberately are not always: the checkout above releases
+          # main's tip rather than the commit that triggered this run. Gating
+          # the trigger would check one commit's tests and publish a different
+          # one -- the exact vacuous gate this exists to prevent.
+          GATE_WORKFLOW="Tests"
+
+          echo "Gate: waiting for '$GATE_WORKFLOW' on $RELEASE_SHA"
+          STATUS=absent
+          CONCLUSION=none
+          for attempt in $(seq 1 60); do
+            RUN=$(gh api \
+                    "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$RELEASE_SHA&per_page=100" \
+                  | jq --arg wf "$GATE_WORKFLOW" \
+                      '[.workflow_runs[] | select(.name == $wf)]
+                       | sort_by(.created_at) | last')
+            STATUS=$(echo "$RUN" | jq -r '.status // "absent"')
+            CONCLUSION=$(echo "$RUN" | jq -r '.conclusion // "none"')
+            echo "  attempt $attempt: $GATE_WORKFLOW is $STATUS/$CONCLUSION"
+            if [ "$STATUS" = "completed" ]; then break; fi
+            sleep 30
+          done
+
+          # Fail closed on every branch. A blocked release is not a lost one:
+          # the commits stay on main and the next push releases them together.
+          if [ "$STATUS" != "completed" ]; then
+            echo "REFUSING TO RELEASE: '$GATE_WORKFLOW' is '$STATUS' for $RELEASE_SHA after 30 minutes."
+            echo "If it never ran at all, tests.yml has lost its 'push: [main]' trigger"
+            echo "and this gate would otherwise be vacuous."
+            exit 1
+          fi
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "REFUSING TO RELEASE: '$GATE_WORKFLOW' concluded '$CONCLUSION' for $RELEASE_SHA."
+            exit 1
+          fi
+          echo "Gate: '$GATE_WORKFLOW' passed."
+
+          # Waiting for a test run takes minutes, where the window this job
+          # previously had between reading the tip and pushing was ~60-90s. If
+          # main moved while we waited then $RELEASE_SHA is no longer the tip,
+          # the checkout is stale, and `semantic-release version` would die on
+          # "Upstream branch 'origin/main' has changed!" -- the failure the tip
+          # checkout above was added to end. Stand down cleanly instead: the
+          # merge that moved main queued its own release run behind this one,
+          # and semantic-release bumps from every commit since the last tag, so
+          # that run covers these commits too. Nothing is dropped by yielding.
+          git fetch origin +refs/heads/main:refs/remotes/origin/main
+          TIP=$(git rev-parse refs/remotes/origin/main)
+          if [ "$TIP" != "$RELEASE_SHA" ]; then
+            echo "No release: main moved $RELEASE_SHA -> $TIP while waiting for tests."
+            echo "The queued run for $TIP releases these commits."
+            echo "released=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # $NEXT is a genuine bump, so an existing tag really does mean
+          # another run got there first.
           #
           # Re-fetch before asking. Checkout does fetch every tag (fetch-depth: 0
           # fetches refs/tags/* regardless of fetch-tags), but it did so before


### PR DESCRIPTION
## What this fixes

`release.yml` and `tests.yml` both trigger on `push` to `main`. They start at the
same moment and run **alongside** each other, so nothing has ever stood between a
merge and PyPI. A `fix:` merged with a broken suite publishes while the tests are
still running, and the red X lands on a commit that is already released. v3.0.0
went out from a commit no test job had seen.

Adding `push: [main]` to `tests.yml` (#145) made main's status *visible*. This
makes it *binding*.

## Why the gate is here and not in branch protection

Branch protection is the obvious answer and it is a **measured dead end** --
`handouts/loose-ends-after-scils-alignment.md` records the probe. A
`secrets.GITHUB_TOKEN` push cannot bypass required status checks, so enabling
them blocks this workflow's own `semantic-release version` commit *while the tag
still lands*, leaving the repo tagged-but-not-bumped. The Actions app is rejected
as a repo-level bypass actor (HTTP 422).

This gate needs no bypass. Rather than stopping the merge, it refuses to release
from it.

## Design notes

**It gates on the `Tests` workflow by name, not on every check for the commit.**
Waiting on "all checks, minus my own suite" sounds safer and is worse in three
ways: advisory workflows (complexity monitoring) get a veto over releases; the
condition "some check finished and none are pending" can be satisfied by one fast
unrelated check that completed *before* the test run had even registered; and it
needs check-suite self-exclusion to avoid deadlocking on its own job. Naming the
workflow removes all three -- this workflow has a different name, so it can never
wait on itself.

**It sits after the "nothing releasable" exit.** `ci:`/`test:`/`chore:` pushes
still finish in seconds; only a run that is actually about to cut a release pays
the wait.

**Every branch fails closed** -- absent, still-running, and non-success all refuse.
A blocked release is not a lost one: the commits stay on main and the next push
releases them together.

## Verification

The gate script was extracted **verbatim** from the workflow and run against the
live GitHub API for each branch. Only the retry count and sleep were shortened,
for the absent case, so it did not take 30 minutes.

| Case | Commit | Observed | Result |
| --- | --- | --- | --- |
| Tests passed | `ad8b470` (13 green checks) | `completed/success` | **exit 0** -- release allowed |
| Tests failed | `8bed74d` (probe, below) | `completed/failure` | **exit 1** -- refused |
| Tests never ran | `db816a1` (pre-#145 main) | `absent/none` | **exit 1** -- refused |

No failing `Tests` run existed in history -- all 27 recent runs were green -- so
one was manufactured: a throwaway branch carrying a deliberately failing test,
with `Tests` dispatched manually. `tests.yml`'s push trigger is main-only, so
pushing that branch triggered nothing on its own and no release path was ever
involved. **The branch and its commit have been deleted**; nothing from it remains.

The "keep waiting" behaviour is covered by the absent case, which looped on a
non-`completed` status instead of breaking -- the same code path `queued` and
`in_progress` take.

Wiring: `publish` is `needs: [release]` and, for a push, requires
`needs.release.outputs.released == 'true'`. The gate exits before that output is
ever set, so a refusal skips the publish rather than failing after it.

## What I could not prove, and what to watch

**The gate only runs on commits that would actually release, and this is a `ci:`
commit -- so merging this PR will not exercise it.** The first real exercise is
the next `fix:`/`feat:` merge to main. On that merge, `Create Release` should log:

```
Gate: waiting for 'Tests' on <sha>
  attempt 1: Tests is completed/success
Gate: 'Tests' passed.
```

and then release as before. If the gate is wrong it fails closed, so the failure
mode is a **blocked** release showing a red `Create Release` on main -- not a bad
publish. Reverting this one file restores the previous behaviour exactly.

Worth knowing: a release now waits for the test matrix (~4 min) before cutting.
