### PR TITLE
perf(converters): make PCS the streaming default and drop the size threshold

### DIFF
--- a/tests/unit/converters/test_routing_estimate.py
+++ b/tests/unit/converters/test_routing_estimate.py
@@ -1,10 +1,9 @@
 # tests/unit/converters/test_routing_estimate.py
-"""Tests that CSR-vs-CSC routing is decided on the real bin count.
+"""The size estimate must be honest, and routing must not depend on it.
 
 ``_estimate_output_size_gb`` scores a dataset as
-``n_pixels * n_mz_bins * 4`` and ``_should_use_pcs`` compares that against
-``PCS_SIZE_THRESHOLD_GB``. The resampling branch already resolved the real
-bin count (issue #87), but the raw-axis branch still guessed it from
+``n_pixels * n_mz_bins * 4``. The resampling branch already resolved the
+real bin count (issue #87), but the raw-axis branch still guessed it from
 ``(max_mass - min_mass) / 0.01`` -- a 10 mDa spacing the data need not have.
 
 That guess is wrong in both directions. A continuous file carrying 4,000
@@ -13,12 +12,21 @@ points over 250-1200 m/z was scored as though it had 95,000, inflating it
 low, which routed the very largest datasets to the method that holds the
 most in memory.
 
-``convert()`` runs ``_initialize_conversion()`` before it asks which method
-to use, so the axis is already built when the gate is evaluated and there is
-nothing to estimate. These tests pin that the built axis is preferred, and
-that the old heuristics still apply when it is not available -- which is the
-case when the estimator is called directly, as the older tests in
-``test_streaming_converter.py`` do.
+**The routing half of that is now history.** ``_should_use_pcs`` no longer
+consults the estimate at all: PCS is faster and lighter at every size
+measured, so ``"auto"`` picks it unconditionally and
+``PCS_SIZE_THRESHOLD_GB`` is gone. The estimate survives as a log line, and
+these tests survive with it -- an inaccurate number in a support log is a
+smaller problem than an inaccurate route, but it is still a problem, and the
+24x inflation is the kind of thing that gets re-derived if nobody wrote down
+that the fallback is unreliable.
+
+``convert()`` runs ``_initialize_conversion()`` before reaching the
+estimate, so the axis is already built and there is nothing to guess. These
+tests pin that the built axis is preferred, that the old heuristics still
+apply when it is not available -- which is the case when the estimator is
+called directly, as the older tests in ``test_streaming_converter.py`` do --
+and that no combination of sizes changes the route.
 """
 
 from __future__ import annotations
@@ -30,11 +38,11 @@ from typing import Optional, Tuple
 import numpy as np
 import pytest
 
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
 from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
     StreamingSpatialDataConverter,
 )
-
-THRESHOLD = StreamingSpatialDataConverter.PCS_SIZE_THRESHOLD_GB
 
 
 class _Meta:
@@ -130,42 +138,68 @@ class TestFallbacksStillApply:
         assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
 
 
-class TestRoutingDecision:
-    """The estimate exists to pick a method, so pin the decision itself."""
+class TestRoutingIsSizeIndependent:
+    """``"auto"`` means PCS, whatever the estimate says.
 
-    def test_narrow_real_axis_routes_to_coo(self):
-        """Was PCS on an estimate inflated 24x by the 10 mDa assumption."""
-        axis = np.linspace(250.0, 1200.0, 4_000)
-        conv = _converter((1000, 600, 1), axis=axis)
+    Each case below picked a *different* route under the old threshold, so
+    together they pin that the size no longer reaches the decision.
+    """
 
-        assert conv._estimate_output_size_gb() < THRESHOLD
-        assert conv._should_use_pcs() is False
+    def test_tiny_dataset_still_routes_to_pcs(self):
+        """A 400-byte dataset. Went to COO under the threshold."""
+        conv = _converter((10, 10, 1), axis=np.linspace(250.0, 1200.0, 10))
 
-        # Same dataset under the old rule would have been sent to PCS.
-        conv._common_mass_axis = None
-        assert conv._estimate_output_size_gb() > THRESHOLD
-
-    def test_wide_real_axis_routes_to_pcs(self):
-        """Was COO despite being genuinely large."""
-        axis = np.linspace(250.0, 1200.0, 200_000)
-        conv = _converter((250, 200, 1), axis=axis)
-
-        assert conv._estimate_output_size_gb() > THRESHOLD
+        assert conv._estimate_output_size_gb() < 1.0
         assert conv._should_use_pcs() is True
 
-        # The old rule scored this below the threshold.
+    def test_narrow_real_axis_routes_to_pcs(self):
+        """Comfortably under the old 30 GB gate, so this went to COO."""
+        conv = _converter((1000, 600, 1), axis=np.linspace(250.0, 1200.0, 4_000))
+
+        assert conv._estimate_output_size_gb() < 30.0
+        assert conv._should_use_pcs() is True
+
+    def test_wide_real_axis_routes_to_pcs(self):
+        """Over the old gate, so this one already went to PCS. Still does."""
+        conv = _converter((250, 200, 1), axis=np.linspace(250.0, 1200.0, 200_000))
+
+        assert conv._estimate_output_size_gb() > 30.0
+        assert conv._should_use_pcs() is True
+
+    def test_route_does_not_move_when_the_estimate_does(self):
+        """The strongest form: swing the estimate 24x, route must not budge.
+
+        Dropping the built axis makes the estimator fall back to the 10 mDa
+        heuristic, which inflates this dataset from ~9 GB to ~223 GB -- a
+        swing that straddled the old threshold and flipped the route. If a
+        size gate is ever reintroduced, this is what fails.
+        """
+        conv = _converter((1000, 600, 1), axis=np.linspace(250.0, 1200.0, 4_000))
+
+        with_axis = conv._estimate_output_size_gb()
+        assert conv._should_use_pcs() is True
+
         conv._common_mass_axis = None
-        assert conv._estimate_output_size_gb() < THRESHOLD
+        without_axis = conv._estimate_output_size_gb()
+
+        assert without_axis > with_axis * 20  # 95,000 / 4,000 = 23.75x
+        assert conv._should_use_pcs() is True
 
     def test_explicit_use_csc_still_wins(self):
-        """The estimate is only consulted in auto mode."""
-        axis = np.linspace(250.0, 1200.0, 10)
-        conv = _converter((10, 10, 1), axis=axis)
+        """COO stays reachable: it is an escape hatch, not dead code."""
+        conv = _converter((10, 10, 1), axis=np.linspace(250.0, 1200.0, 10))
 
         conv._use_csc = True
         assert conv._should_use_pcs() is True
         conv._use_csc = False
         assert conv._should_use_pcs() is False
+
+    def test_the_threshold_constant_is_gone(self):
+        """A leftover constant would read as a live gate. It is not one.
+
+        Left behind, the next person tunes it and nothing happens.
+        """
+        assert not hasattr(StreamingSpatialDataConverter, "PCS_SIZE_THRESHOLD_GB")
 
 
 class TestDegenerate:
@@ -174,9 +208,76 @@ class TestDegenerate:
     def test_empty_axis_is_zero_sized(self):
         conv = _converter((10, 10, 1), axis=np.array([]))
         assert conv._estimate_output_size_gb() == 0.0
-        assert conv._should_use_pcs() is False
+        # Zero is a size like any other now; it does not divert the route.
+        assert conv._should_use_pcs() is True
 
     def test_single_bin_axis(self):
         conv = _converter((10, 10, 1), axis=np.array([500.0]))
         expected = 100 * 1 * 4 / (1024**3)
         assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
+
+
+@pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+class TestTheRouteIsActuallyTaken:
+    """End-to-end: which branch ``convert()`` reaches, not what a predicate says.
+
+    ``_should_use_pcs`` returning True is not the same as the conversion
+    taking the PCS branch -- ``convert()`` has to consult it and act on the
+    answer. Asserting the predicate alone would keep passing if that wiring
+    were bypassed, so this drives a real conversion and records which of the
+    two entry points ran.
+    """
+
+    @staticmethod
+    def _route_taken(**kwargs) -> str:
+        reader = MockMSIReader(
+            MockMSIConfig(n_x=6, n_y=4, n_mz_bins=400, peaks_per_spectrum=(20, 40))
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            converter = StreamingSpatialDataConverter(
+                reader=reader,
+                output_path=Path(tmpdir) / "out.zarr",
+                dataset_id="route",
+                pixel_size_um=10.0,
+                **kwargs,
+            )
+
+            calls: list[str] = []
+
+            def _spy(name):
+                original = getattr(converter, name)
+
+                def wrapper(*args, **kwargs_):
+                    calls.append(name)
+                    return original(*args, **kwargs_)
+
+                return wrapper
+
+            for entry_point in ("_convert_to_csc_no_cache", "_stream_build_coo"):
+                setattr(converter, entry_point, _spy(entry_point))
+
+            assert converter.convert() is True, "conversion fixture failed"
+
+        if "_convert_to_csc_no_cache" in calls:
+            return "pcs"
+        if "_stream_build_coo" in calls:
+            return "coo"
+        raise AssertionError(f"neither route ran: {calls}")
+
+    def test_default_conversion_takes_pcs(self):
+        """No ``use_csc`` at all -- the case every in-repo caller hits.
+
+        Nothing in ``thyra/`` passes ``use_csc``, so this is what the CLI and
+        the public API did, and before this change it was COO.
+        """
+        assert self._route_taken() == "pcs"
+
+    def test_explicit_true_takes_pcs(self):
+        assert self._route_taken(use_csc=True) == "pcs"
+
+    def test_explicit_false_still_takes_coo(self):
+        """COO must stay reachable, or the tests covering it stop meaning anything."""
+        assert self._route_taken(use_csc=False) == "coo"

--- a/tests/unit/converters/test_streaming_converter.py
+++ b/tests/unit/converters/test_streaming_converter.py
@@ -245,8 +245,9 @@ def test_drop_empty_pixels_no_op_when_all_rows_have_data():
 def test_estimate_output_size_uses_real_bins_for_width_based_config():
     """Regression for #87: when ``target_bins`` is None, the size estimator
     must resolve the bin count via ``width_at_mz`` rather than fall back to a
-    hardcoded 10,000 placeholder. A 10k fallback would also pick the wrong
-    streaming method against ``PCS_SIZE_THRESHOLD_GB``.
+    hardcoded 10,000 placeholder. That fallback used to pick the wrong
+    streaming method as well; routing no longer depends on the estimate, so
+    what is left at stake is the number in the log.
     """
     reader = MockMSIReader(
         dimensions=(50, 50, 1),
@@ -680,8 +681,7 @@ def test_rectangular_grid():
     reason="SpatialData dependencies not available",
 )
 def test_auto_use_csc_mode_large_dataset():
-    """Test that auto mode selects CSC for large estimated datasets."""
-    # Create reader with large dimensions that exceeds PCS_SIZE_THRESHOLD_GB
+    """Auto mode selects the PCS (CSC) route, whatever the estimated size."""
     reader = MockMSIReader(
         dimensions=(100, 100, 1),  # 10000 pixels
         peaks_per_spectrum=500,
@@ -698,12 +698,9 @@ def test_auto_use_csc_mode_large_dataset():
             use_csc="auto",  # Auto mode
         )
 
-        # Check that auto mode correctly evaluates the threshold
-        # The _should_use_pcs method should be callable
-        should_use = converter._should_use_pcs()
-        # With 10000 pixels * 10000 m/z bins * 4 bytes ~ 0.37 GB
-        # This is below 50GB threshold, so should return False
-        assert isinstance(should_use, bool)
+        # ~0.37 GB estimated (10,000 pixels x 10,000 bins x 4 bytes), which
+        # under the old 30 GB gate sent this to COO. "auto" is PCS now.
+        assert converter._should_use_pcs() is True
 
 
 @pytest.mark.integration

--- a/tests/unit/converters/test_uns_provenance_parity.py
+++ b/tests/unit/converters/test_uns_provenance_parity.py
@@ -17,13 +17,20 @@ There are four write paths and they had drifted:
   ``format_specific`` / ``instrument_info`` / ``raw_metadata`` / ``regions``
   dropped entirely.
 
-Which path a dataset takes is decided by size, in
+Which path a dataset took was decided by size at the time, in
 ``StreamingSpatialDataConverter._should_use_pcs`` -- so two acquisitions
 off the same instrument landed on opposite sides of the split and came out
-described differently.  On ``test_data/``: ``pea.imzML`` estimates 29.9 GB
+described differently.  On ``test_data/``: ``pea.imzML`` estimated 29.9 GB
 (COO, complete provenance) and ``bellini.imzML`` 43.3 GB (PCS, wrong
 ``spectrum_type``, everything else missing).  Ousia's import wizard forces
 ``use_csc=True``, so *every* wizard conversion took the PCS path.
+
+That size split is gone -- ``"auto"`` is PCS now, unconditionally -- which
+removes the *mechanism* that made two sibling datasets disagree but not the
+hazard: the paths still compose provenance separately, so a section added
+to one and not the other diverges just as silently. Hence this module keeps
+asserting parity across all of them rather than being retired with the
+threshold.
 
 Nothing caught it because ``MockMSIReader`` reported
 ``spectrum_type="processed"`` too -- the fixture agreed with the hardcoded
@@ -356,7 +363,7 @@ def test_slice_paths_write_the_same_obs_columns(stores):
 
     PCS hand-writes its ``obs`` group and simply had no ``region_number``
     column, so a consumer that branches on it saw a different schema
-    depending on which side of ``PCS_SIZE_THRESHOLD_GB`` the dataset fell.
+    depending on which side of the old size threshold the dataset fell.
     """
     reference_name = "in_memory"
     reference = set(_read_obs(_table_path(stores, reference_name)).columns)

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -519,12 +519,14 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         ``adata.uns``; the streaming-PCS path hand-writes the Zarr layout
         and used to compose its own, much smaller block -- with
         ``spectrum_type`` hardcoded to ``"processed"``, which is not even
-        a value the extractors produce. A dataset that crossed
-        ``StreamingSpatialDataConverter.PCS_SIZE_THRESHOLD_GB`` therefore
-        came out claiming a spectrum representation it did not have, and
-        without any of the other sections, while a slightly smaller one
-        from the same instrument came out complete. Both paths now render
-        this mapping, so a section added here reaches every store.
+        a value the extractors produce. Routing was on a size threshold at
+        the time, so a dataset large enough to reach the PCS path came out
+        claiming a spectrum representation it did not have, and without any
+        of the other sections, while a slightly smaller one from the same
+        instrument came out complete. Both paths now render this mapping,
+        so a section added here reaches every store. (The threshold is
+        gone -- PCS is the default route -- but the divergence it exposed
+        is exactly what this method exists to prevent.)
 
         Sections the reader has nothing for are omitted rather than
         written empty, so consumers can tell "not available from this

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -50,26 +50,39 @@ _INDEX_BUILD_CHUNK = 1_000_000
 class StreamingSpatialDataConverter(BaseSpatialDataConverter):
     """Memory-efficient streaming converter for MSI data to SpatialData format.
 
-    Uses a two-pass approach to keep memory bounded during processing:
-    - Pass 1: Count non-zeros to build sparse matrix structure (indptr)
-    - Pass 2: Write indices and data directly to Zarr
+    Two routes, both two-pass over the reader:
 
-    For large datasets (>50GB), uses CSC format with memory-mapped files
-    to handle datasets of any size with ~200MB RAM. For smaller datasets,
-    uses the simpler CSR approach.
+    - **PCS** (Pre-calculated Scatter, ``use_csc=True``, and what ``"auto"``
+      now picks). Pass 1 counts entries per column, pass 2 scatters straight
+      into memory-mapped CSC arrays and streams those to Zarr. The matrix is
+      never a scipy object in RAM.
+    - **COO** (``use_csc=False``). Pass 1 counts non-zeros per row, pass 2
+      writes CSR components to a temporary Zarr, which is then read back
+      whole into a ``scipy.sparse.csr_matrix`` and converted with
+      ``.tocsc()``. That materialise-then-convert step is the peak.
 
-    Key advantages:
-    - Memory stays bounded (~200MB) regardless of dataset size
-    - Writes directly to Zarr without scipy matrix in memory
-    - CSC format enables efficient ion image extraction
-    - Handles 1M+ pixels without memory issues
+    PCS is the default because it is faster *and* lighter, and the gap widens
+    with the dataset. Measured on ``MockMSIReader``, peak process RSS sampled
+    at 20 ms, one subprocess per route:
+
+    ===========  ==============  ==============
+    nnz          PCS             COO
+    ===========  ==============  ==============
+    16M          7.4 s / 540 MB  10.4 s / 655 MB
+    64M          35.6 s / 1.1 GB 58.5 s / 1.9 GB
+    ===========  ==============  ==============
+
+    Both routes iterate the reader twice, so the usual "PCS re-reads the
+    file" objection does not apply -- that cost is symmetric, which is why
+    PCS wins on time at all.
+
+    Note what the numbers do *not* say: PCS is not the "~200 MB regardless of
+    dataset size" this docstring used to claim. Its RSS grew 540 MB -> 1.1 GB
+    across those two points. Much of that is memmap pages, which count toward
+    working set while remaining evictable, so the private-memory gap is wider
+    than the table suggests -- but "bounded" was never true and is not
+    claimed here.
     """
-
-    # Threshold in GB above which PCS (Pre-calculated Scatter) method is used
-    # for memory-efficient CSC conversion. Below this, standard COO approach is used.
-    # Set to 30 GB to catch continuous mode datasets that would cause memory spikes
-    # (the standard method can use 2-3x the dataset size in peak memory).
-    PCS_SIZE_THRESHOLD_GB: float = 30.0
 
     def __init__(
         self,
@@ -88,11 +101,13 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 Default: 5000 spectra per chunk.
             temp_dir: Directory for temporary Zarr files. If None, uses
                 system temp directory. Cleaned up after conversion.
-            use_csc: Controls CSC format conversion method:
-                - "auto" (default): Use PCS method for large datasets (>50GB),
-                  standard method for smaller datasets
-                - True: Always use PCS method for memory-efficient CSC
-                - False: Use CSR format instead
+            use_csc: Which of the two write routes to take:
+                - "auto" (default): PCS. Kept as a distinct value from
+                  ``True`` so a caller can say "whatever the converter
+                  thinks best" and follow the default if it moves again.
+                - True: PCS, pinned.
+                - False: COO. The escape hatch -- it materialises the
+                  matrix in RAM, so reach for it only with a reason.
             **kwargs: Keyword arguments passed to BaseSpatialDataConverter
 
         Note:
@@ -115,10 +130,17 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         setattr(self.reader, "_quiet_mode", True)
 
     def _estimate_output_size_gb(self) -> float:
-        """Estimate the output dataset size in GB.
+        """Estimate the output dataset size in GB, for the log line.
 
-        Uses metadata to estimate the dense matrix size:
-        n_pixels * n_mz_bins * 4 bytes (float32)
+        Dense size, ``n_pixels * n_mz_bins * 4`` bytes (float32).
+
+        **Diagnostic only since PCS became the default.** Nothing routes on
+        this any more. It is kept because the number is genuinely useful in a
+        support log and because getting it right was not free: the fallback
+        below is wrong in both directions (see the comment in the body), and
+        deleting the function would delete that finding along with the tests
+        that pin it. If you are looking for the routing decision it is in
+        :meth:`_should_use_pcs`, which no longer calls this.
 
         Returns:
             Estimated size in gigabytes
@@ -131,19 +153,20 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
 
         # Prefer the axis that was actually built. ``convert()`` runs
         # ``_initialize_conversion()`` -- and so ``_setup_mass_axis()`` --
-        # before it asks which method to use, so by the time this gate is
-        # evaluated the real bin count is known and there is nothing to
-        # estimate. That matters most on the raw-axis path, where the
-        # fallback below assumes a 10 mDa spacing that the data need not
-        # have: a continuous file carrying 4,000 points over 250-1200 m/z
-        # was scored as though it had 95,000, and a processed file whose
-        # spectra share no m/z values was scored far too low, which routed
-        # the largest datasets to the method that holds the most in memory.
+        # before this is reached, so the real bin count is known and there
+        # is nothing to estimate. That matters most on the raw-axis path,
+        # where the fallback below assumes a 10 mDa spacing that the data
+        # need not have: a continuous file carrying 4,000 points over
+        # 250-1200 m/z was scored as though it had 95,000, and a processed
+        # file whose spectra share no m/z values was scored far too low.
+        # While this drove the routing (issue #87) that mis-sent the
+        # largest datasets to the method that holds the most in memory; it
+        # now only makes the logged number honest.
         if self._common_mass_axis is not None:
             n_mz_bins = len(self._common_mass_axis)
         elif self._resampling_config:
-            # Same resolution path the axis builder will use, so the gate
-            # against PCS_SIZE_THRESHOLD_GB sees the real bin count.
+            # Same resolution path the axis builder will use, so the
+            # reported bin count is the real one.
             _, _, _, n_mz_bins = self._resolve_resampling_plan()
         else:
             min_mass, max_mass = metadata.mass_range
@@ -163,43 +186,41 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         return size_gb
 
     def _should_use_pcs(self) -> bool:
-        """Determine whether to use PCS method based on settings and dataset size.
+        """Which write route to take. ``"auto"`` means PCS.
+
+        This used to compare an estimated dense size against a 30 GB
+        threshold and send anything smaller to COO -- which, since nothing
+        in the repo passes ``use_csc`` at all, made COO the *default* route
+        for essentially every conversion. The threshold assumed PCS bought
+        memory safety at a cost in speed, so it was worth paying only on
+        datasets big enough to need it.
+
+        Measured, that trade does not exist: PCS is faster and lighter at
+        every size tried, and its margin grows with the dataset (the table
+        in the class docstring). Both routes iterate the reader twice, so
+        there is no second read to pay for. A threshold whose cheap side is
+        never actually cheaper is not a threshold, so it is gone rather
+        than retuned -- a retuned one would just be a number nobody could
+        justify either.
+
+        ``use_csc=False`` still selects COO, so the route remains reachable
+        and tested; it is an escape hatch now rather than the default.
 
         Returns:
-            True if PCS method should be used, False otherwise
+            True if the PCS route should be used, False for COO.
         """
         if self._use_csc is True:
             return True
-        elif self._use_csc is False:
+        if self._use_csc is False:
             return False
-        else:  # "auto"
-            estimated_size = self._estimate_output_size_gb()
-            use_pcs = estimated_size > self.PCS_SIZE_THRESHOLD_GB
-            if use_pcs:
-                logger.info(
-                    f"Dataset size ({estimated_size:.1f} GB) exceeds threshold "
-                    f"({self.PCS_SIZE_THRESHOLD_GB} GB) - using PCS method"
-                )
-            else:
-                logger.info(
-                    f"Dataset size ({estimated_size:.1f} GB) below threshold "
-                    f"({self.PCS_SIZE_THRESHOLD_GB} GB) - using standard method"
-                )
-            return use_pcs
+        return True  # "auto"
 
     def convert(self) -> bool:
         """Stream-convert MSI data to SpatialData format.
 
-        Overrides the base convert() method. Writes directly to final output
-        Zarr without creating scipy sparse matrix, keeping memory bounded.
-
-        For large datasets (>50GB by default), uses the Pre-calculated Scatter
-        (PCS) approach for CSC format:
-        - O(N) time complexity (no sorting required)
-        - ~200 MB memory regardless of dataset size
-        - CSC format for efficient ion image access
-
-        For smaller datasets, uses the standard COO approach which is simpler.
+        Overrides the base convert() method. Both routes stream to Zarr; see
+        the class docstring for what separates them and why PCS is the
+        default. ``use_csc=False`` selects COO.
 
         Returns:
             True if conversion was successful, False otherwise
@@ -209,16 +230,21 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             self._initialize_conversion()
             self._refuse_multiple_z_planes()
 
-            # Decide which method to use based on settings and dataset size
+            # Diagnostic only -- the route below does not depend on it. Called
+            # here rather than inside _should_use_pcs() so the predicate stays
+            # a predicate, and after _initialize_conversion() so it reports the
+            # built axis instead of guessing at it.
+            self._estimate_output_size_gb()
+
             if self._should_use_pcs():
-                # Use no-cache approach for memory-efficient CSC conversion
-                # This processes spectra twice but eliminates the ~200GB cache file
+                # Scatter straight into memmapped CSC arrays: the matrix is
+                # never a scipy object in RAM.
                 result = self._convert_to_csc_no_cache()
                 logger.info(
                     f"Zero-copy CSC conversion complete: {result['total_nnz']:,} non-zeros"
                 )
             else:
-                # Use standard COO approach for smaller datasets
+                # Opt-in COO route: materialises the matrix to convert it.
                 self._setup_temp_storage()
                 coo_result = self._stream_build_coo()
                 data_structures = self._create_data_structures_from_coo(coo_result)


### PR DESCRIPTION
## What this changes

`streaming="auto"` now takes the **PCS** route instead of choosing on
estimated dataset size. `PCS_SIZE_THRESHOLD_GB` is removed. `use_csc=False`
still selects COO.

Because nothing in `thyra/` passes `use_csc` at all, the 30 GB gate made **COO
the default for essentially every conversion** the CLI or the public API
performs — not a niche branch.

## Why — measured, not assumed

The threshold assumed PCS bought memory safety at a cost in speed, worth paying
only above 30 GB. That trade does not exist. `MockMSIReader`, peak process RSS
sampled at 20 ms, one subprocess per route:

| nnz | PCS | COO | PCS advantage |
|---|---|---|---|
| 16M (1.2 GB dense est.) | 7.4 s / 540 MB | 10.4 s / 655 MB | 29% faster, 18% lighter |
| 64M (4.8 GB dense est.) | 35.6 s / 1084 MB | 58.5 s / 1914 MB | 39% faster, 43% lighter |

PCS wins on both axes at every size tried, and the margin **grows** with the
dataset. Two reasons, both structural rather than incidental:

- **Both routes already iterate the reader twice** — COO counts then writes
  (lines 471 / 643), PCS pre-scans then scatters (1245 / 1360). There is no
  second read to pay for, which is why PCS wins on time at all. The usual "PCS
  re-reads the file" objection does not apply.
- **COO materialises the matrix to convert it** — it reads its CSR components
  back into a `scipy.sparse.csr_matrix` and calls `.tocsc()`, roughly doubling
  it. PCS scatters into memmapped arrays and streams those out.

A threshold whose cheap side is never actually cheaper is not a threshold, so
it is removed rather than retuned — a new number would be equally
unjustifiable.

## What does not change

**Stored values.** The three write paths already agree pixel for pixel, which
`test_stored_pixel_spectrum_oracle.py` (#150) pins across `read_zarr` and
`read_lazy`, and #147 aligned their out-of-grid behaviour. What changes is
which branch runs, not what lands on disk.

## Honest caveats

- The numbers are synthetic (`MockMSIReader`). The *mechanism* is not — see the
  `.tocsc()` point above.
- **PCS is not "bounded" memory.** The class docstring claimed "~200 MB
  regardless of dataset size"; measured, its RSS grew 540 MB → 1.1 GB. That
  claim is corrected in this PR rather than left standing. Much of that is
  memmap pages, which count toward working set while remaining evictable, so
  the private-memory gap is *wider* than the table shows — but "bounded" was
  never true.
- Two other stale docstrings fixed while here: the class and `convert()` both
  described the gate as ">50GB" when the constant said 30.

## `_estimate_output_size_gb` is kept

It no longer routes anything, but it is still logged and is now marked
diagnostic. Deleting it would have discarded the #87 finding that its raw-axis
fallback is wrong in both directions — inflating a 4,000-point continuous file
24x by assuming 10 mDa spacing — along with the tests pinning it. An inaccurate
number in a support log is a smaller problem than an inaccurate route, but it
is still a problem.

## Tests

Six new, +6 net (1371 → 1377 collected).

- `TestRoutingIsSizeIndependent` — four size cases that previously routed
  *differently*, plus the strongest form: swing the estimate 24x by dropping
  the built axis (a swing that straddled the old threshold and flipped the
  route) and assert the route does not budge. If a size gate is ever
  reintroduced, that test is what fails. Also asserts the constant is **gone**
  rather than merely unused — a leftover reads as a live gate, and the next
  person tunes it and nothing happens.
- `TestTheRouteIsActuallyTaken` — drives real conversions and records which
  entry point ran. A predicate returning `True` is not the same as `convert()`
  acting on it; asserting the predicate alone would keep passing if that wiring
  were bypassed.

## Verification

- Unit: **1346 passed, 13 skipped, 18 deselected** (baseline 1353 selected /
  1371 total at the base commit; this is 1359 / 1377).
- Integration: **18 passed**, run separately since one integration test's
  routing assertion changed.
- `black`, `isort`, `flake8`, `mypy`, `bandit`, `pydocstyle` all pass.
- Rebased onto `e6c8eb8` and re-run before pushing.

## Sequencing note

Landing this first turns the follow-up in Ousia into a no-op: its wizard pins
`use_csc=True` (`backend/import_wizard/steps/convert_msi.py:251`) to force PCS,
and once `"auto"` means PCS that pin is redundant and can be removed as pure
cleanup rather than as a routing change.

`perf:` is releasable, so merging this cuts a PyPI release.

**Not merging this myself** — it changes the code path every conversion takes,
so it wants your eyes. To sanity-check quickly: convert any dataset with no
`use_csc` argument and confirm the log shows `Step 1/3: Pre-scan` (PCS) rather
than `Pass 1: Counting` (COO).
