### PR TITLE
ci: pin the release toolchain and fail loudly when it crashes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install python-semantic-release
+          # Both pins are load-bearing. GitPython 3.1.60 removed
+          # Actor.name_email_regex, which semantic-release <= 10.6.1 reads at
+          # config load, so the fresh unpinned install this used to do died on
+          # every invocation the day 3.1.60 shipped -- and the --print gate
+          # below read the resulting empty output as "no release" and went
+          # green (runs 32957432684 and 32957823551). Move both pins together,
+          # to a semantic-release that handles current GitPython, after
+          # verifying `semantic-release version --print` against a clone.
+          pip install "python-semantic-release==10.6.1" "gitpython==3.1.59"
 
       - name: Configure Git
         run: |
@@ -121,18 +129,28 @@ jobs:
           # `--print` reports the version semantic-release WOULD release. When
           # nothing on main is releasable -- a ci:/chore:/docs:/test: commit --
           # it prints the CURRENT version, not an empty string. So an emptiness
-          # test can never fire, and what actually stopped the no-op release was
-          # the already-tagged guard below, reporting a concurrent run that
-          # never happened. Compare against the last released version instead,
-          # which is the thing "is there a release to cut?" really asks.
-          NEXT=$(semantic-release version --print 2>/dev/null || true)
-          LAST=$(semantic-release version --print-last-released 2>/dev/null || true)
+          # test can never fire on a healthy no-op, and what actually stopped
+          # the no-op release was the already-tagged guard below, reporting a
+          # concurrent run that never happened. Compare against the last
+          # released version instead, which is the thing "is there a release
+          # to cut?" really asks.
+          #
+          # stderr goes to a file rather than /dev/null: an empty print means
+          # semantic-release itself crashed before deciding anything, and the
+          # discarded stderr held the only evidence. The GitPython 3.1.60
+          # break was exactly this -- two runs reported "no release" with a
+          # green check while a fix commit sat unreleased on main.
+          NEXT=$(semantic-release version --print 2>"$RUNNER_TEMP/psr-print.log" || true)
+          LAST=$(semantic-release version --print-last-released 2>>"$RUNNER_TEMP/psr-print.log" || true)
           echo "next=${NEXT:-<none>} last-released=${LAST:-<none>}"
 
           if [ -z "$NEXT" ]; then
-            echo "No release: semantic-release could not determine a version."
-            echo "released=false" >> $GITHUB_OUTPUT
-            exit 0
+            # Not a no-op: a healthy no-op prints the current version (see
+            # above). Fail the job so the crash is seen, instead of skipping
+            # the release with a green check.
+            cat "$RUNNER_TEMP/psr-print.log"
+            echo "semantic-release produced no version -- it crashed rather than declined. Failing."
+            exit 1
           fi
 
           if [ "$NEXT" = "$LAST" ]; then


### PR DESCRIPTION
## What happened

The merge of #177 carried a `fix:` commit, so its release run should have cut v3.5.1 -- the first release through the hatchling backend and the first live run of the `uv lock` build_command from #178. Instead the run finished **green with no release**: run 32957823551 printed

```
next=<none> last-released=3.5.0
No release: semantic-release could not determine a version.
```

Run 32957432684 (the #178 merge) did the same. The v3.5.0 release run, one day earlier, worked.

## Root cause

GitPython 3.1.60 removed `Actor.name_email_regex`, which python-semantic-release <= 10.6.1 reads at config load (`semantic_release/cli/config.py:745`). The release job installs its toolchain fresh and unpinned (`pip install python-semantic-release`), so the day 3.1.60 shipped, every `semantic-release` invocation started dying with

```
::ERROR:: type object 'Actor' has no attribute 'name_email_regex'
```

before deciding anything. The version gate captures `--print` with `2>/dev/null`, so the traceback went nowhere, the empty output fell into the "could not determine a version" branch, and that branch exits 0 -- a crash presented as a green no-release, with the fix commit sitting unreleased on main.

Reproduced against a clone of main at d10979a: unpinned resolve (GitPython 3.1.60) crashes as above; with `gitpython==3.1.59` the same command prints `3.5.1`.

## Changes

- **Pin the pair**: `pip install "python-semantic-release==10.6.1" "gitpython==3.1.59"`, with a comment explaining why both pins are load-bearing and that they move together, after verification, once a semantic-release ships that handles current GitPython.
- **Fail loudly on a crash**: `--print` stderr now goes to a file instead of `/dev/null`, and the empty-`NEXT` branch cats it and exits 1. The gate's own comment already establishes that a healthy no-op prints the current version and never an empty string, so emptiness can only mean semantic-release crashed -- and a crash must fail the job, not skip the release with a green check.

The legitimate no-release path (`NEXT == LAST`) is untouched, as is the workflow_dispatch escape hatch.

## After merge

This `ci:` commit bumps nothing by itself, but the pending `fix:` from #177 does: the release run for this merge should cut **v3.5.1** -- which is still the first hatchling-built upload and the first live `uv lock` build_command run, so that release is worth watching land end to end (release commit contains uv.lock, tag, PyPI upload).
