### PR TITLE
fix: convert imzML pixel size to micrometres using its declared unit

### DIFF
--- a/docs/imzml-parser-notes.md
+++ b/docs/imzml-parser-notes.md
@@ -187,33 +187,34 @@ succeeding. That is exactly where SCiLS puts `MS:1000127`.
 
 ---
 
-## Still open
+## Fixed in Thyra, still true of pyimzml
 
-One finding is real, unfixed, and owned by nobody:
+One finding was real enough to grow code: **`imzmldict` discards
+`unitAccession`.** `convert_cv_param(accession, value)` takes no unit argument,
+so `__readimzmlmeta` cannot carry one even though `ParamGroup.cv_params`
+preserves it. `imzmldict['pixel size x']` is a bare number in whatever unit the
+vendor declared, and Thyra used to label it micrometres. A file declaring its
+pixel as `4406.25` nanometre (`UO:0000018`) therefore landed on disk with
+`obs/spatial_x` a thousand times too large, and `convert_msi` returned `True`.
 
-**`imzmldict` discards `unitAccession`.** `convert_cv_param(accession, value)`
-takes no unit argument, so `__readimzmlmeta` cannot carry one even though
-`ParamGroup.cv_params` preserves it. `imzmldict['pixel size x']` is a bare
-number in whatever unit the vendor declared, and Thyra labels it micrometres. A
-file declaring its pixel as `4406.25` nanometre (`UO:0000018`) therefore lands on
-disk with `obs/spatial_x` a thousand times too large, and `convert_msi` returns
-`True`.
+The information is never lost from the document, only from the dict, so
+`ImzMLMetadataExtractor` now reads the unit-bearing path — each `cv_params`
+tuple is `(name, accession, value, raw_name, raw_value, unit_name,
+unit_accession)` — and converts: `UO:0000016` mm x1000, `UO:0000017` um x1,
+`UO:0000018` nm /1000. Any other declared unit is refused with a `ValueError`,
+which fails the conversion; a cvParam with no unit at all keeps the historical
+micrometre reading, because real vendor files (the IONTOF class among them)
+write `IMS:1000046` unitless and were being read correctly.
 
-The information is not lost from the document, only from the dict — the fix is
-to read the unit-bearing path, where each `cv_params` tuple is `(name,
-accession, value, raw_name, raw_value, unit_name, unit_accession)`, and convert
-`UO:0000016` mm x1000, `UO:0000017` um x1, `UO:0000018` nm /1000, refusing
-anything else loudly.
-
-Corroboration that the ambiguity is genuine rather than theoretical: pyimzml's
+Corroboration that the ambiguity was genuine rather than theoretical: pyimzml's
 own `get_physical_coordinates` docstring says it returns **nanometers** while
 multiplying by the same unlabelled `pixel size x` that Thyra treats as
 micrometres. The library's author disagreed with Thyra about the unit.
 
 The behaviour is pinned by
 `tests/unit/readers/test_hand_authored_fixtures.py::TestUnitNanometre`, whose
-assertions are characterisation — they record the error rather than endorse it,
-and say so.
+assertions now state the correct conversion — including the refusal — rather
+than characterise the error.
 
 ---
 

--- a/tests/data/fixtures/README.md
+++ b/tests/data/fixtures/README.md
@@ -19,7 +19,7 @@ repository actually carries is under 6 KB.
 | Pair | The one thing it carries |
 |---|---|
 | `iontof_sparse` | ISO-8859-1, CRLF, unindented, no `mzML/@version`, no `IMS:1000052`, three misspelled ontology names, `max dimension` contradicting `pixel size`, and a sparse 6-of-16 acquisition. The whole IONTOF/bellini class in one file. |
-| `unit_nanometre` | `IMS:1000046/47` carrying `UO:0000018` nanometre. pyimzml's `imzmldict` drops the unit, so a 4.40625 um pixel is read as 4406.25 um. |
+| `unit_nanometre` | `IMS:1000046/47` carrying `UO:0000018` nanometre. pyimzml's `imzmldict` drops the unit, so a 4.40625 um pixel would read as 4406.25 um if the extractor did not fetch the unit from the ParamGroup path. |
 | `two_scansettings` | Two `<scanSettings>` blocks with different pixel sizes. `__readimzmlmeta` resolves each accession by first-match-anywhere, producing a chimera present in neither block. |
 | `two_precision_terms` | One param group declaring both `32-bit float` and `64-bit float`. pyimzml picks by dict insertion order and says nothing. |
 

--- a/tests/data/fixtures/build_fixtures.py
+++ b/tests/data/fixtures/build_fixtures.py
@@ -447,12 +447,12 @@ def build_unit_nanometre() -> Path:
 
     The physical pixel is 4.40625 um, declared as 4406.25 nm. pyimzml's
     ``convert_cv_param`` takes no unit argument, so ``imzmldict['pixel size x']``
-    is the bare number 4406.25 and Thyra labels it micrometres -- a 1000x
-    spatial error that ``convert_msi`` reports as success.
+    is the bare number 4406.25 -- which Thyra used to label micrometres, a
+    1000x spatial error that ``convert_msi`` reported as success.
 
     The unit is not lost from the document, only from the dict pyimzml builds:
     it survives on ``metadata.scan_settings[...].cv_params``, which is the path
-    a fix would read.
+    ``ImzMLMetadataExtractor`` now reads to convert the value to micrometres.
     """
     scan_settings = [
         '  <scanSettingsList count="1">',

--- a/tests/unit/readers/test_hand_authored_fixtures.py
+++ b/tests/unit/readers/test_hand_authored_fixtures.py
@@ -8,8 +8,9 @@ one carries and for the two ways they can be destroyed without a test noticing.
 
 A number of assertions below pin behaviour that is **wrong**. Each carries a
 comment naming the audit finding it characterises and what a fix would turn it
-into. ``assert pixel_size == (4406.25, 4406.25)`` is a record of a 1000x error
-reaching disk today, not a claim that it should.
+into. ``assert imzmldict["pixel size x"] == 4406.25`` is a record of pyimzml
+discarding a nanometre unit, not a claim that 4406.25 um is the pixel size --
+the extractor compensates, which is what ``TestUnitNanometre`` now asserts.
 """
 
 import shutil
@@ -246,7 +247,28 @@ class TestIontofSparse:
 
 
 class TestUnitNanometre:
-    """Audit #9: the discarded ``unitAccession``, worth a factor of 1000."""
+    """Audit #9, closed: the discarded ``unitAccession``, worth a factor of 1000.
+
+    ``_extract_pixel_size_fast`` now pairs the bare ``imzmldict`` number with
+    the unit preserved on the ParamGroup path and converts to micrometres, so
+    the assertions below state the truth rather than characterise the error.
+    """
+
+    def _variant_with_unit(self, tmp_path, unit_accession: str, unit_name: str):
+        """Copy the fixture pair into ``tmp_path`` with the unit swapped."""
+        text = raw_bytes("unit_nanometre").decode("utf-8")
+        text = text.replace(
+            'unitAccession="UO:0000018"', f'unitAccession="{unit_accession}"'
+        )
+        text = text.replace('unitName="nanometer"', f'unitName="{unit_name}"')
+
+        imzml = tmp_path / "unit_variant.imzML"
+        imzml.write_text(text, encoding="utf-8")
+        shutil.copyfile(
+            fixture_path("unit_nanometre").with_suffix(".ibd"),
+            imzml.with_suffix(".ibd"),
+        )
+        return imzml
 
     def test_the_document_declares_nanometre(self):
         """The unit is in the file. Whether anything reads it is the next test."""
@@ -257,15 +279,13 @@ class TestUnitNanometre:
         assert 'unitName="nanometer"' in text
 
     def test_imzmldict_drops_the_unit(self):
-        """CHARACTERISATION of audit #9 -- currently wrong, no lane owns the fix.
+        """pyimzml's dict is still unit-blind; the extractor must not trust it.
 
         ``convert_cv_param`` takes no unit argument, so ``__readimzmlmeta``
         cannot carry one and ``imzmldict['pixel size x']`` is a bare number in
-        whatever unit the vendor declared. 4406.25 nanometre is 4.40625 um.
-
-        Handout I assigns #9 to neither lane I nor lane J; it is documented in
-        ``docs/imzml-parser-notes.md`` as open. Whoever closes it inverts this
-        assertion to ``== pytest.approx(4.40625)``.
+        whatever unit the vendor declared. This pins the reason
+        ``_extract_pixel_size_fast`` reads the unit off the ParamGroup path
+        rather than taking this number at face value.
         """
         reader = open_reader("unit_nanometre")
         try:
@@ -274,27 +294,20 @@ class TestUnitNanometre:
         finally:
             reader.close()
 
-    def test_the_1000x_error_reaches_essential_metadata(self):
-        """CHARACTERISATION of audit #9 -- currently wrong, no lane owns the fix.
-
-        ``_extract_pixel_size_fast`` reads straight out of ``imzmldict`` and
-        labels the result micrometres, so the unit loss becomes a spatial error
-        the moment it is used. Truth is (4.40625, 4.40625).
-        """
+    def test_nanometre_pixel_size_reaches_essential_metadata_in_um(self):
+        """4406.25 nanometre reads as 4.40625 um, not 4406.25 um."""
         reader = open_reader("unit_nanometre")
         try:
             assert reader.get_essential_metadata().pixel_size == pytest.approx(
-                (4406.25, 4406.25)
+                (4.40625, 4.40625)
             )
         finally:
             reader.close()
 
-    def test_the_1000x_error_reaches_disk(self, temp_dir):
-        """CHARACTERISATION of audit #9 -- currently wrong, no lane owns the fix.
-
-        End to end, because the point of #9 is that ``convert_msi`` returns
-        ``True`` and writes wrong coordinates rather than failing. Truth for a
-        2x2 acquisition at 4.40625 um is ``[0, 4.40625, 0, 4.40625]``.
+    def test_converted_coordinates_reach_disk_in_um(self, temp_dir):
+        """End to end, because the point of #9 was that ``convert_msi`` returned
+        ``True`` and wrote coordinates 1000x too large rather than failing. For
+        a 2x2 acquisition at 4.40625 um the x positions are ``[0, 4.40625]``.
         """
         import spatialdata
 
@@ -304,14 +317,38 @@ class TestUnitNanometre:
 
         table = next(iter(spatialdata.read_zarr(output).tables.values()))
 
-        assert sorted(set(table.obs["spatial_x"])) == pytest.approx([0.0, 4406.25])
+        assert sorted(set(table.obs["spatial_x"])) == pytest.approx([0.0, 4.40625])
+
+    def test_millimetre_pixel_size_is_scaled_up(self, tmp_path):
+        """UO:0000016 goes the other way: x1000 rather than /1000."""
+        imzml = self._variant_with_unit(tmp_path, "UO:0000016", "millimeter")
+        reader = ImzMLReader(imzml)
+        try:
+            assert reader.get_essential_metadata().pixel_size == pytest.approx(
+                (4406250.0, 4406250.0)
+            )
+        finally:
+            reader.close()
+
+    def test_an_unrecognised_unit_is_refused(self, tmp_path):
+        """A unit outside mm/um/nm raises instead of guessing a factor.
+
+        UO:0000015 is centimetre -- a real length unit deliberately not in the
+        table, so accepting it unconverted would be a silent x10000 error.
+        """
+        imzml = self._variant_with_unit(tmp_path, "UO:0000015", "centimeter")
+        reader = ImzMLReader(imzml)
+        try:
+            with pytest.raises(ValueError, match="UO:0000015"):
+                reader.get_essential_metadata()
+        finally:
+            reader.close()
 
     def test_the_unit_survives_on_the_param_group_path(self):
-        """The fix is reachable: ``cv_params`` keeps what ``imzmldict`` threw away.
+        """``cv_params`` keeps what ``imzmldict`` threw away.
 
-        This is the assertion that makes #9 worth fixing rather than merely
-        documenting -- the information is still in the parsed metadata, one
-        attribute along a different access path.
+        This is the path the fix reads: the unit is in the parsed metadata,
+        one attribute along a different access path from the bare number.
         """
         reader = open_reader("unit_nanometre")
         try:

--- a/thyra/metadata/extractors/imzml_extractor.py
+++ b/thyra/metadata/extractors/imzml_extractor.py
@@ -19,6 +19,16 @@ from ..types import ComprehensiveMetadata, EssentialMetadata
 
 logger = logging.getLogger(__name__)
 
+# Micrometres per declared pixel-size unit, keyed by unitAccession. Everything
+# downstream of the extractor -- ``EssentialMetadata.pixel_size``,
+# ``obs/spatial_*`` -- is micrometres, so a unit outside this table is refused
+# rather than passed through as a silent scale error.
+UM_PER_UNIT = {
+    "UO:0000016": 1000.0,  # millimeter
+    "UO:0000017": 1.0,  # micrometer
+    "UO:0000018": 0.001,  # nanometer
+}
+
 
 class ImzMLMetadataExtractor(MetadataExtractor):
     """ImzML-specific metadata extractor with optimized two-phase extraction."""
@@ -470,7 +480,15 @@ class ImzMLMetadataExtractor(MetadataExtractor):
         return mass_range
 
     def _extract_pixel_size_fast(self) -> Optional[Tuple[float, float]]:
-        """Fast pixel size extraction from imzmldict first."""
+        """Fast pixel size extraction from imzmldict, converted to micrometres.
+
+        ``imzmldict`` discards ``unitAccession`` -- ``convert_cv_param`` takes
+        no unit argument -- so ``pixel size x`` is a bare number in whatever
+        unit the vendor declared. Taking that number at face value stored a
+        nanometre pixel size as micrometres, 1000x too large, and
+        ``convert_msi`` still returned ``True``. The unit survives on the
+        ParamGroup path, so it is read from there and the value converted.
+        """
         if hasattr(self.parser, "imzmldict") and self.parser.imzmldict:
             # Check for pixel size parameters in the parsed dictionary
             x_size = self.parser.imzmldict.get("pixel size x")
@@ -478,11 +496,71 @@ class ImzMLMetadataExtractor(MetadataExtractor):
 
             if x_size is not None and y_size is not None:
                 try:
-                    return (float(x_size), float(y_size))
+                    x_size, y_size = float(x_size), float(y_size)
                 except (ValueError, TypeError):
-                    pass
+                    return None  # Defer to comprehensive extraction
+
+                units = self._pixel_size_unit_accessions()
+                return (
+                    self._pixel_size_to_um(
+                        x_size, units.get(ImzMLAccessions.PIXEL_SIZE_X)
+                    ),
+                    self._pixel_size_to_um(
+                        y_size, units.get(ImzMLAccessions.PIXEL_SIZE_Y)
+                    ),
+                )
 
         return None  # Defer to comprehensive extraction
+
+    def _pixel_size_unit_accessions(self) -> Dict[str, Optional[str]]:
+        """The declared ``unitAccession`` of each pixel-size cvParam.
+
+        ``__readimzmlmeta`` resolves each accession by first match anywhere in
+        the document, so the unit is looked up the same way: scan-settings
+        blocks in document order, first declaration of each accession wins.
+        That keeps the unit paired with the value ``imzmldict`` actually holds
+        when a file carries more than one ``<scanSettings>`` block.
+        """
+        units: Dict[str, Optional[str]] = {}
+        metadata = getattr(self.parser, "metadata", None)
+        scan_settings = getattr(metadata, "scan_settings", None)
+        if not isinstance(scan_settings, dict):
+            return units
+
+        wanted = (ImzMLAccessions.PIXEL_SIZE_X, ImzMLAccessions.PIXEL_SIZE_Y)
+        for group in scan_settings.values():
+            for param in getattr(group, "cv_params", []):
+                # (name, accession, value, raw_name, raw_value, unit_name,
+                #  unit_accession)
+                accession, unit_accession = param[1], param[6]
+                if accession in wanted and accession not in units:
+                    units[accession] = unit_accession
+        return units
+
+    def _pixel_size_to_um(self, value: float, unit_accession: Optional[str]) -> float:
+        """Convert a declared pixel size to micrometres, or refuse.
+
+        No declared unit keeps the historical reading: the bare number is
+        micrometres. Real vendor files (the IONTOF class among them) write
+        ``IMS:1000046`` with no ``unitAccession`` at all, so refusing here
+        would reject files that were being read correctly.
+
+        Raises:
+            ValueError: If the file declares a unit outside ``UM_PER_UNIT``.
+                Guessing a factor for, say, centimetre would be the same
+                silent scale error this method exists to close.
+        """
+        if unit_accession is None:
+            return value
+        factor = UM_PER_UNIT.get(unit_accession)
+        if factor is None:
+            raise ValueError(
+                f"{self.imzml_path} declares its pixel size in unit "
+                f"{unit_accession!r}, which Thyra cannot convert to "
+                f"micrometres. Supported units: UO:0000016 (millimeter), "
+                f"UO:0000017 (micrometer), UO:0000018 (nanometer)."
+            )
+        return value * factor
 
     def _estimate_memory(self, n_spectra: int) -> float:
         """Estimate memory usage in GB."""
@@ -861,7 +939,17 @@ class ImzMLMetadataExtractor(MetadataExtractor):
         return None
 
     def _extract_pixel_size_from_xml(self) -> Optional[Tuple[float, float]]:
-        """Extract pixel size using full XML parsing as fallback."""
+        """Extract pixel size using full XML parsing as fallback.
+
+        The unit conversion happens outside the ``try`` so a refused unit
+        propagates as loudly as it does on the fast path, while a merely
+        unparseable document still degrades to "no pixel size".
+        """
+        x_size = None
+        y_size = None
+        x_unit = None
+        y_unit = None
+
         try:
             if not hasattr(self.parser, "metadata") or not hasattr(
                 self.parser.metadata, "root"
@@ -876,22 +964,24 @@ class ImzMLMetadataExtractor(MetadataExtractor):
                 "ims": "http://www.maldi-msi.org/download/imzml/imagingMS.obo",
             }
 
-            x_size = None
-            y_size = None
-
             # Search for cvParam elements with the pixel size accessions
             for cvparam in root.findall(".//mzml:cvParam", namespaces):
                 accession = cvparam.get("accession")
-                if accession == "IMS:1000046":  # pixel size x
+                if accession == ImzMLAccessions.PIXEL_SIZE_X:
                     x_size = float(cvparam.get("value", 0))
-                elif accession == "IMS:1000047":  # pixel size y
+                    x_unit = cvparam.get("unitAccession")
+                elif accession == ImzMLAccessions.PIXEL_SIZE_Y:
                     y_size = float(cvparam.get("value", 0))
-
-            if x_size is not None and y_size is not None:
-                logger.info(f"Detected pixel size from XML: x={x_size}μm, y={y_size}μm")
-                return (x_size, y_size)
+                    y_unit = cvparam.get("unitAccession")
 
         except Exception as e:
             logger.warning(f"Failed to parse XML metadata for pixel size: {e}")
+            return None
+
+        if x_size is not None and y_size is not None:
+            x_um = self._pixel_size_to_um(x_size, x_unit)
+            y_um = self._pixel_size_to_um(y_size, y_unit)
+            logger.info(f"Detected pixel size from XML: x={x_um}μm, y={y_um}μm")
+            return (x_um, y_um)
 
         return None

--- a/thyra/resampling/constants.py
+++ b/thyra/resampling/constants.py
@@ -14,6 +14,10 @@ class ImzMLAccessions:
     CONTINUOUS_BINARY = "IMS:1000030"
     PROCESSED_BINARY = "IMS:1000031"
 
+    # Pixel size (imzML ontology)
+    PIXEL_SIZE_X = "IMS:1000046"
+    PIXEL_SIZE_Y = "IMS:1000047"
+
     # Software identifiers
     SCILS_LAB = "MS:1002384"
 

--- a/uv.lock
+++ b/uv.lock
@@ -3827,7 +3827,7 @@ wheels = [
 
 [[package]]
 name = "thyra"
-version = "3.4.0"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anndata" },


### PR DESCRIPTION
## Problem

pyimzml's `imzmldict` discards `unitAccession` -- `convert_cv_param(accession, value)` takes no unit argument -- so `imzmldict['pixel size x']` is a bare number in whatever unit the vendor declared, and Thyra labelled it micrometres. A file declaring its pixel size as `4406.25` nanometre (`UO:0000018`) therefore reached the converted store with `obs/spatial_x` a thousand times too large, and `convert_msi` still returned `True`.

The finding was documented as open in `docs/imzml-parser-notes.md` and pinned by characterisation tests in `TestUnitNanometre`.

## Fix

The unit is never lost from the document, only from the dict pyimzml builds: it survives on `metadata.scan_settings[*].cv_params`, where each tuple is `(name, accession, value, raw_name, raw_value, unit_name, unit_accession)`.

`ImzMLMetadataExtractor._extract_pixel_size_fast` now pairs the bare `imzmldict` value with the unit read off that path -- first match in document order per accession, mirroring how `__readimzmlmeta` resolves the values themselves -- and converts to micrometres:

| unitAccession | unit | factor |
|---|---|---|
| `UO:0000016` | millimeter | x1000 |
| `UO:0000017` | micrometer | x1 |
| `UO:0000018` | nanometer | /1000 |

Any other declared unit raises `ValueError`, which fails the conversion instead of writing wrong coordinates. A cvParam with **no** unit keeps the historical micrometre reading: real vendor files (the IONTOF class among them, `iontof_sparse` in the fixture corpus) write `IMS:1000046` unitless and were being read correctly.

The full-XML fallback path applies the same conversion, with the refusal placed outside its `try/except` so it propagates while a merely unparseable document still degrades to "no pixel size". The pixel-size accessions move into `ImzMLAccessions` alongside the existing constants.

## Tests

- The `TestUnitNanometre` characterisation assertions are inverted as their comments instructed: essential metadata now asserts `(4.40625, 4.40625)` and the end-to-end test asserts `spatial_x` of `[0.0, 4.40625]` on disk.
- The `imzmldict == 4406.25` pin stays, reworded -- it records pyimzml's still-true behaviour, which is the reason the extractor must not trust the dict.
- New: millimetre scaling (x1000) and refusal of an unrecognised unit (`UO:0000015` centimetre, which accepted unconverted would be a silent x10000 error), both via fixture variants written to `tmp_path`.

Full unit suite: 1447 passed, 13 skipped, 18 deselected. All pre-commit hooks pass.

## Docs

`docs/imzml-parser-notes.md`'s "Still open" section becomes "Fixed in Thyra, still true of pyimzml"; the fixture README and `build_fixtures.py` provenance docstring are updated to match.
