### PR TITLE
feat(converters): give the 3D TIC volume a real z spacing

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -284,6 +284,7 @@ thyra data.d output.zarr --intensity-threshold 100
 |--------|---------|-------------|
 | `--dataset-id TEXT` | `msi_dataset` | Dataset identifier used in element keys |
 | `--handle-3d` | off | Process as 3D volume instead of 2D slices |
+| `--z-spacing FLOAT` | in-plane pixel size | Distance between consecutive slices, in um. Only used with `--handle-3d` |
 
 ### Examples
 
@@ -294,7 +295,32 @@ thyra input.imzML output.zarr --dataset-id hippocampus
 
 # Combine z-slices into a single 3D table
 thyra volume.imzML output.zarr --handle-3d
+
+# 20 um sections acquired on a 50 um raster
+thyra volume.imzML output.zarr --handle-3d --pixel-size 50 --z-spacing 20
 ```
+
+### Set `--z-spacing` whenever you know it
+
+`--pixel-size` is the **in-plane** raster pitch. It says nothing about how far
+apart consecutive slices are: that distance is set by the microtome that cut the
+sections, not by the stage that rastered them, and the two match only by
+coincidence.
+
+With no `--z-spacing`, Thyra reuses the in-plane pitch, warns, and records
+`z_spacing_source: "assumed_isotropic"` in the store so the guess stays
+distinguishable from a measurement. The volume's voxel values are unaffected
+either way — what is wrong is its depth, so a viewer reading it in micrometres
+renders the stack squashed or stretched along z.
+
+There is no way to detect this from the data. imzML has no term for slice
+spacing, and 3D MSI acquisitions are frequently non-consecutive sections, so
+the number has to come from whoever cut them.
+
+!!! warning "It does nothing without `--handle-3d`"
+    Without 3D handling each slice is written as its own 2D image and there is
+    no z axis to space out. Passing `--z-spacing` on its own is logged as
+    ignored rather than silently accepted.
 
 ---
 

--- a/docs/coordinate-systems.md
+++ b/docs/coordinate-systems.md
@@ -35,6 +35,10 @@ zarr.attrs["coordinate_systems"] = {
         "reference_element": str | None,
         "convention_version": 1,
         "produced_by": "thyra/<version>",
+
+        # Multi-slice volumes only -- see "The z axis" below
+        "z_spacing_um": float,
+        "z_spacing_source": "manual" | "automatic" | "assumed_isotropic",
     }
 }
 ```
@@ -46,6 +50,36 @@ zarr.attrs["coordinate_systems"] = {
 | ``reference_element`` | Name of the canonical raster element that defines pixel space, when ``unit="pixel"``. ``None`` otherwise. |
 | ``convention_version`` | Schema version; bump when the shape of this attr changes. Currently ``1``. |
 | ``produced_by`` | ``"thyra/<version>"`` for Thyra-produced zarrs. |
+| ``z_spacing_um`` | Micrometers between consecutive slices. **Only present on multi-slice volumes.** Always an absolute micrometer distance, even when ``unit="pixel"``: the optical affine governs only x and y, while z is always scaled directly. |
+| ``z_spacing_source`` | Where ``z_spacing_um`` came from. **Only present on multi-slice volumes.** |
+
+---
+
+## The z axis
+
+A 2D store has no slice-to-slice distance, so it carries neither z field. Their
+**absence is the signal** that there is no z axis — which is also why adding
+them did not move ``convention_version``: they are purely additive, and a
+consumer that never reads volumes sees exactly the schema it already knew.
+
+``z_spacing_source`` is the field that matters:
+
+| Value | Meaning |
+|-------|---------|
+| ``"manual"`` | The caller supplied it (``--z-spacing`` / ``z_spacing_um=``). Trust it. |
+| ``"automatic"`` | The source metadata reported it. Trust it. |
+| ``"assumed_isotropic"`` | **Nobody supplied one.** The in-plane pixel pitch was reused, which asserts that slices sit exactly one pixel width apart. Treat the depth as unknown. |
+
+Section thickness is set by the microtome that cut the sections; the in-plane
+pitch is set by the stage that rastered them. The two agree only by coincidence,
+and for 3D MSI usually do not — often by an order of magnitude. A volume whose
+``z_spacing_source`` is ``"assumed_isotropic"`` has correct voxel *values* and an
+unreliable *depth*, so rendering it in micrometers stretches or squashes the
+stack along z.
+
+Thyra cannot detect this: imzML has no standard term for slice spacing, and 3D
+acquisitions are frequently non-consecutive sections, so the value has to be
+supplied by whoever prepared them.
 
 Consumers that don't know the schema can still open the zarr; they
 just won't be able to render distances in micrometers without

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -33,7 +33,10 @@ A converted dataset contains the following elements:
 
 !!! note "3D mode"
     When converted with `--handle-3d`, the `_z{z}` suffix is dropped and all
-    slices are merged into a single table with `x`, `y`, `z` coordinates in `.obs`.
+    slices are merged into a single table with `x`, `y`, `z` coordinates in
+    `.obs`. The TIC image becomes a single **volume** of shape `(c, z, y, x)`
+    rather than one 2D image per slice — see
+    [3D Data / Z-Slices](#3d-data--z-slices).
 
 !!! tip "Default dataset ID"
     The default `dataset_id` is `msi_dataset`, so typical keys look like
@@ -288,8 +291,71 @@ z0_table = sdata.tables[slice_tables[0]]
 print(f"Slice 0: {z0_table.shape}")
 ```
 
+### 3D mode (`--handle-3d`)
+
 When converted with `--handle-3d`, all slices are combined into a single table
-with `x`, `y`, `z` coordinates in `.obs`.
+with `x`, `y`, `z` coordinates in `.obs`, and the per-slice TIC images are
+replaced by one **volume**:
+
+| Element | Key | Shape / dims |
+|---------|-----|--------------|
+| **Table** | `{dataset_id}` | pixels x m/z, with `x`, `y`, `z` and `spatial_x`, `spatial_y`, `spatial_z` in `.obs` |
+| **TIC volume** | `{dataset_id}_tic` | `(c, z, y, x)` — one channel, then the three spatial axes |
+| **Pixel Shapes** | `{dataset_id}_pixels` | GeoDataFrame of 2D pixel boxes |
+
+```python
+volume = sdata.images[f"{dataset_id}_tic"]
+print(volume.dims)                      # ('c', 'z', 'y', 'x')
+
+arr = np.asarray(volume.data)[0]        # drop channel -> (z, y, x)
+plt.imshow(arr[0], cmap="viridis")      # first slice
+```
+
+Note the axis order is `(c, z, y, x)`, not `(c, x, y, z)`: index a slice with
+`arr[z]`, not `arr[..., z]`.
+
+#### Voxel depth
+
+The volume carries a `Scale` to `"global"` built from **two** distinct numbers —
+the in-plane pixel pitch for `x` and `y`, and the slice spacing for `z`:
+
+```python
+from spatialdata.transformations import get_transformation
+
+axes = ("c", "z", "y", "x")
+matrix = get_transformation(volume, to_coordinate_system="global").to_affine_matrix(
+    input_axes=axes, output_axes=axes
+)
+print(matrix[1, 1])   # um per slice step
+print(matrix[3, 3])   # um per pixel in x
+```
+
+The slice spacing comes from `--z-spacing`. When nothing supplies one, Thyra
+falls back to the in-plane pitch and records that it did:
+
+```python
+cs = sdata.attrs["coordinate_systems"]["global"]
+cs["z_spacing_um"]      # the number used
+cs["z_spacing_source"]  # "manual" | "automatic" | "assumed_isotropic"
+```
+
+A `z_spacing_source` of `"assumed_isotropic"` means **nobody supplied a spacing
+and the in-plane pitch was reused** — treat the depth as unknown rather than as
+measured. Section thickness is set by the microtome, not by the raster, so the
+two agree only by coincidence. See
+[`--z-spacing`](cli.md#set---z-spacing-whenever-you-know-it).
+
+!!! note "These keys only appear on volumes"
+    `z_spacing_um` and `z_spacing_source` are written only when the store
+    actually holds a multi-slice volume. Their absence is how a 2D store says it
+    has no z axis, which is why `convention_version` stays at `1` — the keys are
+    additive and a consumer that never reads 3D sees the schema it already
+    knows.
+
+!!! warning "Pixel shapes are still 2D"
+    The pixel-polygon shapes carry no z coordinate, so all slices' polygons
+    coincide in depth. Use the table's `spatial_z` (or the volume itself) when
+    you need a per-slice position.
 
 ---
 

--- a/tests/unit/converters/test_3d_tic_z_spacing.py
+++ b/tests/unit/converters/test_3d_tic_z_spacing.py
@@ -1,0 +1,478 @@
+# tests/unit/converters/test_3d_tic_z_spacing.py
+"""The 3D TIC volume must be scaled by a real slice-to-slice distance.
+
+``_create_tic_image`` used to build the volume's transform as::
+
+    Scale([pixel_size_um, pixel_size_um, pixel_size_um], axes=("x", "y", "z"))
+
+``pixel_size_um`` is the **in-plane** raster pitch. Reusing it for z asserts
+that consecutive slices sit exactly one pixel width apart -- which is true only
+by coincidence, because sections are cut by a microtome while the raster is set
+by the stage. The voxel *values* were right (PR #146 fixed the permutation that
+made them wrong); the volume was simply the wrong depth, so any consumer
+reading it in micrometres -- Ousia does -- rendered the stack squashed or
+stretched along z.
+
+What these tests pin, and why each is here:
+
+* **The affine, not the absence of an exception.** A converter that raises
+  nothing tells you nothing about what it wrote. Every assertion below reads
+  the store back off disk and checks
+  ``get_transformation(...).to_affine_matrix(...)`` entry by entry.
+* **Three pairwise-different lengths.** ``pixel_size_um``, ``z_spacing_um`` and
+  the grid extents are all distinct and none is a multiple of another, so a
+  value landing on the wrong axis cannot coincidentally produce the expected
+  matrix. With the old code ``test_explicit_z_spacing_reaches_the_global_affine``
+  reports 10.0 where 45.0 is required.
+* **The table, not just the image.** ``spatial_z`` in ``obs`` had the same
+  hardcoded pitch. Fixing only the image would leave the volume and the table
+  disagreeing about depth at ``"global"``, which is worse than both being
+  consistently wrong, so their agreement is asserted directly.
+* **The assumption is machine-readable.** The no-spacing-given case still falls
+  back to the in-plane pitch -- what changes is that the store now says so, via
+  ``coordinate_systems.global.z_spacing_source``. A warning in a log nobody kept
+  is not a record.
+
+Note ``Scale`` pairs values with axis *names*, not by position, so the
+converter's ``axes=("x", "y", "z")`` against a ``(c, z, y, x)`` image is correct
+and deliberate. The expected matrices below are written out in ``(c, z, y, x)``
+order to make that mapping explicit rather than implied.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Generator, List, Optional, Tuple
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    SPATIALDATA_AVAILABLE,
+)
+from thyra.converters.spatialdata.spatialdata_3d_converter import SpatialData3DConverter
+from thyra.core.base_converter import ZSpacingSource
+from thyra.core.base_extractor import MetadataExtractor
+from thyra.core.base_reader import BaseMSIReader
+from thyra.metadata.types import ComprehensiveMetadata, EssentialMetadata
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+_DATASET_ID = "vol"
+
+# Pairwise different, as in test_3d_tic_axis_order: a cubic grid cannot tell a
+# correct volume from a permuted one.
+_N_X, _N_Y, _N_Z = 5, 3, 2
+
+# Deliberately unrelated numbers. 45 is not a multiple of 10, so reusing the
+# in-plane pitch for z (the defect) cannot produce the expected matrix, and
+# neither can swapping the two.
+_PIXEL_SIZE_UM = 10.0
+_Z_SPACING_UM = 45.0
+
+_MASS_AXIS = np.array([100.0, 200.0], dtype=np.float64)
+
+
+class _VolumeProbeExtractor(MetadataExtractor):
+    """Reports the grid the probe reader emits, and nothing else.
+
+    ``pixel_size`` is ``None`` on purpose: it forces the converter to keep the
+    ``pixel_size_um`` the test passed in, rather than auto-detecting over it,
+    so the in-plane pitch under test is the one the test chose.
+    """
+
+    def __init__(
+        self,
+        dimensions: Tuple[int, int, int],
+        z_spacing_um: Optional[float] = None,
+    ) -> None:
+        super().__init__(None)
+        self._dimensions = dimensions
+        self._z_spacing_um = z_spacing_um
+
+    def _extract_essential_impl(self) -> EssentialMetadata:
+        n_x, n_y, n_z = self._dimensions
+        n_spectra = n_x * n_y * n_z
+        return EssentialMetadata(
+            dimensions=self._dimensions,
+            coordinate_bounds=(0.0, float(n_x - 1), 0.0, float(n_y - 1)),
+            mass_range=(float(_MASS_AXIS[0]), float(_MASS_AXIS[-1])),
+            pixel_size=None,
+            n_spectra=n_spectra,
+            total_peaks=n_spectra * len(_MASS_AXIS),
+            estimated_memory_gb=0.001,
+            source_path="z_spacing_probe",
+            z_spacing_um=self._z_spacing_um,
+        )
+
+    def _extract_comprehensive_impl(self) -> ComprehensiveMetadata:
+        return ComprehensiveMetadata(
+            essential=self._extract_essential_impl(),
+            format_specific={"format": "probe"},
+            acquisition_params={},
+            instrument_info={"instrument": "probe"},
+            raw_metadata={"source": "probe"},
+        )
+
+
+class _VolumeProbeReader(BaseMSIReader):
+    """A full grid; every voxel carries a positive intensity so none is dropped."""
+
+    def __init__(
+        self,
+        dimensions: Tuple[int, int, int],
+        z_spacing_um: Optional[float] = None,
+    ) -> None:
+        super().__init__(Path("z_spacing_probe"))
+        self._dimensions = dimensions
+        self._z_spacing_um = z_spacing_um
+
+    def _create_metadata_extractor(self) -> MetadataExtractor:
+        return _VolumeProbeExtractor(self._dimensions, self._z_spacing_um)
+
+    @property
+    def has_shared_mass_axis(self) -> bool:
+        return True
+
+    def get_common_mass_axis(self) -> NDArray[np.float64]:
+        return _MASS_AXIS.copy()
+
+    def get_optical_image_paths(self) -> List[Path]:
+        return []
+
+    def get_peak_counts_per_pixel(self) -> Optional[NDArray[np.int32]]:
+        return None
+
+    def reset(self) -> None:
+        """Spectra are a pure function of the coordinate; nothing to reset."""
+
+    def iter_spectra(self, batch_size: Optional[int] = None) -> Generator[
+        Tuple[Tuple[int, int, int], NDArray[np.float64], NDArray[np.float64]],
+        None,
+        None,
+    ]:
+        n_x, n_y, n_z = self._dimensions
+        for z in range(n_z):
+            for y in range(n_y):
+                for x in range(n_x):
+                    intensities = np.array(
+                        [1.0 + x + 10.0 * y, 100.0 * (1.0 + z)], dtype=np.float64
+                    )
+                    yield (x, y, z), _MASS_AXIS.copy(), intensities
+
+    def close(self) -> None:
+        """No resource to release."""
+
+
+def _convert(
+    tmp_path: Path,
+    dimensions: Tuple[int, int, int] = (_N_X, _N_Y, _N_Z),
+    z_spacing_um: Optional[float] = None,
+    reader_z_spacing_um: Optional[float] = None,
+) -> Path:
+    """Convert one probe grid through the 3D route; hand back the store root."""
+    output_path = tmp_path / "out.zarr"
+    converter = SpatialData3DConverter(
+        _VolumeProbeReader(dimensions, z_spacing_um=reader_z_spacing_um),
+        output_path,
+        dataset_id=_DATASET_ID,
+        pixel_size_um=_PIXEL_SIZE_UM,
+        z_spacing_um=z_spacing_um,
+    )
+    assert converter.convert() is True, f"{dimensions} conversion failed"
+    return output_path
+
+
+def _read_store(store_path: Path):
+    import spatialdata
+
+    return spatialdata.read_zarr(str(store_path))
+
+
+def _global_affine(store_path: Path) -> NDArray[np.float64]:
+    """The TIC element's affine to ``"global"``, in ``(c, z, y, x)`` order."""
+    from spatialdata.transformations import get_transformation
+
+    image = _read_store(store_path).images[f"{_DATASET_ID}_tic"]
+    transform = get_transformation(image, to_coordinate_system="global")
+    axes = ("c", "z", "y", "x")
+    return np.asarray(
+        transform.to_affine_matrix(input_axes=axes, output_axes=axes),
+        dtype=np.float64,
+    )
+
+
+def _expected_affine(pixel_size_um: float, z_spacing_um: float) -> NDArray[np.float64]:
+    """The matrix a correct ``Scale`` produces, written out in ``(c, z, y, x)``.
+
+    Spelled as a literal diagonal rather than derived from a ``Scale`` so the
+    test cannot agree with the code by sharing its mistake.
+    """
+    return np.diag([1.0, z_spacing_um, pixel_size_um, pixel_size_um, 1.0])
+
+
+def _zarr_attrs(store_path: Path) -> Dict[str, Any]:
+    """Top-level zarr attrs, for both the v2 and v3 layouts."""
+    z3 = store_path / "zarr.json"
+    if z3.exists():
+        with open(z3, encoding="utf-8") as f:
+            return (json.load(f) or {}).get("attributes", {}) or {}
+    z2 = store_path / ".zattrs"
+    if z2.exists():
+        with open(z2, encoding="utf-8") as f:
+            return json.load(f) or {}
+    raise FileNotFoundError(f"No zarr attrs in {store_path}")
+
+
+def _global_cs(store_path: Path) -> Dict[str, Any]:
+    return _zarr_attrs(store_path)["coordinate_systems"]["global"]
+
+
+@contextmanager
+def _captured_warnings(logger_name: str = "thyra"):
+    """Collect warnings from ``logger_name``, whatever the logging state.
+
+    Deliberately not ``caplog``. ``setup_logging`` sets ``propagate = False`` on
+    the ``thyra`` logger, and it is process-global: once any test has invoked
+    the CLI, ``caplog``'s root handler never sees another Thyra record. That
+    made this assertion pass alone and fail in the full suite, which is the
+    worst way for a test to be wrong.
+
+    Attaching a handler directly to the logger sidesteps propagation entirely,
+    so the result does not depend on which tests ran first.
+    """
+    import logging
+
+    records: List[str] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record.getMessage())
+
+    handler = _Collector(level=logging.WARNING)
+    logger = logging.getLogger(logger_name)
+    previous_level = logger.level
+    logger.addHandler(handler)
+    if previous_level > logging.WARNING or previous_level == logging.NOTSET:
+        logger.setLevel(logging.WARNING)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+
+class TestTheGlobalAffine:
+    """What the volume actually claims about its own physical extent."""
+
+    def test_explicit_z_spacing_reaches_the_global_affine(self, tmp_path):
+        """The reproduction. On the old code the z entry is 10.0, not 45.0."""
+        store = _convert(tmp_path, z_spacing_um=_Z_SPACING_UM)
+
+        np.testing.assert_allclose(
+            _global_affine(store),
+            _expected_affine(_PIXEL_SIZE_UM, _Z_SPACING_UM),
+            rtol=1e-12,
+        )
+
+    def test_the_z_entry_is_not_the_in_plane_pitch(self, tmp_path):
+        """Stated on its own, so the intent survives a rewrite of the matrix.
+
+        The whole defect is one number being reused for a quantity it does not
+        describe. Naming that here means a future refactor that reintroduces it
+        fails on a test whose message says why.
+        """
+        matrix = _global_affine(_convert(tmp_path, z_spacing_um=_Z_SPACING_UM))
+
+        z_entry = matrix[1, 1]
+        assert z_entry == pytest.approx(_Z_SPACING_UM)
+        assert z_entry != pytest.approx(_PIXEL_SIZE_UM), (
+            "z was scaled by the in-plane pixel pitch, which asserts slices "
+            "are one pixel width apart -- true only by coincidence"
+        )
+
+    def test_the_in_plane_axes_are_untouched(self, tmp_path):
+        """Giving z its own spacing must not disturb x or y."""
+        matrix = _global_affine(_convert(tmp_path, z_spacing_um=_Z_SPACING_UM))
+
+        assert matrix[2, 2] == pytest.approx(_PIXEL_SIZE_UM)  # y
+        assert matrix[3, 3] == pytest.approx(_PIXEL_SIZE_UM)  # x
+
+    def test_a_reader_reported_spacing_is_used(self, tmp_path):
+        """``EssentialMetadata.z_spacing_um`` beats the fallback.
+
+        No shipped reader populates it yet -- imzML has no term for it -- but
+        the precedence chain is live code, so it is tested like live code.
+        """
+        store = _convert(tmp_path, reader_z_spacing_um=_Z_SPACING_UM)
+
+        np.testing.assert_allclose(
+            _global_affine(store),
+            _expected_affine(_PIXEL_SIZE_UM, _Z_SPACING_UM),
+            rtol=1e-12,
+        )
+
+    def test_an_explicit_spacing_outranks_the_reader(self, tmp_path):
+        """The caller knows their sections better than the file does."""
+        store = _convert(tmp_path, z_spacing_um=_Z_SPACING_UM, reader_z_spacing_um=7.5)
+
+        assert _global_affine(store)[1, 1] == pytest.approx(_Z_SPACING_UM)
+
+
+class TestTheAssumedCase:
+    """What happens when nobody supplies a spacing -- the default path."""
+
+    def test_it_falls_back_to_the_in_plane_pitch(self, tmp_path):
+        """Unchanged behaviour: this is what every existing 3D store did.
+
+        Kept deliberately rather than made an error, so converting a volume
+        without knowing its section thickness still works. What is new is the
+        record asserted in the next test.
+        """
+        store = _convert(tmp_path)
+
+        np.testing.assert_allclose(
+            _global_affine(store),
+            _expected_affine(_PIXEL_SIZE_UM, _PIXEL_SIZE_UM),
+            rtol=1e-12,
+        )
+
+    def test_the_assumption_is_recorded_in_the_store(self, tmp_path):
+        """The guess must be distinguishable from a measurement, on disk.
+
+        Without this a consumer sees a plain number and no way to tell whether
+        anyone ever measured it. A warning at conversion time does not help
+        someone opening the store six months later.
+        """
+        cs = _global_cs(_convert(tmp_path))
+
+        assert cs["z_spacing_source"] == ZSpacingSource.ASSUMED_ISOTROPIC.value
+        assert cs["z_spacing_um"] == pytest.approx(_PIXEL_SIZE_UM)
+
+    def test_a_supplied_spacing_is_recorded_as_supplied(self, tmp_path):
+        cs = _global_cs(_convert(tmp_path, z_spacing_um=_Z_SPACING_UM))
+
+        assert cs["z_spacing_source"] == ZSpacingSource.USER_PROVIDED.value
+        assert cs["z_spacing_um"] == pytest.approx(_Z_SPACING_UM)
+
+    def test_a_reader_reported_spacing_is_recorded_as_detected(self, tmp_path):
+        cs = _global_cs(_convert(tmp_path, reader_z_spacing_um=_Z_SPACING_UM))
+
+        assert cs["z_spacing_source"] == ZSpacingSource.AUTO_DETECTED.value
+        assert cs["z_spacing_um"] == pytest.approx(_Z_SPACING_UM)
+
+    def test_the_warning_names_the_flag_that_fixes_it(self, tmp_path):
+        """A warning that does not say what to do instead is noise."""
+        with _captured_warnings() as records:
+            _convert(tmp_path)
+
+        assumed = [m for m in records if "z spacing" in m]
+        assert assumed, "converting a volume with no z spacing warned about nothing"
+        assert any("--z-spacing" in message for message in assumed)
+
+    def test_supplying_a_spacing_silences_the_warning(self, tmp_path):
+        with _captured_warnings() as records:
+            _convert(tmp_path, z_spacing_um=_Z_SPACING_UM)
+
+        assert not [m for m in records if "No z spacing was supplied" in m]
+
+    def test_two_dimensional_conversions_do_not_warn(self, tmp_path):
+        """A 2D dataset has no depth to get wrong.
+
+        Warning on every ordinary conversion would train people to ignore the
+        message on the volumes where it actually matters.
+        """
+        with _captured_warnings() as records:
+            _convert(tmp_path, dimensions=(_N_X, _N_Y, 1))
+
+        assert not [m for m in records if "z spacing" in m]
+
+
+class TestTheTableAgreesWithTheVolume:
+    """``obs.spatial_z`` and the image's ``Scale`` are one contract."""
+
+    def test_slice_depth_uses_the_z_spacing(self, tmp_path):
+        """Both elements resolve to the same depth at ``"global"``.
+
+        ``spatial_z`` carried the same hardcoded in-plane pitch, so before this
+        change a volume and its own table disagreed the moment the two numbers
+        differed.
+        """
+        table = _read_store(_convert(tmp_path, z_spacing_um=_Z_SPACING_UM)).tables[
+            _DATASET_ID
+        ]
+
+        for z_index in range(_N_Z):
+            rows = table.obs[table.obs["z"] == z_index]
+            assert not rows.empty, f"no pixels at z={z_index}"
+            np.testing.assert_allclose(
+                rows["spatial_z"].to_numpy(),
+                z_index * _Z_SPACING_UM,
+                rtol=1e-12,
+            )
+
+    def test_the_table_depth_is_not_the_in_plane_pitch(self, tmp_path):
+        """The specific wrong answer, named."""
+        table = _read_store(_convert(tmp_path, z_spacing_um=_Z_SPACING_UM)).tables[
+            _DATASET_ID
+        ]
+
+        top = table.obs[table.obs["z"] == _N_Z - 1]["spatial_z"].to_numpy()
+        assert top[0] == pytest.approx((_N_Z - 1) * _Z_SPACING_UM)
+        assert top[0] != pytest.approx((_N_Z - 1) * _PIXEL_SIZE_UM)
+
+
+class TestTwoDimensionalStoresAreUnchanged:
+    """A 2D conversion must be byte-identical to what earlier versions wrote."""
+
+    def test_a_single_slice_carries_no_z_keys(self, tmp_path):
+        """Absence is the signal that there is no z axis.
+
+        This is also why ``convention_version`` does not move for this change:
+        the keys are additive and only volumes carry them, so a consumer that
+        never does 3D sees exactly the schema it already knows.
+        """
+        cs = _global_cs(_convert(tmp_path, dimensions=(_N_X, _N_Y, 1)))
+
+        assert "z_spacing_um" not in cs
+        assert "z_spacing_source" not in cs
+        assert cs["convention_version"] == 1
+
+    def test_the_single_slice_transform_is_still_two_dimensional(self, tmp_path):
+        """The ``n_z == 1`` branch takes a different path and must not gain a z."""
+        store = _convert(tmp_path, dimensions=(_N_X, _N_Y, 1))
+        image = _read_store(store).images[f"{_DATASET_ID}_tic"]
+
+        assert image.dims == ("c", "y", "x")
+
+
+class TestRejectedInput:
+    def test_a_non_positive_spacing_is_rejected(self, tmp_path):
+        """Caught in the constructor, before anything is read or written."""
+        for bad in (0.0, -1.0, -0.5):
+            with pytest.raises(ValueError, match="z_spacing_um must be positive"):
+                SpatialData3DConverter(
+                    _VolumeProbeReader((_N_X, _N_Y, _N_Z)),
+                    tmp_path / "rejected.zarr",
+                    dataset_id=_DATASET_ID,
+                    pixel_size_um=_PIXEL_SIZE_UM,
+                    z_spacing_um=bad,
+                )
+
+    def test_nothing_is_written_when_it_is_rejected(self, tmp_path):
+        output = tmp_path / "rejected.zarr"
+        with pytest.raises(ValueError):
+            SpatialData3DConverter(
+                _VolumeProbeReader((_N_X, _N_Y, _N_Z)),
+                output,
+                dataset_id=_DATASET_ID,
+                pixel_size_um=_PIXEL_SIZE_UM,
+                z_spacing_um=-1.0,
+            )
+        assert not output.exists()

--- a/tests/unit/test_cli_z_spacing.py
+++ b/tests/unit/test_cli_z_spacing.py
@@ -1,0 +1,122 @@
+# tests/unit/test_cli_z_spacing.py
+"""``--z-spacing`` on the command line.
+
+The flag is only a transport: it becomes ``convert_msi(z_spacing_um=...)``,
+and everything that matters about the value happens further down (see
+``tests/unit/converters/test_3d_tic_z_spacing.py``). What is worth pinning here
+is the transport itself, plus the two ways a user can hold it wrong:
+
+* **Passing it without ``--handle-3d``.** Without 3D handling each slice is
+  written as its own 2D image and there is no z axis, so the value is inert. A
+  silently ignored calibration flag is the same class of defect as
+  ``--optimize-chunks``, which accepted input and did nothing for two releases.
+* **Passing a non-positive value.** Rejected before any file is opened, so a
+  multi-hour conversion cannot fail on it at the end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+import thyra.__main__ as cli
+from thyra.__main__ import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def captured_call(monkeypatch):
+    """Record convert_msi's kwargs instead of running a conversion."""
+    seen: dict = {}
+
+    def _fake_convert_msi(*args, **kwargs):
+        seen.update(kwargs)
+        return True
+
+    monkeypatch.setattr(cli, "convert_msi", _fake_convert_msi)
+    return seen
+
+
+def _invoke(runner, tmp_path: Path, *extra: str):
+    """Run the CLI against an input that clears its path validation.
+
+    The ``.ibd`` sidecar has to exist: the CLI checks for it before any of the
+    conversion runs, and without it every case below would fail on the path
+    rather than on the thing it is testing.
+    """
+    source = tmp_path / "in.imzML"
+    source.write_text("not parsed -- convert_msi is stubbed", encoding="utf-8")
+    (tmp_path / "in.ibd").write_bytes(b"")
+    return runner.invoke(main, [str(source), str(tmp_path / "out.zarr"), *extra])
+
+
+class TestTransport:
+    def test_the_value_reaches_convert_msi(self, runner, tmp_path, captured_call):
+        result = _invoke(runner, tmp_path, "--handle-3d", "--z-spacing", "45")
+
+        assert result.exit_code == 0, result.output
+        assert captured_call["z_spacing_um"] == 45.0
+        assert captured_call["handle_3d"] is True
+
+    def test_omitting_it_forwards_none(self, runner, tmp_path, captured_call):
+        """``None`` is what tells the converter to fall back and say so.
+
+        Forwarding a number here instead would erase the distinction between
+        an assumed spacing and one somebody chose.
+        """
+        result = _invoke(runner, tmp_path, "--handle-3d")
+
+        assert result.exit_code == 0, result.output
+        assert captured_call["z_spacing_um"] is None
+
+    def test_a_fractional_spacing_survives(self, runner, tmp_path, captured_call):
+        """Section thicknesses are not integers."""
+        _invoke(runner, tmp_path, "--handle-3d", "--z-spacing", "12.5")
+
+        assert captured_call["z_spacing_um"] == 12.5
+
+
+class TestRejectedInput:
+    @pytest.mark.parametrize("bad", ["0", "-5", "-0.1"])
+    def test_a_non_positive_spacing_is_rejected(self, runner, tmp_path, bad):
+        result = _invoke(runner, tmp_path, "--handle-3d", "--z-spacing", bad)
+
+        assert result.exit_code != 0
+
+    def test_it_is_rejected_before_the_input_is_opened(
+        self, runner, tmp_path, captured_call
+    ):
+        """Validation runs ahead of the conversion, not after it."""
+        _invoke(runner, tmp_path, "--handle-3d", "--z-spacing", "-1")
+
+        assert captured_call == {}, "convert_msi ran despite an invalid z spacing"
+
+    def test_a_non_numeric_spacing_is_rejected_by_click(self, runner, tmp_path):
+        result = _invoke(runner, tmp_path, "--z-spacing", "thick")
+
+        assert result.exit_code != 0
+        assert "thick" in result.output
+
+
+class TestFlagSurface:
+    def test_help_advertises_it(self, runner):
+        result = runner.invoke(main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--z-spacing" in result.output
+
+    def test_help_points_from_handle_3d_to_it(self, runner):
+        """Someone reaching for ``--handle-3d`` has to be able to find it."""
+        result = runner.invoke(main, ["--help"])
+
+        assert "--z-spacing" in result.output
+        handle_3d_line = next(
+            line for line in result.output.splitlines() if "--handle-3d" in line
+        )
+        assert "z-spacing" in handle_3d_line

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -396,7 +396,7 @@ class GroupedCommand(click.Command):
             "--interactive-calibration",
             "--intensity-threshold",
         ],
-        "Other": ["--dataset-id", "--handle-3d"],
+        "Other": ["--dataset-id", "--handle-3d", "--z-spacing"],
         "General": ["--version", "--help"],
     }
 
@@ -613,7 +613,18 @@ class GroupedCommand(click.Command):
 @click.option(
     "--handle-3d",
     is_flag=True,
-    help="Process as 3D data instead of 2D slices",
+    help="Process as 3D data instead of 2D slices (see --z-spacing)",
+)
+@click.option(
+    "--z-spacing",
+    type=float,
+    default=None,
+    help=(
+        "Distance between consecutive slices in um, for --handle-3d. "
+        "Default: reuse the in-plane pixel size and record it as an "
+        "assumption -- correct only if sections happen to be one pixel "
+        "width apart. Set this whenever the section thickness is known."
+    ),
 )
 def main(
     input: Path,
@@ -622,6 +633,7 @@ def main(
     dataset_id: str,
     pixel_size: Optional[float],
     handle_3d: bool,
+    z_spacing: Optional[float],
     optimize_chunks: bool,
     log_level: str,
     log_file: Optional[Path],
@@ -663,6 +675,7 @@ def main(
     _validate_positive_float(
         intensity_threshold, "intensity_threshold", "Intensity threshold"
     )
+    _validate_positive_float(z_spacing, "z_spacing", "Z spacing")
     _validate_input_path(input)
     _validate_output_path(output)
 
@@ -716,6 +729,7 @@ def main(
         dataset_id=dataset_id,
         pixel_size_um=pixel_size,
         handle_3d=handle_3d,
+        z_spacing_um=z_spacing,
         resampling_config=resampling_config,
         reader_options=reader_options,
         sparse_format=sparse_format,

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -47,12 +47,20 @@ def _validate_string_parameters(format_type: str, dataset_id: str) -> bool:
     return True
 
 
-def _validate_numeric_parameters(pixel_size_um: Optional[float]) -> bool:
+def _validate_numeric_parameters(
+    pixel_size_um: Optional[float], z_spacing_um: Optional[float] = None
+) -> bool:
     """Validate numeric parameters."""
     if pixel_size_um is not None and (
         not isinstance(pixel_size_um, (int, float)) or pixel_size_um <= 0
     ):
         logger.error("Pixel size must be a positive number")
+        return False
+
+    if z_spacing_um is not None and (
+        not isinstance(z_spacing_um, (int, float)) or z_spacing_um <= 0
+    ):
+        logger.error("Z spacing must be a positive number")
         return False
 
     return True
@@ -64,12 +72,13 @@ def _validate_input_parameters(
     format_type: str,
     dataset_id: str,
     pixel_size_um: Optional[float],
+    z_spacing_um: Optional[float] = None,
 ) -> bool:
     """Validate all input parameters for convert_msi function."""
     return (
         _validate_paths_parameters(input_path, output_path)
         and _validate_string_parameters(format_type, dataset_id)
-        and _validate_numeric_parameters(pixel_size_um)
+        and _validate_numeric_parameters(pixel_size_um, z_spacing_um)
     )
 
 
@@ -209,6 +218,7 @@ def _create_converter(
     include_optical: bool = True,
     apply_optical_alignment: bool = True,
     streaming: Union[bool, Literal["auto"]] = "auto",
+    z_spacing_um: Optional[float] = None,
     **kwargs: Any,
 ) -> Any:
     """Create and return a converter for the specified format."""
@@ -217,6 +227,7 @@ def _create_converter(
         "pixel_size_um": pixel_size_um,
         "pixel_size_source": pixel_size_source,
         "handle_3d": handle_3d,
+        "z_spacing_um": z_spacing_um,
         "pixel_size_detection_info": pixel_size_detection_info,
         "resampling_config": resampling_config,
         "sparse_format": sparse_format,
@@ -278,6 +289,7 @@ def convert_msi(
     dataset_id: str = "msi_dataset",
     pixel_size_um: Optional[float] = None,
     handle_3d: bool = False,
+    z_spacing_um: Optional[float] = None,
     resampling_config: Optional[Dict[str, Any]] = None,
     reader_options: Optional[Dict[str, Any]] = None,
     sparse_format: str = "csc",
@@ -297,8 +309,16 @@ def convert_msi(
         output_path: Path for output file
         format_type: Output format type (default: "spatialdata")
         dataset_id: Identifier for the dataset
-        pixel_size_um: Pixel size in micrometers (None for auto)
+        pixel_size_um: In-plane pixel size in micrometers (None for auto)
         handle_3d: Whether to process as 3D data (default: False)
+        z_spacing_um: Distance between consecutive slices in micrometers.
+            Only meaningful together with ``handle_3d=True``; ignored
+            (with a warning) otherwise. ``None`` (default) means nothing
+            supplied one, in which case the in-plane pitch is reused and
+            the store records ``z_spacing_source="assumed_isotropic"``
+            so the guess is not mistaken for a measurement. Supply it
+            whenever the section thickness is known -- the in-plane
+            pitch matches it only by coincidence.
         resampling_config: Optional resampling configuration
         reader_options: Optional format-specific reader options:
             - intensity_threshold: float - Minimum intensity
@@ -355,8 +375,22 @@ def convert_msi(
         format_type,
         dataset_id,
         pixel_size_um,
+        z_spacing_um,
     ):
         return False
+
+    # A z spacing without --handle-3d changes nothing: the 2D route
+    # writes one image per slice and never builds a z axis. Say so rather
+    # than accepting it silently -- a caller who set it believes their
+    # volume is calibrated.
+    if z_spacing_um is not None and not handle_3d:
+        logger.warning(
+            "z_spacing_um=%g was given without handle_3d=True and will be "
+            "ignored: without 3D handling each slice is written as its own "
+            "2D image and there is no z axis to space out. Pass "
+            "handle_3d=True (--handle-3d) to build a volume.",
+            z_spacing_um,
+        )
 
     # Convert to Path objects and validate
     input_path = Path(input_path).resolve()
@@ -400,6 +434,7 @@ def convert_msi(
             include_optical=include_optical,
             apply_optical_alignment=apply_optical_alignment,
             streaming=streaming,
+            z_spacing_um=z_spacing_um,
             **kwargs,
         )
 

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -226,6 +226,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         pixel_size_um: float = 1.0,
         pixel_size_source: PixelSizeSource = PixelSizeSource.DEFAULT,
         handle_3d: bool = False,
+        z_spacing_um: Optional[float] = None,
         pixel_size_detection_info: Optional[Dict[str, Any]] = None,
         resampling_config: Optional[Union[Dict[str, Any], ResamplingConfig]] = None,
         sparse_format: str = "csc",
@@ -239,10 +240,16 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             reader: MSI data reader
             output_path: Path for output file
             dataset_id: Identifier for the dataset
-            pixel_size_um: Size of each pixel in micrometers
+            pixel_size_um: In-plane size of each pixel in micrometers
             pixel_size_source: How pixel size was determined
             handle_3d: Whether to process as 3D data (True) or 2D slices
                 (False)
+            z_spacing_um: Distance between consecutive slices in
+                micrometers.  Only meaningful when a true volume is
+                written (``handle_3d=True`` and more than one slice).
+                ``None`` (default) falls back to the in-plane pitch and
+                records that as an assumption rather than a measurement;
+                see :meth:`BaseMSIConverter._resolve_z_spacing`.
             pixel_size_detection_info: Optional metadata about pixel size
                 detection
             resampling_config: Optional resampling configuration dict
@@ -302,6 +309,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             pixel_size_um=pixel_size_um,
             pixel_size_source=pixel_size_source,
             handle_3d=handle_3d,
+            z_spacing_um=z_spacing_um,
             **kwargs_filtered,
         )
 
@@ -888,6 +896,9 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             elif self.pixel_size_source == PixelSizeSource.USER_PROVIDED:
                 logger.info(f"Using user-specified pixel size: {self.pixel_size_um} um")
 
+            # After pixel size, because the fallback is the pixel size.
+            self._resolve_z_spacing(essential)
+
             # Handle mass axis setup
             self._setup_mass_axis()
 
@@ -1361,8 +1372,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 "region": np.full(n_pixels, f"{self.dataset_id}_pixels"),
                 "spatial_x": x_idx * self.pixel_size_um,
                 "spatial_y": y_idx * self.pixel_size_um,
+                # Slice depth uses the z spacing, not the in-plane pitch:
+                # the table has to land in the same micrometre frame as
+                # the TIC volume's Scale, or the two disagree at "global".
                 "spatial_z": (
-                    z_idx * self.pixel_size_um
+                    z_idx * self.z_spacing_um
                     if n_z > 1
                     else np.zeros(n_pixels, dtype=np.float64)
                 ),
@@ -2208,6 +2222,19 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
           (FlexImaging does not generally calibrate the optical photo
           to um); leave them null and let the consumer fill in.
 
+        Multi-slice volumes additionally get `z_spacing_um` and
+        `z_spacing_source`. These are written **only** for volumes, so a
+        2D store is byte-identical to what earlier versions produced and
+        their absence is itself the signal that no z axis exists. That
+        is also why `convention_version` does not move: the keys are
+        purely additive, a consumer that does not do 3D is unaffected,
+        and bumping the version would make every existing consumer log a
+        "newer than I understand" warning on ordinary 2D datasets.
+
+        Note `z_spacing_um` is an absolute micrometre distance even when
+        `unit="pixel"`, because the 3D route always scales z by it
+        directly -- the optical affine only ever governs x and y.
+
         Returns:
             Dict suitable for storing under
             `zarr.attrs["coordinate_systems"]`.
@@ -2227,16 +2254,20 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             pixel_size_um_y = float(self.pixel_size_um)
             reference_element = None
 
-        return {
-            "global": {
-                "unit": unit,
-                "pixel_size_um_x": pixel_size_um_x,
-                "pixel_size_um_y": pixel_size_um_y,
-                "reference_element": reference_element,
-                "convention_version": self._COORDINATE_SYSTEMS_SCHEMA_VERSION,
-                "produced_by": f"thyra/{thyra_version}",
-            }
+        global_cs: Dict[str, Any] = {
+            "unit": unit,
+            "pixel_size_um_x": pixel_size_um_x,
+            "pixel_size_um_y": pixel_size_um_y,
+            "reference_element": reference_element,
+            "convention_version": self._COORDINATE_SYSTEMS_SCHEMA_VERSION,
+            "produced_by": f"thyra/{thyra_version}",
         }
+
+        if self._is_volume:
+            global_cs["z_spacing_um"] = float(self.z_spacing_um)
+            global_cs["z_spacing_source"] = self.z_spacing_source.value
+
+        return {"global": global_cs}
 
     def _add_comprehensive_sections(
         self, pixel_size_attrs: Dict[str, Any], comprehensive_metadata_obj
@@ -2286,6 +2317,8 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         metadata_dict["conversion_options"] = {
             "handle_3d": self.handle_3d,
             "pixel_size_um": self.pixel_size_um,
+            "z_spacing_um": self.z_spacing_um,
+            "z_spacing_source": self.z_spacing_source.value,
             "dataset_id": self.dataset_id,
             **self.options,
         }

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -292,8 +292,19 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
                 dims=("c", "z", "y", "x"),
             )
 
+            # z gets its own spacing. It used to reuse the in-plane pitch,
+            # which asserts that consecutive slices sit exactly one pixel
+            # width apart -- true only by coincidence, since sections are
+            # cut by a microtome and the raster is set by the stage. The
+            # voxel values were right; the volume was simply the wrong
+            # depth. See BaseMSIConverter._resolve_z_spacing for where the
+            # number comes from when the caller supplies nothing.
+            #
+            # Scale pairs values with axis *names*, not by position, so
+            # this reads ("x", "y", "z") against a (c, z, y, x) image
+            # deliberately. Do not "reorder" it to match the dims.
             transform = Scale(
-                [self.pixel_size_um, self.pixel_size_um, self.pixel_size_um],
+                [self.pixel_size_um, self.pixel_size_um, self.z_spacing_um],
                 axes=("x", "y", "z"),
             )
             try:

--- a/thyra/core/base_converter.py
+++ b/thyra/core/base_converter.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from os import PathLike
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -14,6 +14,9 @@ from tqdm import tqdm
 
 from .base_reader import BaseMSIReader
 
+if TYPE_CHECKING:
+    from ..metadata.types import EssentialMetadata
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,6 +26,26 @@ class PixelSizeSource(Enum):
     DEFAULT = "default"  # Using default 1.0 (fallback)
     USER_PROVIDED = "manual"  # User explicitly provided via parameter
     AUTO_DETECTED = "automatic"  # Detected from metadata
+
+
+class ZSpacingSource(Enum):
+    """How the slice-to-slice (z) spacing was determined.
+
+    Deliberately separate from :class:`PixelSizeSource`: the in-plane
+    pitch is a property of the raster and is nearly always recoverable
+    from the file, while the z spacing is a property of how the sections
+    were physically cut and usually is not recoverable at all.
+
+    ``ASSUMED_ISOTROPIC`` is the one that matters. It records that
+    nothing supplied a spacing and the in-plane pitch was reused, which
+    is what this code has always done -- the point of naming it is that
+    a consumer can now tell a measured spacing from a guessed one
+    instead of receiving both as bare numbers.
+    """
+
+    ASSUMED_ISOTROPIC = "assumed_isotropic"  # Nothing supplied one; reused x pitch
+    USER_PROVIDED = "manual"  # Explicit z_spacing_um argument
+    AUTO_DETECTED = "automatic"  # Reported by the source metadata
 
 
 class BaseMSIConverter(ABC):
@@ -41,6 +64,7 @@ class BaseMSIConverter(ABC):
         pixel_size_source: PixelSizeSource = PixelSizeSource.DEFAULT,
         compression_level: int = 5,
         handle_3d: bool = False,
+        z_spacing_um: Optional[float] = None,
         **kwargs: Any,
     ):
         """Initialize the MSI converter.
@@ -49,12 +73,25 @@ class BaseMSIConverter(ABC):
             reader: MSI data reader instance
             output_path: Path for output file
             dataset_id: Identifier for the dataset
-            pixel_size_um: Size of each pixel in micrometers
+            pixel_size_um: In-plane pixel pitch in micrometers
             pixel_size_source: How pixel size was determined
             compression_level: Compression level for output
             handle_3d: Whether to process as 3D data
+            z_spacing_um: Distance between consecutive slices in
+                micrometers.  Only meaningful with ``handle_3d=True``.
+                ``None`` (default) means "nobody said", which falls back
+                to the in-plane pitch and records that it was assumed --
+                see :meth:`_resolve_z_spacing`.
             **kwargs: Additional keyword arguments
+
+        Raises:
+            ValueError: If ``z_spacing_um`` is given and is not positive.
         """
+        if z_spacing_um is not None and (
+            not isinstance(z_spacing_um, (int, float)) or z_spacing_um <= 0
+        ):
+            raise ValueError(f"z_spacing_um must be positive, got {z_spacing_um}")
+
         self.reader = reader
         self.output_path = Path(output_path)
         self.dataset_id = dataset_id
@@ -62,6 +99,15 @@ class BaseMSIConverter(ABC):
         self.pixel_size_source = pixel_size_source
         self.compression_level = compression_level
         self.handle_3d = handle_3d
+
+        # Settled in _resolve_z_spacing() once metadata is loaded, because
+        # the fallback is the in-plane pitch and that may itself still be
+        # the placeholder 1.0 until auto-detection has run.
+        self._z_spacing_um_arg = (
+            float(z_spacing_um) if z_spacing_um is not None else None
+        )
+        self.z_spacing_um: float = float(pixel_size_um)
+        self.z_spacing_source = ZSpacingSource.ASSUMED_ISOTROPIC
         self.options: Dict[str, Any] = kwargs
         self._common_mass_axis: Optional[NDArray[np.float64]] = None
         self._dimensions: Optional[Tuple[int, int, int]] = None
@@ -134,6 +180,9 @@ class BaseMSIConverter(ABC):
             elif self.pixel_size_source == PixelSizeSource.USER_PROVIDED:
                 logger.info(f"Using user-specified pixel size: {self.pixel_size_um} um")
 
+            # After pixel size, because the fallback is the pixel size.
+            self._resolve_z_spacing(essential)
+
             # Load mass axis separately (still expensive operation)
             self._common_mass_axis = self.reader.get_common_mass_axis()
             if len(self._common_mass_axis) == 0:
@@ -152,6 +201,89 @@ class BaseMSIConverter(ABC):
         except Exception as e:
             logger.error(f"Error during initialization: {e}")
             raise
+
+    @property
+    def _is_volume(self) -> bool:
+        """True when this conversion writes a real multi-slice volume.
+
+        ``handle_3d`` alone is not enough: it is forced on by
+        ``SpatialData3DConverter.__init__`` regardless of the data, and a
+        single-slice acquisition converted through that class still takes
+        the 2D branch of ``_create_tic_image``. Only the combination has
+        a z axis to space out.
+        """
+        return bool(self.handle_3d and self._dimensions and self._dimensions[2] > 1)
+
+    def _resolve_z_spacing(self, essential: "EssentialMetadata") -> None:
+        """Settle the slice-to-slice spacing, and record where it came from.
+
+        Precedence mirrors the in-plane pitch: an explicit argument wins,
+        then whatever the source could report, then a fallback.
+
+        The fallback is the in-plane pitch, which is what every 3D volume
+        this project has written so far already used. What changes is that
+        it is no longer *stated as a fact*: ``z_spacing_source`` marks it
+        as an assumption, the store carries that marker, and a volume
+        built on a guess is loud about it in the log.
+
+        Reusing the in-plane pitch asserts that consecutive slices sit
+        exactly one pixel-width apart. Sections are cut by a microtome and
+        the raster is set by the stage, so the two agree only by
+        coincidence -- for 3D MSI usually not at all, and often by an
+        order of magnitude. A consumer reading the volume in micrometres
+        renders the stack at the wrong depth.
+
+        Args:
+            essential: Metadata for the dataset being converted.
+        """
+        if self._z_spacing_um_arg is not None:
+            self.z_spacing_um = self._z_spacing_um_arg
+            self.z_spacing_source = ZSpacingSource.USER_PROVIDED
+        elif getattr(essential, "z_spacing_um", None) is not None:
+            self.z_spacing_um = float(essential.z_spacing_um)
+            self.z_spacing_source = ZSpacingSource.AUTO_DETECTED
+        else:
+            self.z_spacing_um = float(self.pixel_size_um)
+            self.z_spacing_source = ZSpacingSource.ASSUMED_ISOTROPIC
+
+        self._log_z_spacing()
+
+    def _log_z_spacing(self) -> None:
+        """Report the resolved z spacing, warning when it was assumed.
+
+        Silent for anything that is not a volume: a 2D conversion has no
+        slice-to-slice distance to get wrong, and warning about one on
+        every ordinary dataset would train people to ignore the message
+        on the datasets where it matters.
+        """
+        if not self._is_volume:
+            logger.debug(
+                "Not a multi-slice volume; z spacing (%g um, %s) is unused.",
+                self.z_spacing_um,
+                self.z_spacing_source.value,
+            )
+            return
+
+        if self.z_spacing_source is ZSpacingSource.ASSUMED_ISOTROPIC:
+            logger.warning(
+                "No z spacing was supplied, so this volume assumes slices sit "
+                "one in-plane pixel apart (%g um). That is a guess, not a "
+                "measurement: section thickness is set by the microtome, not "
+                "by the raster, so any consumer reading this volume in "
+                "micrometres will render the stack at the wrong depth unless "
+                "the two happen to coincide. Pass --z-spacing (CLI) or "
+                "z_spacing_um= (API) to set it. The store records this as "
+                "z_spacing_source='%s' so the assumption stays visible.",
+                self.z_spacing_um,
+                ZSpacingSource.ASSUMED_ISOTROPIC.value,
+            )
+        else:
+            logger.info(
+                "Using %s z spacing: %g um (in-plane pitch %g um)",
+                self.z_spacing_source.value,
+                self.z_spacing_um,
+                self.pixel_size_um,
+            )
 
     @abstractmethod
     def _create_data_structures(self) -> Any:
@@ -397,7 +529,7 @@ class BaseMSIConverter(ABC):
         # Add spatial coordinates
         coords_df["spatial_x"] = coords_df["x"] * self.pixel_size_um
         coords_df["spatial_y"] = coords_df["y"] * self.pixel_size_um
-        coords_df["spatial_z"] = coords_df["z"] * self.pixel_size_um
+        coords_df["spatial_z"] = coords_df["z"] * self.z_spacing_um
 
         return coords_df
 

--- a/thyra/metadata/types.py
+++ b/thyra/metadata/types.py
@@ -14,8 +14,9 @@ class EssentialMetadata:
         dimensions: Grid dimensions as ``(x, y, z)``.
         coordinate_bounds: Spatial extent as ``(min_x, max_x, min_y, max_y)``.
         mass_range: Mass-to-charge range as ``(min_mz, max_mz)``.
-        pixel_size: Pixel dimensions as ``(x_um, y_um)`` in micrometres,
-            or ``None`` when not detected.
+        pixel_size: In-plane pixel dimensions as ``(x_um, y_um)`` in
+            micrometres, or ``None`` when not detected.  This is the
+            raster pitch and says nothing about z; see ``z_spacing_um``.
         n_spectra: Total number of spectra in the dataset.
         total_peaks: Total number of peaks across all spectra (used for
             sparse matrix pre-allocation).
@@ -29,6 +30,16 @@ class EssentialMetadata:
             construction in the streaming converter.  Array of size
             ``n_pixels`` where ``arr[pixel_idx] = peak_count`` and
             ``pixel_idx = z * (n_x * n_y) + y * n_x + x``.
+        z_spacing_um: Distance between consecutive slices in micrometres,
+            or ``None`` when the source cannot report it.  This is a
+            *physical* distance set by how the sections were cut, and is
+            unrelated to the in-plane pitch in ``pixel_size`` -- the two
+            agree only by coincidence.  No reader populates this today:
+            imzML has no standard term for it, and 3D acquisitions are
+            frequently non-consecutive sections, so the value usually has
+            to be supplied by the user.  The field exists so a format that
+            *does* record it has somewhere to report it, and so the
+            converter's precedence chain has something to consult.
     """
 
     dimensions: Tuple[int, int, int]
@@ -42,6 +53,7 @@ class EssentialMetadata:
     coordinate_offsets: Optional[Tuple[int, int, int]] = None
     spectrum_type: Optional[str] = None
     peak_counts_per_pixel: Optional[NDArray[np.int32]] = None
+    z_spacing_um: Optional[float] = None
 
     @property
     def has_pixel_size(self) -> bool:


### PR DESCRIPTION
Surfaced by #146 and deliberately left out of it.

## The problem

`_create_tic_image` built the volume's transform to `"global"` from the
**in-plane** raster pitch on all three axes:

```python
Scale([pixel_size_um, pixel_size_um, pixel_size_um], axes=("x", "y", "z"))
```

That asserts consecutive slices sit exactly one pixel width apart. Section
thickness is set by the microtome; the raster is set by the stage. They agree
only by coincidence, and for 3D MSI usually not at all.

The voxel *values* were right -- #146 fixed the permutation that made them
wrong -- the volume was simply the wrong **depth**. Any consumer reading it in
micrometres (Ousia does) rendered the stack squashed or stretched along z.

## Wider than one line

`obs["spatial_z"]` carried the same hardcoded pitch, so the volume and its own
table disagreed about depth the moment the two numbers differed. Fixing only
the image would have been worse than leaving both consistently wrong. Both now
use the resolved spacing, and a test asserts they agree.

## The interface

`z_spacing_um` on `convert_msi()`, `--z-spacing` on the CLI, resolved
**user-supplied > reader-reported > fallback** -- the same precedence the
in-plane pitch already gets. `EssentialMetadata` gains an optional
`z_spacing_um` so a format that *can* report slice spacing has somewhere to put
it. No shipped reader populates it: imzML has no term for it, and 3D
acquisitions are frequently non-consecutive sections, so the number generally
has to come from whoever cut them.

## The default, when nothing is supplied

Still the in-plane pitch, so existing 3D conversions keep working -- but it is
no longer *stated as a fact*. The converter warns, naming the flag that fixes
it, and the store records the provenance:

```python
cs = sdata.attrs["coordinate_systems"]["global"]
cs["z_spacing_um"]      # the number used
cs["z_spacing_source"]  # "manual" | "automatic" | "assumed_isotropic"
```

`"assumed_isotropic"` means nobody supplied one. A warning at conversion time
does not help someone opening the store six months later; the attr does.

The z keys are written **only** for multi-slice volumes, so a 2D store is
unchanged and their absence is itself the signal that there is no z axis.
`convention_version` therefore stays at `1`: the keys are purely additive, and
bumping it would make every existing consumer -- Ousia's
`backend/readers/coordinate_systems.py` gates on exactly this -- log a "newer
than I understand" warning on ordinary 2D datasets.

## What I did not change

- **The axis order in that `Scale`.** `axes=("x","y","z")` against a
  `(c,z,y,x)` image looks mismatched and is not: `Scale` pairs values with axis
  *names*. Verified -- the two spellings produce an identical affine. A comment
  now says so, since it reads like a bug.
- **`test_3d_tic_axis_order.py`.** Untouched, still passing.
- **Anisotropic in-plane pixels.** `essential.pixel_size[0]` discards y, so
  non-square pixels are collapsed too. That is a different defect with a much
  larger blast radius (every 2D dataset), and mixing it in would make this
  change impossible to reason about. Left alone deliberately.

## Verification

Both halves were confirmed to **fail** before passing -- I reverted each and
watched the tests break:

- reverting the `Scale` -> `test_explicit_z_spacing_reaches_the_global_affine`
  reports `Obtained: 10.0, Expected: 45.0`, plus 3 others
- reverting `spatial_z` -> the two table-agreement tests fail

27 new tests assert the **affine matrix entry by entry**, read back off disk,
not merely that the converter did not raise. Constants are pairwise
non-multiples (pitch 10, spacing 45, grid 5x3x2) so a value on the wrong axis
cannot coincidentally produce the expected matrix.

Full suite: **1368 passed, 13 skipped, 18 deselected** (rebased onto current `main`). `black` / `isort` /
`flake8` / `mypy` / `pydocstyle` clean (the 7 `union-attr` errors a local mypy
reports in `base_spatialdata_converter.py` are present identically on `main`).

## Please look at

This changes the **geometry of every 3D volume**, which is a scientific result,
so it wants your eyes rather than a self-merge.

1. **Is `"assumed_isotropic"` the right default?** The alternative was refusing
   to convert without `--z-spacing`. That is stricter but breaks every existing
   3D invocation and blocks "just give me the voxels, I'll scale later". I took
   the back-compatible option on the grounds that the wrongness is now recorded
   rather than silent -- say the word and I will make it an error.
2. **Not bumping `convention_version`.** Reasoning above; the trade is a
   spurious Ousia warning on all 2D datasets versus a 3D consumer having to
   treat an absent key as "no z axis".
3. **Ousia will need a follow-up** to actually read `z_spacing_um` -- this PR
   only makes the number correct and available. Nothing in Ousia reads it yet.

## Found and not fixed

`_create_pixel_shapes(adata, is_3d=True)` accepts `is_3d` and **never reads
it**. Pixel shapes are flat x/y boxes regardless, so all slices' polygons
coincide in depth -- the coordinate-systems contract's promise that every
element resolves to the same frame at `"global"` is already false for 3D,
independently of spacing. Fixing it means deciding whether 3D pixel shapes
should exist at all (shapely `box` is 2D). Documented as a warning in
`output-format.md`; worth its own issue.
