### PR TITLE
docs: make the header logomark visible, and list PHI in the README formats table

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ Full documentation: **[M4i-Imaging-Mass-Spectrometry.github.io/thyra](https://M4
 |-------|-----------|--------|
 | ImzML | `.imzML` | Full support |
 | Bruker | `.d` | Full support (timsTOF + Rapiflex) |
-| Waters | `.raw` | Full support |
+| Waters | `.raw` directory | Full support |
+| PHI | `.raw` file | Full support (SmartSoft-TOF nanoTOF, ToF-SIMS) |
+
+PHI mosaic, MS/MS and depth-profiling acquisitions are implemented but so far
+tested only against synthetic files -- real data in those modes is very welcome.
 
 Output: **SpatialData/Zarr** -- cloud-ready, efficient, standardized
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -67,6 +67,18 @@ body {
   background: linear-gradient(135deg, #792074, #9A4B3D);
 }
 
+/* The logomark is filled with this same purple -> brick gradient, so on the
+   bar above it reads as a faint ghost rather than a logo. Knock it out to
+   solid white -- the usual treatment for a brand mark on a coloured field --
+   rather than plating a background behind it: brightness(0) flattens every
+   gradient stop to black while keeping the alpha, invert(1) turns that white.
+   The gradient logotype on the home page is untouched. The second selector is
+   the same mark in the mobile drawer's title bar, which is also primary. */
+.md-header__button.md-logo img,
+.md-nav__button.md-logo img {
+  filter: brightness(0) invert(1);
+}
+
 /* ---- Navigation tabs bar ---- */
 /* Clean white bar beneath the gradient header */
 .md-tabs {


### PR DESCRIPTION
## Description

Two small documentation fixes.

The site header logomark was invisible: the SVG is filled with the same purple -> brick gradient (`#964b41` -> `#76266e`) that `.md-header` paints behind it, so the mark rendered as a faint ghost on every page rather than as a logo.

Separately, the README's Supported Formats table still stopped at Waters, even though the same README documents PHI SmartSoft-TOF in its feature list, its CLI examples, and its note on how `.raw` is resolved.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issues

None -- both were spotted directly.

## Changes Made

**`docs/stylesheets/extra.css`** -- knock the header logomark out to solid white:

- `brightness(0)` flattens every gradient stop to black while preserving the alpha; `invert(1)` turns that white. This is the usual treatment for a brand mark on a coloured field.
- Chosen over plating a background behind the mark (visually intrusive) and over shipping a separate white-variant SVG (which would need maintaining in parallel with the original).
- The gradient header is untouched, as is the gradient logotype on the docs home page -- the selectors are scoped to the header and the mobile drawer only.
- The second selector covers the same mark in the mobile drawer's title bar, which also sits on the primary colour and had the identical problem.

**`README.md`** -- add the missing PHI row:

- Adds a `PHI | .raw file | Full support (SmartSoft-TOF nanoTOF, ToF-SIMS)` row.
- Disambiguates the extension column (`.raw` directory vs `.raw` file). With both vendors listed the table would otherwise carry two identical `.raw` rows, which is precisely the confusion the note above it warns about.
- Keeps the status honest rather than a flat "Full support": per `docs/supported-formats.md`, mosaic, MS/MS and depth-profiling acquisitions are implemented but have so far only been exercised against synthetic files.

## Testing

- [x] All existing tests pass
- [x] Manual testing has been performed

Full unit suite run locally against Python 3.12: **1440 passed, 16 skipped, 18 deselected** in 95s. No new tests were added -- the diff touches only CSS and Markdown, so there is no Python behaviour to cover.

The header fix was verified by building the docs with the project's own toolchain (`mkdocs build --strict`, with mkdocs-jupyter and mkdocstrings) and screenshotting the rendered header in Chromium in both light and dark schemes. Before/after was isolated by injecting `filter: none`, confirming the new rule is what makes the difference. The strict build passes.

## Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Code is well-commented, particularly in hard-to-understand areas
- [x] No new warnings or errors introduced

The CSS rule carries a comment explaining why the filter is used and why a background plate was rejected, matching the commenting style already used in `extra.css` and `mkdocs.yml`.

## Documentation

- [x] Documentation has been updated (if applicable)

CHANGELOG.md is not updated: releases are cut by python-semantic-release from the Conventional Commit messages, which both commits follow (`fix(docs):` and `docs(readme):`).

## Performance Impact

- [x] No performance impact

## Additional Notes

The two changes are kept as separate commits so either can be reverted independently.