### PR TITLE
feat: recognize Shimadzu imaging formats (.imdx, .kbd) with imzML guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Full documentation: **[M4i-Imaging-Mass-Spectrometry.github.io/thyra](https://M4
 | ImzML | `.imzML` | Full support |
 | Bruker | `.d` | Full support (timsTOF + Rapiflex) |
 | Waters | `.raw` | Full support |
+| PHI SmartSoft-TOF | `.raw` | Full support |
+| Shimadzu | `.imdx`, `.kbd` | In development (workaround: imzML export from IMAGEREVEAL MS) |
 
 Output: **SpatialData/Zarr** -- cloud-ready, efficient, standardized
 

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -130,6 +130,22 @@ class TestRegistry:
         with pytest.raises(ValueError, match="Unsupported format"):
             detect_format(unknown_file)
 
+    def test_shimadzu_imdx_recognised_but_in_development(self, tmp_path):
+        """Shimadzu .imdx files get a guidance error, not 'unsupported'."""
+        imdx_file = tmp_path / "test.imdx"
+        imdx_file.touch()
+
+        with pytest.raises(ValueError, match="in development"):
+            detect_format(imdx_file)
+
+    def test_shimadzu_kbd_recognised_but_in_development(self, tmp_path):
+        """Shimadzu .kbd files get a guidance error, not 'unsupported'."""
+        kbd_file = tmp_path / "test.kbd"
+        kbd_file.touch()
+
+        with pytest.raises(ValueError, match="export the dataset as imzML"):
+            detect_format(kbd_file)
+
     def test_missing_ibd_file(self, tmp_path):
         """Test error for ImzML without .ibd file."""
         imzml_file = tmp_path / "test.imzml"

--- a/thyra/core/registry.py
+++ b/thyra/core/registry.py
@@ -158,6 +158,8 @@ class MSIRegistry:
             return self._detect_bruker_d_format(input_path)
         if extension == ".raw":
             return self._detect_raw_format(input_path)
+        if extension in (".imdx", ".kbd"):
+            self._raise_shimadzu_in_development(input_path)
         if input_path.is_dir():
             return self._detect_directory_format(input_path)
         self._raise_unsupported_format(input_path)
@@ -202,6 +204,21 @@ class MSIRegistry:
         if self._detect_waters_format(input_path):
             return "waters"
         self._raise_unsupported_format(input_path)
+
+    def _raise_shimadzu_in_development(self, input_path: Path) -> NoReturn:
+        """Raise a guidance error for recognised Shimadzu imaging data.
+
+        Shimadzu iMScope data (.kbd from LabSolutions, .imdx from
+        IMAGEREVEAL MS) is recognised but native reading is still in
+        development. Until it lands, IMAGEREVEAL MS can export the data
+        as imzML, which Thyra converts today.
+        """
+        raise ValueError(
+            f"Shimadzu imaging data detected: {input_path}. Native support "
+            "for Shimadzu formats (.imdx, .kbd) is in development. In the "
+            "meantime, export the dataset as imzML from IMAGEREVEAL MS and "
+            "convert the imzML file instead."
+        )
 
     def _raise_unsupported_format(self, input_path: Path) -> NoReturn:
         """Raise error for unsupported format."""


### PR DESCRIPTION
## Summary

- Detects Shimadzu iMScope data by extension (.imdx from IMAGEREVEAL MS, .kbd from LabSolutions) and raises a guidance error stating native support is in development, pointing users to the IMAGEREVEAL imzML export as the interim route
- Adds Shimadzu (in development) and the previously missing PHI row to the README supported-formats table

## Context

Native Shimadzu support is being worked on: the IMDX container structure (ZIP wrapping per-pixel spectral blocks plus an OLE2 metadata file) has been mapped from Shimadzu's public sample data; the remaining work is decoding the spectral record semantics before a reader can land. Until then, pointing thyra at .imdx/.kbd fails with an actionable message instead of a generic unsupported-format error.

## Test plan

- Two new unit tests cover .imdx and .kbd detection paths
- Full registry test suite passes (19 tests)