### PR TITLE
fix(deps): declare click, tifffile and xarray as runtime dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,9 +106,31 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
-        pip install pytest pytest-cov mock
     - name: Report the resolved dependency set
       run: pip list
+    - name: Verify the installed console script actually runs
+      # Deliberately placed BEFORE the test-only installs, so this runs
+      # against exactly the closure pyproject.toml declares and nothing
+      # else: a dependency supplied only by pytest/mock cannot mask a
+      # missing declaration here.
+      #
+      # `pip install .` can succeed while the shipped entry point is
+      # unusable. `click` was imported at module scope by thyra/__main__.py
+      # and declared nowhere in pyproject.toml, surviving only because dask
+      # happens to require it; the day that stopped being true, this job
+      # would have gone green and `thyra --help` would have raised
+      # ImportError for the user. Executing the console script is what
+      # closes that gap -- importing the package is not enough, because
+      # the entry point in [tool.poetry.scripts] is itself untested code.
+      #
+      # Run from outside the checkout so this exercises the INSTALLED
+      # distribution and cannot silently fall back to the repo's ./thyra.
+      run: |
+        cd /tmp
+        thyra --version
+        thyra --help
+    - name: Install the test-only dependencies
+      run: pip install pytest pytest-cov mock
     - name: Verify save / read-back round-trip on the resolved set
       # thyra + its dependencies come from the non-editable pip install
       # above; PYTHONPATH only puts the repo root on sys.path so the

--- a/poetry.lock
+++ b/poetry.lock
@@ -7135,4 +7135,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12, <3.14"
-content-hash = "dc91cd0dfb58e8792133bcd998f49708371b5e17f14102d7e3b5f0a0498a579c"
+content-hash = "3c8324f75c92f614d0f72757a0ed727c768e180cd4e23485b3d703a70ae2c86b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,22 @@ python = ">=3.12, <3.14"
 # exercises exactly this pip-resolved path so these bounds stay honest.
 # Bump the ceilings deliberately after re-testing against newer releases.
 dask = ">=2026.3.0, <2026.8"        # tested 2026.7.1 (spatialdata 0.8.0 needs >=2026.3.0)
+# The CLI is built on click -- `thyra/__main__.py` imports it at module scope,
+# so the `thyra` console script cannot start without it. It went undeclared
+# for the project's whole history before this line, and resolved only by
+# accident: dask requires click >=8.1, so every resolution to date happened
+# to supply one. That is luck, not a guarantee. If
+# dask ever drops or vendors click, `pip install thyra` yields an install
+# whose entry point dies with `ImportError: No module named 'click'` on the
+# first run, at __main__.py's import line, before any command executes.
+# The floor matches dask's own and the version the lockfile resolves. The
+# ceiling is `<9` because GroupedCommand subclasses click.Command and
+# overrides format_help(): a major release is free to change that. Verified
+# --help (including the grouped sections), --version and the Choice/IntRange
+# validators render identically on 8.1.8 (the lockfile, held there by
+# python-semantic-release's dev-only `<8.2` cap) and on 8.4.2, which is what
+# a plain `pip install thyra` resolves today and the lockfile never exercises.
+click = ">=8.1, <9"                 # tested 8.1.8 and 8.4.2
 defusedxml = ">=0.7.1"  # Secure XML parsing for the Bruker Rapiflex reader
 geopandas = ">=0.9.0"
 lxml = ">=4.6.0"
@@ -110,6 +126,20 @@ imagecodecs = ">=2024.1.1"  # For reading compressed TIFF optical images
 # that coercion was deleted when this floor moved. See issue #117.
 anndata = ">=0.13.2, <0.14"         # tested 0.13.2
 psutil = ">=5.0.0"
+# Imported directly, not merely re-exported through spatialdata: tifffile by
+# converters/spatialdata/base_spatialdata_converter.py, xarray by that module
+# and the 2D, 3D and streaming converters. Both arrive transitively today
+# (spatialdata requires xarray >=2024.10.0 outright; tifffile comes in behind
+# scikit-image and dask-image), so this is the same undeclared-direct-import
+# defect as click above -- but a quieter one. Their imports sit inside the
+# SPATIALDATA_AVAILABLE try/except, so losing either degrades instead of
+# crashing: every converter is replaced by a dummy and the run reports
+# "SpatialData dependencies not available" rather than naming the real cause.
+# Floors only, and deliberately so. They restate what the existing requirers
+# already demand, which makes the direct dependency honest without asserting
+# an upper bound nothing here has tested; the resolved set does not move.
+tifffile = ">=2022.8.12"
+xarray = ">=2024.10.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=7.0.0"


### PR DESCRIPTION
## What was wrong

`thyra/__main__.py:11` does `import click` at module scope, and the whole CLI is built on it (`@click.command`, `GroupedCommand(click.Command)`, `click.prompt`, `click.Choice`, `click.IntRange`). `click` was declared nowhere in `pyproject.toml`.

It resolved only by accident. `poetry.lock` records click 8.1.8 as a transitive of dask (`click >=8.1`) and black (`>=8.0.0`). The day dask drops or vendors click, `pip install thyra` produces an installation whose console script raises `ImportError` on first run, before any command executes.

Reproduced by blocking the import in an otherwise complete environment:

```
File "thyra\__main__.py", line 11, in <module>
    import click  # noqa: E402
ImportError: No module named 'click'
```

## Two more, found by sweeping

An AST pass over every top-level third-party import under `thyra/`, compared against the declared set, found `tifffile` and `xarray` in the same state — imported directly, declared nowhere.

They fail more quietly than click. Both sit inside the `SPATIALDATA_AVAILABLE` `try/except` in `base_spatialdata_converter.py` (and behind `if SPATIALDATA_AVAILABLE:` in the 2D/3D/streaming converters), so losing either degrades to dummy converters and a `"SpatialData dependencies not available"` message rather than crashing. Arguably the worse failure, since it does not name the real cause — but either way they are undeclared direct imports.

They get **floors only**, restating what their existing requirers already demand (`spatialdata` needs `xarray >=2024.10.0` outright; `tifffile` arrives behind scikit-image/dask-image). That makes the direct dependency honest without asserting an upper bound nothing here has tested.

After this change the sweep reports **no undeclared direct imports**. Three declared-but-unimported remain: `imagecodecs` and `ome-zarr` are deliberate (a tifffile codec backend and spatialdata's zarr backend, both already commented); `lxml` looks genuinely vestigial and is noted below, not touched here.

## Bounds, and why they are honest

`click = ">=8.1, <9"`. The floor matches dask's own and the lockfile. The ceiling is `<9` because `GroupedCommand` subclasses `click.Command` and overrides `format_help()` — a major release is free to change that.

The lockfile pins click **8.1.8**, but only because `python-semantic-release` (dev group) caps it at `<8.2.0`. A real `pip install thyra` resolves **8.4.2** today, which the lockfile therefore never exercises. So the upper bound was verified directly against 8.4.2 rather than assumed:

| | click 8.1.8 (lockfile) | click 8.4.2 (what pip gets) |
|---|---|---|
| `--help`, grouped sections | renders | byte-identical |
| `--version` | `thyra, version 3.0.2` | same |
| `--mass-axis-type NOPE` (`Choice`) | correct error | same |

CI then confirmed this on the real path: the clean-venv job resolved **click 8.4.2**, tifffile 2026.7.31 and xarray 2026.7.0, and the console script ran.

## The lockfile moved as predicted

`poetry lock` changes the content-hash and nothing else — **263 packages before and after, identical versions and groups**:

```
 poetry.lock | 2 +-
-content-hash = "dc91cd0dfb58e8792133bcd998f49708371b5e17f14102d7e3b5f0a0498a579c"
+content-hash = "3c8324f75c92f614d0f72757a0ed727c768e180cd4e23485b3d703a70ae2c86b"
```

`poetry check --lock` passes after the rebase onto main's 3.0.3 (the version field is not part of the content-hash).

## Why `clean-venv-install` missed it, and what changed

That job exists to keep these bounds honest against the pip resolver, and it went green throughout — click still arrives transitively.

Worth being precise about how blind it was: `tests/unit/test_cli_exit_status.py` imports `from click.testing import CliRunner`, so pytest *would* have failed the day click stopped arriving. But it would have failed as an obscure collection error, and it never covers the thing that actually breaks for a user: the **console script** in `[tool.poetry.scripts]` is itself untested code, and importing the package does not exercise it.

The job now runs the installed entry point:

```yaml
- name: Verify the installed console script actually runs
  run: |
    cd /tmp
    thyra --version
    thyra --help
```

Two placement details are load-bearing. It sits **before** the test-only installs, so the check sees exactly the closure `pyproject.toml` declares and a dependency supplied only by pytest/mock cannot mask a missing declaration. And it runs **from outside the checkout**, so it exercises the installed distribution rather than falling back to the repo's `./thyra`.

## This has to be `fix:`, not `build:`

Measured against this repo's `[tool.semantic_release]` config, since `patch_tags = ["fix", "perf"]` and `build` is in `allowed_tags` but neither bump list:

| commit type | next version from 3.0.3 |
|---|---|
| `build:` | **3.0.3 — no release** |
| `docs:` | 3.0.3 — no release |
| `fix:` | **3.0.4** |
| `feat:` | 3.1.0 |

A `build:` commit would leave the corrected metadata sitting on main while PyPI kept shipping a wheel that does not declare click, which defeats the point. Hence `fix:`; this merges as **3.0.4**.

## Verification

- Bug reproduced (ImportError with click blocked) and the fix confirmed against click 8.1.8 and 8.4.2.
- Built wheel now carries `Requires-Dist: click (>=8.1,<9)`, `tifffile (>=2022.8.12)`, `xarray (>=2024.10.0)`.
- `poetry check --lock` passes (only pre-existing poetry-2.x `[project]` deprecation warnings).
- `pre-commit` clean on all three changed files.
- Unit suite: **1323 passed, 3 skipped**.
- The new CI step ran on the runner and printed `thyra, version …` plus the grouped help.

## Follow-up, not in this PR

`lxml = ">=4.6.0"` is declared but never imported anywhere under `thyra/`; the imzML path uses `defusedxml`/ElementTree. It may be vestigial, or a deliberate backend for pyimzML. Removing a declared dependency changes the install closure, so it belongs in its own change rather than riding along with a release-cutting fix.
