### PR TITLE
chore: ignore the complexity monitor's generated reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,10 @@ benchmarks/test_*.py
 # .github/scripts/, the one tracked scripts directory, so git refused to add
 # changes to the complexity monitor without -f.
 /scripts/
+
+# Generated analysis output. The complexity monitor writes
+# reports/complexity/ on every run -- in CI, where it is uploaded as a
+# 30-day artifact, and locally for anyone running the script by hand.
+# Nothing under here has ever been tracked. Anchored for the same reason
+# /scripts/ is.
+/reports/


### PR DESCRIPTION
Loose end from #148, flagged there but deliberately left out to keep that
PR's CI change a pure deletion.

`.github/scripts/complexity_monitor.py:478` writes `reports/complexity/` on
every run -- in CI, where the workflow uploads it as a 30-day artifact and
then throws it away, and locally for anyone running the script by hand. The
directory was never ignored, so a local run leaves untracked output in
`git status`, one `git add -A` away from being committed.

Nothing under `reports/` has ever been tracked (`git ls-files reports/` is
empty), so this untracks nothing.

## Why `/reports/` and not `reports/`

The neighbouring comment in `.gitignore` already records this trap: `/scripts/`
is anchored because unanchored it also matched `.github/scripts/`, the one
tracked scripts directory, and git then refused to add changes to the
complexity monitor without `-f`. Same reasoning here -- unanchored, the rule
would swallow any nested `reports/` added later under `thyra/` or `tests/`.

## Verified

Ran the monitor to generate a real report, then checked all three directions:

- `git check-ignore -v` on the generated file -> `.gitignore:82:/reports/`, and
  `git status` shows only the `.gitignore` edit
- a probe `thyra/reports/probe.txt` is **not** ignored, so the anchor holds
- `.github/scripts/complexity_monitor.py` is **not** ignored and stays listed
  by `git ls-files`

Non-releasable: `chore` is outside `patch_tags`/`minor_tags` and is in
`exclude_commit_patterns`.