### PR TITLE
ci: keep uv.lock in step with the version semantic-release stamps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,16 @@ jobs:
         with:
           python-version: '3.12'
 
+      # semantic-release's build_command starts with `uv lock` so the release
+      # commit carries a lockfile matching the version it stamps (see
+      # [tool.semantic_release] in pyproject.toml). This step is what puts uv
+      # on the PATH that build_command inherits. Same SHA pin as tests.yml; no
+      # python-version input, because setup-python above already provides the
+      # interpreter and `uv lock` resolves from requires-python, not from
+      # whichever Python is installed.
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,22 @@ version_toml = ["pyproject.toml:project.version"]
 version_variables = [
     "thyra/__init__.py:__version__",
 ]
-build_command = "pip install build && python -m build"
+# `uv lock` runs here rather than as a workflow step because the build
+# command is the only hook that executes AFTER semantic-release stamps the
+# new version into pyproject.toml and BEFORE it makes the release commit.
+# Without it, the lockfile's own `[[package]] name = "thyra"` entry keeps
+# the previous version. The release commit lands on main without a test run
+# (a GITHUB_TOKEN push starts no workflows), so nothing notices until the
+# first branch cut after the release fails every CI job at
+# `uv sync --locked` with "The lockfile at `uv.lock` needs to be updated" --
+# see the one-off repair on PR #177 after v3.5.0. Regenerating the lockfile
+# is only half the fix: `assets` below is what carries it into the release
+# commit. uv reaches this command's PATH via the same SHA-pinned setup-uv
+# step the test workflow uses (see release.yml).
+build_command = "uv lock && pip install build && python -m build"
+# Extra files to include in the release commit beyond the version-stamped
+# ones above.
+assets = ["uv.lock"]
 upload_to_vcs_release = true
 
 [tool.semantic_release.branches.main]

--- a/uv.lock
+++ b/uv.lock
@@ -3827,7 +3827,7 @@ wheels = [
 
 [[package]]
 name = "thyra"
-version = "3.4.0"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anndata" },


### PR DESCRIPTION
## Problem

Every release breaks the first PR branched after it. `semantic-release version` stamps `pyproject.toml:project.version` (and `thyra/__init__.py`), but nothing regenerates `uv.lock`, whose own `[[package]] name = "thyra"` entry keeps the previous version. The release commit is pushed with `GITHUB_TOKEN`, so no workflow runs on it and the mismatch sits latent on main. The first branch cut after the release then fails every test and integration job at `uv sync --locked --no-default-groups --group test` with "The lockfile at `uv.lock` needs to be updated". This happened on #177 (first branch after v3.5.0) and was repaired there with a one-off lock sync (9b91660); this PR removes the trap itself.

## Fix

- `build_command` now starts with `uv lock`. The build command is the only hook that runs after semantic-release writes the new version into `pyproject.toml` and before it makes the release commit, so it is the one place the lockfile can be refreshed with the stamped version.
- New `assets = ["uv.lock"]` in `[tool.semantic_release]` carries the refreshed lockfile into the release commit. Regenerating without committing would fix nothing.
- `release.yml` installs uv with the same SHA-pinned `astral-sh/setup-uv` step `tests.yml` already uses; that is what puts `uv` on the PATH the build command inherits.
- `uv.lock` is also synced with the v3.5.0 bump itself, which the last release left stale on main -- the same repair #177 needed, done here so this branch's own CI is green. If #177 merges first, the two changes are identical and merge cleanly.

## Verification

Dry run in a throwaway repo mirroring this config (python-semantic-release 10.6.1, uv 0.12.5): a project locked at 0.1.0, tagged v0.1.0, one `fix:` commit, then `semantic-release version --no-push --no-vcs-release`. The release commit contained `pyproject.toml`, the version file, `CHANGELOG.md` and `uv.lock` together; the lockfile's own package entry carried the new version; the working tree was clean afterwards; and `uv lock --check` passed on the result, which is the exact freshness `uv sync --locked` enforces in CI.

The alternative of making CI tolerant of the drift (`uv sync --frozen`) was rejected: uv has no flag to exempt only the project's own version, and `--frozen` would stop validating the lockfile against `pyproject.toml` for every dependency, not just this one entry.
