### PR TITLE
feat(converters): give a volume's pixel footprints their slice depth

### DIFF
--- a/docs/coordinate-systems.md
+++ b/docs/coordinate-systems.md
@@ -113,6 +113,30 @@ meaningful frame is **physical micrometers of the imaged tissue**.
 
 Both elements resolve to the same micrometer extent at ``"global"``.
 
+For a **multi-slice volume** (``--handle-3d`` over more than one plane) that
+holds in z as well. The pixel polygons are ``POLYGON Z``: a flat square at the
+micrometre depth of the slice it was acquired on, taken from the same
+``obs["spatial_z"]`` the table stores. So the deepest footprint sits at
+``(n_z - 1) * z_spacing_um``, which is where the TIC volume's last plane lands
+under its own ``Scale``.
+
+These are **footprints, not voxels**. A pixel is its square at one depth, not a
+solid spanning the slice thickness — shapely has no solid geometry. The extent
+in z is the slice spacing, carried by the image.
+
+!!! note "Reading 3D shapes"
+    ``spatialdata``'s shapes model is 2D, so it emits a ``UserWarning`` that
+    "2 is expected" whenever these are parsed, validated or transformed. The
+    geometry is nonetheless carried and transformed correctly, verified
+    through a zarr round trip and a ``Scale`` into ``"global"``. The warning
+    is left unsuppressed: it is upstream stating the limits of its model, and
+    silencing it would hide that from consumers.
+
+    Expressing the depth as a ``Translation`` on flat 2D geometry — the
+    obvious alternative — does **not** work. The transform silently drops z
+    and returns flat polygons, leaving a depth that exists only in the
+    metadata. ``tests/unit/converters/test_3d_pixel_shapes_z.py`` pins that.
+
 ### Mode B: with FlexImaging optical alignment
 
 When the input includes a ``.mis`` ``ImageFile`` and registration

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -308,7 +308,7 @@ replaced by one **volume**:
 |---------|-----|--------------|
 | **Table** | `{dataset_id}` | pixels x m/z, with `x`, `y`, `z` and `spatial_x`, `spatial_y`, `spatial_z` in `.obs` |
 | **TIC volume** | `{dataset_id}_tic` | `(c, z, y, x)` — one channel, then the three spatial axes |
-| **Pixel Shapes** | `{dataset_id}_pixels` | GeoDataFrame of 2D pixel boxes |
+| **Pixel Shapes** | `{dataset_id}_pixels` | GeoDataFrame of `POLYGON Z` footprints, each at its slice's depth |
 
 ```python
 volume = sdata.images[f"{dataset_id}_tic"]
@@ -359,10 +359,35 @@ two agree only by coincidence. See
     additive and a consumer that never reads 3D sees the schema it already
     knows.
 
-!!! warning "Pixel shapes are still 2D"
-    The pixel-polygon shapes carry no z coordinate, so all slices' polygons
-    coincide in depth. Use the table's `spatial_z` (or the volume itself) when
-    you need a per-slice position.
+#### Pixel footprints in a volume
+
+The pixel polygons carry z too, so they meet the volume at `"global"` in all
+three axes. Each is a `POLYGON Z`: a flat square at the micrometre depth of the
+slice it was acquired on, the same value the table stores in `spatial_z`.
+
+```python
+shapes = sdata.shapes[f"{dataset_id}_pixels"]
+geom = shapes.geometry.iloc[0]
+print(geom.has_z)                      # True on a multi-slice volume
+print(geom.exterior.coords[0][2])      # depth in um = z_index * z_spacing_um
+```
+
+They are **footprints, not voxels**: a square at one depth, not a solid
+spanning the slice thickness — shapely has no solid geometry. The extent in z
+is the slice spacing, and it belongs to the image.
+
+!!! note "spatialdata warns on 3D shapes"
+    `spatialdata`'s shapes model is 2D, so parsing, validating or transforming
+    these emits a `UserWarning` that "2 is expected". The geometry is carried
+    and scaled correctly regardless; the warning is left in place rather than
+    suppressed, because it is upstream describing the limits of its own model.
+
+    Expressing the depth as a `Translation` on flat geometry instead does not
+    work — the transform silently drops z. See
+    [Coordinate systems](coordinate-systems.md).
+
+    Single-plane acquisitions and the per-slice 2D route keep flat geometry,
+    since neither has a z axis to place anything on.
 
 ---
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -38,6 +38,13 @@ A converted dataset contains the following elements:
     rather than one 2D image per slice — see
     [3D Data / Z-Slices](#3d-data--z-slices).
 
+    The pixel shapes become `POLYGON Z`: each footprint is a flat square at the
+    micrometre depth of its own slice, so they meet the volume in z as well as
+    in x and y. They are footprints, not voxels — the extent in z is the slice
+    spacing and belongs to the image. See
+    [Coordinate systems](coordinate-systems.md) for why a `Translation` is not
+    used instead, and for the `UserWarning` spatialdata emits on 3D shapes.
+
 !!! tip "Default dataset ID"
     The default `dataset_id` is `msi_dataset`, so typical keys look like
     `msi_dataset_z0`, `msi_dataset_z0_tic`, etc. Change it with `--dataset-id`.

--- a/tests/unit/converters/test_3d_pixel_shapes_z.py
+++ b/tests/unit/converters/test_3d_pixel_shapes_z.py
@@ -1,0 +1,265 @@
+# tests/unit/converters/test_3d_pixel_shapes_z.py
+"""A volume's pixel footprints sit at the depth of the slice they came from.
+
+``_create_pixel_shapes`` took an ``is_3d`` argument and never read it. Every
+slice's footprints were built from ``spatial_x``/``spatial_y`` alone, so a
+volume's polygons all stacked flat at z=0 while its TIC image spanned
+``n_z * z_spacing_um`` in depth. ``docs/coordinate-systems.md`` promises that
+every element in a Thyra store resolves to the same physical frame at
+``"global"``; for a volume that promise was false in z, and PR #160 (which made
+the *image* honest) did not change it.
+
+Footprints now carry z, taken from ``obs["spatial_z"]`` -- already micrometres,
+and the same column the table stores, which is what makes the two elements
+agree rather than merely both look plausible.
+
+**Why not the obvious alternative.** spatialdata's shapes model is 2D, which
+invites keeping flat geometry and putting the depth in a transformation (one
+element per slice, each with a ``Translation`` in z). Measured, that silently
+loses: the element parses without complaint, coexists with a 3D image and
+survives a zarr round trip, but the transform **drops z** and every slice comes
+back at the same depth -- a depth recorded in the metadata that never reaches
+the geometry. ``test_a_translation_would_not_have_worked`` pins that, because
+it is the change someone will otherwise propose again.
+
+These are footprints, not voxels: a flat square at one depth, since shapely has
+no solid. The pixel's extent in z is the slice spacing and is carried by the
+image, not by the polygon.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import numpy as np
+import pytest
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    SPATIALDATA_AVAILABLE,
+)
+from thyra.converters.spatialdata.spatialdata_2d_converter import SpatialData2DConverter
+from thyra.converters.spatialdata.spatialdata_3d_converter import SpatialData3DConverter
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+_DATASET_ID = "vol"
+
+# Pairwise different, as elsewhere in the 3D tests: no axis length can stand in
+# for another and make a wrong answer look right.
+_N_X, _N_Y, _N_Z = 5, 3, 2
+
+# 25x apart, so a footprint placed with the in-plane pitch instead of the slice
+# spacing is off by more than any rounding could explain.
+_PIXEL_SIZE_UM = 10.0
+_Z_SPACING_UM = 250.0
+
+
+def _config(n_z: int = _N_Z) -> MockMSIConfig:
+    """A full grid -- every voxel present, so obs covers the whole volume."""
+    return MockMSIConfig(
+        n_x=_N_X,
+        n_y=_N_Y,
+        n_z=n_z,
+        n_mz_bins=64,
+        peaks_per_spectrum=(4, 8),
+        sparsity=0.0,
+    )
+
+
+def _convert_volume(tmp_path, n_z: int = _N_Z, **kwargs: Any):
+    output_path = tmp_path / "out.zarr"
+    converter = SpatialData3DConverter(
+        MockMSIReader(_config(n_z)),
+        output_path,
+        dataset_id=_DATASET_ID,
+        pixel_size_um=_PIXEL_SIZE_UM,
+        z_spacing_um=_Z_SPACING_UM,
+        **kwargs,
+    )
+    assert converter.convert() is True
+    return output_path
+
+
+@pytest.fixture(scope="module")
+def volume(tmp_path_factory) -> Dict[str, Any]:
+    """One converted volume, read back off disk."""
+    import spatialdata
+
+    store = _convert_volume(tmp_path_factory.mktemp("shapes_z"))
+    sdata = spatialdata.read_zarr(str(store))
+    return {
+        "shapes": sdata.shapes[f"{_DATASET_ID}_pixels"],
+        "obs": sdata.tables[_DATASET_ID].obs,
+        "image": sdata.images[f"{_DATASET_ID}_tic"],
+    }
+
+
+def _depth(geometry) -> float:
+    """The z ordinate of a footprint. Flat, so any vertex will do."""
+    return float(geometry.exterior.coords[0][2])
+
+
+def test_volume_footprints_carry_z(volume):
+    """The reproduction. Before, these were 2D and every depth was absent."""
+    shapes = volume["shapes"]
+
+    assert len(shapes) == _N_X * _N_Y * _N_Z
+    assert all(geometry.has_z for geometry in shapes.geometry)
+
+
+def test_each_footprint_sits_at_its_own_slice_depth(volume):
+    """Depth must be the slice index times the spacing -- in closed form.
+
+    Checked against the arithmetic rather than against the store, so this
+    fails if the converter and the expectation drift apart. The set of depths
+    is compared too: a bug that put every footprint on plane 0 would satisfy a
+    per-row check that only ever looked at plane 0.
+    """
+    shapes, obs = volume["shapes"], volume["obs"]
+
+    expected_depths = [z * _Z_SPACING_UM for z in range(_N_Z)]
+    assert sorted({_depth(g) for g in shapes.geometry}) == expected_depths
+
+    for label, geometry in zip(shapes.index, shapes.geometry):
+        z_index = int(obs.loc[label, "z"])
+        assert _depth(geometry) == pytest.approx(z_index * _Z_SPACING_UM)
+
+
+def test_footprints_and_table_agree_at_global(volume):
+    """The two elements a consumer overlays must land at the same depth.
+
+    obs["spatial_z"] and the polygons are built in different places. Either
+    alone can be self-consistent while the pair disagrees, which is the class
+    of defect this whole area keeps producing.
+    """
+    shapes, obs = volume["shapes"], volume["obs"]
+
+    for label, geometry in zip(shapes.index, shapes.geometry):
+        assert _depth(geometry) == pytest.approx(float(obs.loc[label, "spatial_z"]))
+
+
+def test_footprints_and_image_span_the_same_depth(volume):
+    """The volume's depth extent and the footprints' must be the same range.
+
+    The image spans n_z planes scaled by z_spacing; the deepest footprint sits
+    on the last plane. If either the Scale or the footprint depth used the
+    in-plane pitch, these part company.
+    """
+    from spatialdata.transformations import get_transformation
+
+    shapes, image = volume["shapes"], volume["image"]
+
+    n_z_planes = np.asarray(image.data).shape[1]
+    assert n_z_planes == _N_Z
+
+    axes = ("c", "z", "y", "x")
+    matrix = get_transformation(image, "global").to_affine_matrix(
+        input_axes=axes, output_axes=axes
+    )
+    z_scale = float(matrix[1, 1])
+
+    assert z_scale == pytest.approx(_Z_SPACING_UM)
+    assert max(_depth(g) for g in shapes.geometry) == pytest.approx(
+        (n_z_planes - 1) * z_scale
+    )
+
+
+def test_the_footprint_is_still_pixel_sized(volume):
+    """Adding depth must not disturb the in-plane extent.
+
+    A footprint is the pixel's square at one depth; it is not a voxel, and its
+    x/y size is still the in-plane pitch.
+    """
+    geometry = volume["shapes"].geometry.iloc[0]
+    xs = [c[0] for c in geometry.exterior.coords]
+    ys = [c[1] for c in geometry.exterior.coords]
+
+    assert max(xs) - min(xs) == pytest.approx(_PIXEL_SIZE_UM)
+    assert max(ys) - min(ys) == pytest.approx(_PIXEL_SIZE_UM)
+
+
+def test_a_single_slice_volume_stays_flat(tmp_path):
+    """``handle_3d`` alone is not a volume, so it gets no z.
+
+    ``SpatialData3DConverter`` forces ``handle_3d=True`` regardless of the
+    data, and a one-plane acquisition through it takes the 2D branch
+    everywhere else. Footprints must follow, or a flat dataset acquires a
+    depth axis it has no planes for.
+    """
+    import spatialdata
+
+    store = _convert_volume(tmp_path, n_z=1)
+    sdata = spatialdata.read_zarr(str(store))
+    shapes = sdata.shapes[f"{_DATASET_ID}_pixels"]
+
+    assert not any(geometry.has_z for geometry in shapes.geometry)
+
+
+def test_the_2d_route_is_unchanged(tmp_path):
+    """The per-slice route writes flat elements and must keep doing so.
+
+    It emits one table and one image per plane, so each element genuinely has
+    no third dimension. A z here would be inventing one.
+    """
+    import spatialdata
+
+    output_path = tmp_path / "flat.zarr"
+    converter = SpatialData2DConverter(
+        MockMSIReader(_config()),
+        output_path,
+        dataset_id=_DATASET_ID,
+        pixel_size_um=_PIXEL_SIZE_UM,
+    )
+    assert converter.convert() is True
+
+    sdata = spatialdata.read_zarr(str(output_path))
+    for key, shapes in sdata.shapes.items():
+        assert not any(
+            geometry.has_z for geometry in shapes.geometry
+        ), f"{key} grew a z coordinate"
+
+
+def test_a_translation_would_not_have_worked():
+    """Pins the measured negative result behind the POLYGON Z choice.
+
+    Keeping flat 2D geometry and expressing the depth as a ``Translation`` is
+    the natural reading of spatialdata's 2D shapes model, and it is the change
+    someone will proposeagain on seeing the UserWarning that POLYGON Z
+    provokes. It does not work, and it fails *silently*: the transform drops z
+    and returns flat geometry, so the depth lives only in the metadata.
+
+    If a future spatialdata makes this work, this test fails -- and that is the
+    signal to revisit the choice, not a regression.
+    """
+    import geopandas as gpd
+    import spatialdata
+    from shapely.geometry import box
+    from spatialdata.models import ShapesModel
+    from spatialdata.transformations import Scale, Sequence, Translation
+
+    gdf = gpd.GeoDataFrame(geometry=[box(0.0, 0.0, 1.0, 1.0)], index=["p0"])
+    parsed = ShapesModel.parse(
+        gdf,
+        transformations={
+            "global": Sequence(
+                [
+                    Scale([_PIXEL_SIZE_UM, _PIXEL_SIZE_UM], axes=("x", "y")),
+                    Translation([2 * _Z_SPACING_UM], axes=("z",)),
+                ]
+            )
+        },
+    )
+
+    transformed = spatialdata.transform(parsed, to_coordinate_system="global")
+    geometry = transformed.geometry.iloc[0]
+
+    # x/y scaling lands; the z translation vanishes without a word.
+    assert max(c[0] for c in geometry.exterior.coords) == pytest.approx(_PIXEL_SIZE_UM)
+    assert not geometry.has_z, (
+        "spatialdata now carries z through a Translation on 2D shapes; "
+        "revisit whether POLYGON Z is still the right representation"
+    )

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -151,7 +151,7 @@ try:
     import xarray as xr
     import zarr
     from anndata import AnnData
-    from shapely.geometry import box
+    from shapely.geometry import Polygon, box
     from spatialdata import SpatialData
     from spatialdata.models import Image2DModel, ShapesModel, TableModel
     from spatialdata.transformations import Affine, Identity, Scale, Sequence
@@ -1518,9 +1518,39 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         shapes are created in optical image pixel coordinates for proper overlay.
         Otherwise, shapes use physical (micrometer) coordinates.
 
+        For a multi-slice volume the footprints are ``POLYGON Z``: a flat
+        square at the micrometre depth of the slice it was acquired on,
+        taken from ``obs["spatial_z"]``. They are footprints, not voxels --
+        shapely has no solid, so a pixel is its square at one depth rather
+        than a box spanning the slice thickness.
+
+        Two alternatives were measured and rejected:
+
+        * **Flat 2D shapes carrying the depth in a transformation**
+          (one element per slice, each with a ``Translation`` in z). This
+          is what spatialdata's 2D shapes model invites, and it does not
+          work: the element parses without complaint, coexists with a 3D
+          image and round-trips, but the transform **silently drops z**
+          and every slice comes back at the same depth. It would put a
+          depth in the metadata that never reaches the geometry.
+        * **Leaving them flat** and documenting it. Honest, but then
+          ``docs/coordinate-systems.md``'s promise that every element
+          agrees at ``"global"`` stays false in z.
+
+        The cost of the choice: ``ShapesModel.parse``/``validate`` and
+        every downstream ``transform`` emit a ``UserWarning`` that 2
+        dimensions are expected. It is left unsuppressed deliberately --
+        it is upstream telling consumers this is outside the model, and
+        hiding it would be Thyra deciding that on their behalf. Only the
+        micrometre branch gains z; under optical alignment the frame is
+        optical pixels, which have no depth calibration to place a slice
+        in.
+
         Args:
             adata: AnnData object containing coordinates
-            is_3d: Whether to handle as 3D data
+            is_3d: Whether this is the 3D volume route. Combined with
+                :attr:`_is_volume` (which also requires more than one
+                plane), decides whether footprints carry z.
 
         Returns:
             SpatialData shapes model
@@ -1598,14 +1628,28 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             y_coords: NDArray[np.float64] = adata.obs["spatial_y"].values
             half_pixel_um = self.pixel_size_um / 2
 
+            # A volume's footprints carry the depth of the slice they were
+            # acquired on, so they meet the TIC volume at "global" instead
+            # of stacking flat at z=0. spatial_z is already the micrometre
+            # depth (z index * z_spacing_um), so it needs no scaling here
+            # -- the same column the table stores, which is what keeps the
+            # two elements agreeing.
+            z_coords: Optional[NDArray[np.float64]] = None
+            if is_3d and self._is_volume:
+                z_coords = adata.obs["spatial_z"].values
+
             for i in range(len(adata)):
                 x, y = x_coords[i], y_coords[i]
-                pixel_box = box(
-                    x - half_pixel_um,
-                    y - half_pixel_um,
-                    x + half_pixel_um,
-                    y + half_pixel_um,
-                )
+                x0, y0 = x - half_pixel_um, y - half_pixel_um
+                x1, y1 = x + half_pixel_um, y + half_pixel_um
+
+                if z_coords is None:
+                    pixel_box = box(x0, y0, x1, y1)
+                else:
+                    z = float(z_coords[i])
+                    pixel_box = Polygon(
+                        [(x0, y0, z), (x1, y0, z), (x1, y1, z), (x0, y1, z)]
+                    )
                 geometries.append(pixel_box)
 
         # Create GeoDataFrame with appropriate index


### PR DESCRIPTION
Completes the 3D volume work started in #146 (axis order) and #160 (z spacing).
This is the third and last element that was flat in z.

## What was wrong

`_create_pixel_shapes(self, adata, is_3d: bool = False)` took `is_3d`, named it
in its docstring, and **never referenced it in the body**. Footprints were built
from `spatial_x`/`spatial_y` alone, so a volume's polygons all stacked at z=0
while its TIC image spanned `n_z * z_spacing_um` in depth.

`docs/coordinate-systems.md` promises that every element in a Thyra store
resolves to the same physical frame at `"global"`. For a volume that promise was
false in z. #160 made the *image* honest; it did not touch the shapes.

Measured on a 5(x) x 3(y) x 2(z) grid at 10 um pixels and 250 um slices:

| | footprint depths |
|---|---|
| before | all `z = 0` (2D geometry, no z ordinate at all) |
| after | `{0.0, 250.0}` — each footprint on its own plane |

## What it does

Footprints are now `POLYGON Z`: a flat square at the micrometre depth of the
slice it was acquired on, read from `obs["spatial_z"]` — the same column the
table stores, which is what makes the two elements *agree* rather than merely
both look plausible.

**Footprints, not voxels.** A pixel is its square at one depth, not a solid
spanning the slice thickness; shapely has no solid geometry. The extent in z is
the slice spacing and is carried by the image.

Scope is tight:

- **Only the micrometre branch.** Under FlexImaging optical alignment the frame
  is optical pixels, which carry no depth calibration to place a slice in.
- **Only real volumes.** `SpatialData3DConverter` forces `handle_3d=True`
  regardless of the data, so this is gated on `_is_volume` (which also requires
  more than one plane), not on `handle_3d`. A single-plane acquisition through
  the 3D converter stays flat.
- **The 2D route is untouched** — it writes one element per plane, so each
  genuinely has no third dimension.

## The alternative that does not work

spatialdata's shapes model is 2D, which invites keeping flat geometry and
putting the depth in a transformation — one element per slice, each with a
`Translation` in z. **Measured: it silently loses.** The element parses without
complaint, coexists with a 3D image and survives a zarr round trip, but the
transform **drops z** and every slice comes back flat. It would record a depth
in the metadata that never reaches the geometry — a worse failure than the one
being fixed, because the store would then *claim* to be right.

`test_a_translation_would_not_have_worked` pins this, and is written to fail
loudly if a future spatialdata makes it work, so the choice gets revisited
rather than silently outliving its reason.

## The cost, stated plainly

`ShapesModel.parse`/`validate` and every downstream `transform` emit a
`UserWarning` that "2 is expected" on 3D geometry. **It is left unsuppressed
deliberately** — it is upstream stating the limits of its model, and silencing
it would be Thyra making that call on a consumer's behalf.

The geometry is nonetheless carried and scaled correctly. Verified: parse, a
zarr round trip, and a `Scale` into `"global"` (z 2.0 -> 500.0 exactly). What I
verified is the set of operations Thyra performs and a consumer's transform —
not spatialdata's whole API surface.

## Verification

- Full suite **1382 passed, 13 skipped, 18 deselected** on this branch, rebased
  onto `df84a1b`.
- **4 of the 8 new tests fail without the source change**; the other 4 are
  guards (single-slice stays flat, 2D route unchanged, footprint still
  pixel-sized, and the `Translation` negative result) and correctly pass both
  ways.
- `black`, `isort`, `flake8` clean; all pre-commit hooks pass.
- Cross-element checks are the point: footprint depth is asserted against the
  closed form `z_index * z_spacing_um`, against `obs["spatial_z"]`, **and**
  against the image's own `Scale` read off its affine matrix.

## Docs

`docs/coordinate-systems.md` and `docs/output-format.md` both updated — the
former's "both elements resolve to the same micrometer extent" claim now
extends to z, with the warning and the rejected alternative recorded next to it.

Note this is a `feat:`, so merging cuts a minor release.
